### PR TITLE
docs(readme): update status to v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ only routes between agents already running on their own plans.
   session files a request to its producer. All async, all local.
 - **One static Go binary**, multi-mode: a lazy-started daemon, a stdio MCP server
   each agent registers, and a human CLI.
-- **tmux-native wake** — a `send-keys` knock on the target pane, socket-aware so
-  it works across per-project tmux servers.
+- **tmux-native wake** — the daemon lights a status-bar banner on the recipient's
+  session (socket-aware, across per-project tmux servers) without ever typing into
+  a pane; an operator `muster nudge` is the only send-keys path.
 
 Landing page: **muster.tools**
 
 ## Status
 
-Pre-implementation. The approved v1 design lives in
-[`docs/design.md`](docs/design.md).
+**v0.1.0** — Milestones A–E shipped: SQLite store + lazy unix-socket daemon, the
+`muster mcp` server (11 tools), the human CLI, and the notify/nudge wake. The
+approved v1 design lives in [`docs/design.md`](docs/design.md).
 
 ## MCP mode
 


### PR DESCRIPTION
The README "Status" section still said *"Pre-implementation"* — stale now that A–E are shipped and tagged v0.1.0 on `main`.

- Status → **v0.1.0**, summarizing the shipped milestones (store + daemon, `muster mcp`, human CLI, notify/nudge wake).
- Fixed the stale wake bullet: it described the wake as a `send-keys` knock, but Milestone E replaced that — the daemon now lights a status-bar banner and never types into a pane; `muster nudge` is the only send-keys path.

Docs-only.

🤖 Generated with [Claude Code](https://claude.ai/code)