### PR TITLE
fix(test): short /tmp MUSTER_HOME so tests + pre-push hook work natively on macOS

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -6,12 +6,17 @@ import (
 	"testing"
 
 	"github.com/schuettc/muster/internal/client"
+	"github.com/schuettc/muster/internal/mustertest"
 	"github.com/schuettc/muster/internal/proto"
 	"github.com/schuettc/muster/internal/store"
 )
 
 func TestDaemonRegisterAndList(t *testing.T) {
-	dir := t.TempDir()
+	dir, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
 	s, err := store.Open(filepath.Join(dir, "bus.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -49,7 +54,11 @@ func TestDaemonRegisterAndList(t *testing.T) {
 // understood float64 and silently coerced the string thread_id to 0,
 // so the claim landed on thread 0 instead of the real thread.
 func TestTaskClaimAcceptsStringThreadID(t *testing.T) {
-	dir := t.TempDir()
+	dir, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
 	s, err := store.Open(filepath.Join(dir, "bus.db"))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/wake_wiring_test.go
+++ b/internal/daemon/wake_wiring_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/schuettc/muster/internal/client"
+	"github.com/schuettc/muster/internal/mustertest"
 	"github.com/schuettc/muster/internal/paths"
 	"github.com/schuettc/muster/internal/proto"
 	"github.com/schuettc/muster/internal/store"
@@ -41,7 +42,11 @@ func (f *fakeNotifier) snap(which *[]string) []string {
 
 func startWithNotifier(t *testing.T, n *fakeNotifier) string {
 	t.Helper()
-	dir := t.TempDir()
+	dir, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
 	t.Setenv("MUSTER_HOME", dir)
 	s, err := store.Open(filepath.Join(dir, "bus.db"))
 	if err != nil {
@@ -89,7 +94,11 @@ func TestNotifySkipsAgentsWithoutSession(t *testing.T) {
 }
 
 func TestNilNotifierIsSafe(t *testing.T) {
-	dir := t.TempDir()
+	dir, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
 	t.Setenv("MUSTER_HOME", dir)
 	s, err := store.Open(filepath.Join(dir, "bus.db"))
 	if err != nil {

--- a/internal/humancli/humancli_test.go
+++ b/internal/humancli/humancli_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/schuettc/muster/internal/daemon"
+	"github.com/schuettc/muster/internal/mustertest"
 	"github.com/schuettc/muster/internal/paths"
 	"github.com/schuettc/muster/internal/store"
 )
@@ -15,7 +16,11 @@ import (
 // startTestDaemon boots a real in-process daemon on a temp socket.
 func startTestDaemon(t *testing.T) {
 	t.Helper()
-	dir := t.TempDir()
+	dir, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
 	t.Setenv("MUSTER_HOME", dir)
 	s, err := store.Open(filepath.Join(dir, "bus.db"))
 	if err != nil {

--- a/internal/mcpserver/call_test.go
+++ b/internal/mcpserver/call_test.go
@@ -6,13 +6,18 @@ import (
 	"testing"
 
 	"github.com/schuettc/muster/internal/daemon"
+	"github.com/schuettc/muster/internal/mustertest"
 	"github.com/schuettc/muster/internal/paths"
 	"github.com/schuettc/muster/internal/store"
 )
 
 func startTestDaemon(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
+	dir, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
 	t.Setenv("MUSTER_HOME", dir)
 	s, err := store.Open(filepath.Join(dir, "bus.db"))
 	if err != nil {

--- a/internal/mustertest/mustertest.go
+++ b/internal/mustertest/mustertest.go
@@ -1,0 +1,17 @@
+// Package mustertest provides shared test helpers for muster.
+package mustertest
+
+import "os"
+
+// ShortHome creates a short-path temp directory suitable for use as MUSTER_HOME
+// in tests. The daemon's unix socket lives at <home>/sock and must stay under
+// the ~104-char sun_path limit; macOS t.TempDir() paths (under $TMPDIR) are too
+// long, so tests use this /tmp-based dir instead. Returns the dir and a cleanup
+// func the caller should defer/t.Cleanup.
+func ShortHome() (dir string, cleanup func(), err error) {
+	dir, err = os.MkdirTemp("/tmp", "muster-test-")
+	if err != nil {
+		return "", func() {}, err
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}


### PR DESCRIPTION
Daemon-starting test helpers set `MUSTER_HOME = t.TempDir()`; on macOS that's a long `$TMPDIR` (`/var/folders/…`) path, and the daemon's unix socket at `<home>/sock` then exceeds the ~104-char `sun_path` limit → `bind: invalid argument`. Tests only passed with `TMPDIR=/tmp`, which also broke the pre-push lefthook (`just verify`) on macOS.

**Fix:** new `internal/mustertest.ShortHome()` returns a short `/tmp`-based temp dir (+ cleanup); the 6 daemon-starting helpers (mcpserver, humancli, daemon ×2 files) use it instead of `t.TempDir()`. `internal/store` tests (DB-only, no socket) are untouched.

**Proof:** `just verify` is green with `$TMPDIR` at its real long macOS value (no override), and this branch was **pushed with the pre-push hook enabled** — it ran `just verify` natively and passed. macOS pushes no longer need `LEFTHOOK=0`. CI (Linux) was already unaffected.

🤖 Generated with [Claude Code](https://claude.ai/code)