### PR TITLE
Session identity: auto-register, tmux liveness, addressable labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,36 @@ muster send --role reviewer "please look"  --from me   # to a role
 muster send --broadcast "heads up"         --from me   # to everyone
 ```
 
+### Registering & liveness
+
+Agents can self-register (so a shell hook can do it at session start):
+
+```bash
+muster register [alias] --role <r> --model <claude|codex>
+muster deregister [alias]
+muster gc                 # reap agents whose tmux session is gone
+```
+
+`register` captures the tmux pane automatically. Alias precedence: explicit
+arg → `$MUSTER_ALIAS` → tmux session name.
+
+`muster agents` shows each agent's **project** (derived from the per-project
+tmux socket) and its live **label** — the manually-pinned `@claude_task`
+session option (`prefix T`). Auto-topics are shown parenthesized and are not
+addressable.
+
+### Addressing
+
+Any command that takes a target — `send`, `nudge`, `inbox`, `tasks` —
+accepts a target of the form `<alias|label|proj:label>`:
+
+- an **alias** (the tmux session name, globally unique): `muster nudge muster-2`
+- a **label**, resolved within your current project: `muster send frontend "…"`
+- a **qualified label** to cross projects: `muster send timewalk:frontend "…"`
+
+A bare label never silently crosses projects; if it's ambiguous or only exists
+elsewhere, muster errors and lists the `proj:label` candidates.
+
 ### Notifications & nudging
 
 When bus activity is addressed to an agent, muster **notifies** its tmux session
@@ -78,6 +108,18 @@ muster nudge <alias> --no-submit  # type only; don't press Enter
 Nudge auto-submits for Claude Code; Codex holds the text in its composer, so
 you press Enter there (muster tells you). Autonomous Codex wake (via its
 app-server) is possible but requires launching Codex differently — deferred.
+
+### Hooks
+
+Registration and deregistration are meant to be driven by session
+lifecycle hooks, not typed by hand:
+
+- **SessionStart** → `muster register --model <claude|codex> || true`
+- **SessionEnd** → `muster deregister || true`
+
+These are wired into Claude Code's `settings.json` (`SessionStart` /
+`SessionEnd` hooks) and into the equivalent Codex config. The actual
+dotfiles wiring for a given machine is maintained separately from this repo.
 
 ## License
 

--- a/cmd/muster/main.go
+++ b/cmd/muster/main.go
@@ -22,7 +22,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: muster <serve|debug|mcp|agents|inbox|send|tasks|nudge> [args]")
+		fmt.Fprintln(os.Stderr, "usage: muster <serve|debug|mcp|agents|inbox|send|tasks|nudge|register|deregister|gc> [args]")
 		os.Exit(2)
 	}
 	switch os.Args[1] {
@@ -32,7 +32,7 @@ func main() {
 		runDebug(os.Args[2:])
 	case "mcp":
 		runMCP()
-	case "agents", "inbox", "send", "tasks", "nudge":
+	case "agents", "inbox", "send", "tasks", "nudge", "register", "deregister", "gc":
 		if err := humancli.Dispatch(os.Args[1:], os.Stdout); err != nil {
 			fmt.Fprintln(os.Stderr, "muster:", err)
 			os.Exit(1)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,43 @@
+# muster roadmap
+
+Post-v0.1.0 directions. The organizing principle: **daemon = API, tmux =
+substrate, CLI = universal client, hooks = automation glue.** The MCP server and
+the human CLI are *peer clients* of the daemon — neither goes through the other —
+so any daemon op is reachable from a plain CLI command with no MCP involved. And
+because tmux is always present, `$TMUX_PANE` + the stored `session_id` are
+reliable and we can ask tmux questions (liveness, labels) at any time. Every idea
+below slots into one of those four roles.
+
+## 1. Real liveness, zero heartbeats
+
+Ask tmux `has-session -t <session_id>` to know who is actually alive. `muster
+agents` gains a live/dead column; `muster gc` reaps dead registrations. No
+heartbeats, no reaping timers. *(In progress — see
+`docs/superpowers/specs/2026-07-14-session-identity-design.md`.)*
+
+## 2. Lifecycle hooks beyond register
+
+- **SessionStart → `muster register`**, **SessionEnd → `muster deregister`** — the
+  registry maintains itself as tabs open and close. *(In progress — same spec.)*
+- **Stop (turn end) → idle agent auto-drains its inbox** — the missing zero-touch
+  half of the wake loop. Today an idle agent needs an operator `nudge`; a Stop
+  hook lets it check its own inbox the moment it goes idle.
+
+## 3. tmux status-bar integration
+
+A `muster inbox <self> --count` query the tmux status-right polls (same pattern
+as the dotfiles git/context segments) → an ambient per-pane unread indicator,
+e.g. `backend ⬦ 2`. The richer cousin of the `@claude_attn` banner.
+
+## 4. CLI as the full operator / observability surface
+
+All daemon clients: `muster watch` (live bus tail — precursor to the TUI),
+`register`/`deregister`/`gc`, richer `reply`. The v3 `muster tui` is then "just
+another daemon client" that also overlays tmux liveness.
+
+## Further out (from the v1 design)
+
+- **v2 Contracts** — a producer publishes its API surface; consumers subscribe and
+  get diffs on change (the bettor-help producer/consumer use case).
+- **v3 Dashboard TUI** — `muster tui`: live agents/activity/tasks.
+- Advisory file leases; append-only event log; cross-machine.

--- a/docs/superpowers/plans/2026-07-14-session-identity.md
+++ b/docs/superpowers/plans/2026-07-14-session-identity.md
@@ -1,0 +1,1265 @@
+# Session Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make muster's agent registry self-maintaining and human-legible — a plain `muster register`/`deregister` CLI (so shell hooks can auto-register), tmux-verified liveness, and agents surfaced/addressed by their project-scoped, manually-pinned tmux label.
+
+**Architecture:** Additive. A new `internal/tmuxenv` package becomes the single canonical place for tmux interaction outside the daemon (capture, project derivation, liveness, label). The store gains `project`/`label`/`label_manual` columns; the daemon gains a `deregister_agent` op; the human CLI gains `register`/`deregister`/`gc`, a project-scoped target resolver reused by every target-taking command, and liveness/label enrichment in `agents`. The daemon core stays tmux-agnostic.
+
+**Tech Stack:** Go 1.26, cgo-free, `modernc.org/sqlite`, official MCP go-sdk v1.6.1, `text/tabwriter`, stdlib `os/exec` for tmux.
+
+## Global Constraints
+
+- **cgo-free:** builds under `CGO_ENABLED=0`; no new non-pure-Go deps.
+- **`just verify` is the gate:** gofmt, golangci-lint (errcheck, revive, gocritic, staticcheck), `go test -race`, build — all green, locally and in CI. Run as `just verify` (add `TMPDIR=/tmp` on macOS; prefix `GODEBUG=netdns=go` if module DNS flakes).
+- **Exported symbols need doc comments** (revive); ignored params named `_`.
+- **Daemon core stays tmux-agnostic** — tmux is touched ONLY through `internal/tmuxenv` (CLI layer) or the injected `wake.Notifier`. Do not import `tmuxenv` into `internal/daemon` or `internal/store`.
+- **One canonical capture path** — after Task 2, no tmux env/query logic remains in `internal/mcpserver`; it delegates to `tmuxenv`. No duplicated tmux code anywhere.
+- **Tests never shell to real tmux** — inject `tmuxenv.Run`. A test that sets `tmuxenv.Run` must restore it (`defer`) and must not call `t.Parallel()`.
+- **Identity rules (verbatim):** alias precedence = explicit arg → `$MUSTER_ALIAS` → tmux session name. A label is addressable ONLY when manually pinned (`@claude_task_manual == "1"`). Cross-project qualifier is `:` (`proj:label`), never `/`. Bare-label resolution restricts to the caller's project and NEVER silently crosses a project boundary — ambiguity or cross-project-without-qualifier is a loud error listing candidates as `proj:label`.
+- **Label option name** defaults to `@claude_task`, overridable via `$MUSTER_LABEL_OPTION`; its manual companion is `<option>_manual`.
+- **Tests on macOS** use `internal/mustertest.ShortHome()` for any daemon/socket path (sun_path length limit); follow the existing `startTestDaemon` pattern.
+
+---
+
+### Task 1: `internal/tmuxenv` package
+
+**Files:**
+- Create: `internal/tmuxenv/tmuxenv.go`
+- Test: `internal/tmuxenv/tmuxenv_test.go`
+
+**Interfaces:**
+- Consumes: nothing (stdlib only).
+- Produces (consumed by Tasks 2, 5, 6):
+  - `var Run func(args ...string) (string, error)` — executes `tmux <args>`; overridable in tests.
+  - `type Capture struct { SocketPath, PaneID, SessionID, SessionName, Project, Label string; LabelManual bool }`
+  - `func CaptureEnv() Capture`
+  - `func SocketFromEnv() string`
+  - `func ProjectFromSocket(socket string) string`
+  - `func LabelOption() string`
+  - `func IsSessionAlive(socket, sessionID string) bool`
+  - `func SessionLabel(socket, target string) (label string, manual bool)`
+
+- [ ] **Step 1: Write the failing tests**
+
+`internal/tmuxenv/tmuxenv_test.go`:
+
+```go
+package tmuxenv
+
+import (
+	"fmt"
+	"testing"
+)
+
+func withRun(t *testing.T, fn func(args ...string) (string, error)) {
+	t.Helper()
+	prev := Run
+	Run = fn
+	t.Cleanup(func() { Run = prev })
+}
+
+func TestProjectFromSocket(t *testing.T) {
+	cases := map[string]string{
+		"/private/tmp/tmux-501/proj-muster": "muster",
+		"/tmp/tmux-0/proj-foo-bar":          "foo-bar",
+		"/tmp/tmux-0/default":               "",
+		"":                                  "",
+	}
+	for in, want := range cases {
+		if got := ProjectFromSocket(in); got != want {
+			t.Errorf("ProjectFromSocket(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsSessionAlive(t *testing.T) {
+	withRun(t, func(args ...string) (string, error) { return "", nil })
+	if !IsSessionAlive("/s", "$1") {
+		t.Fatal("want alive when has-session exits 0")
+	}
+	withRun(t, func(args ...string) (string, error) { return "", fmt.Errorf("no such session") })
+	if IsSessionAlive("/s", "$1") {
+		t.Fatal("want dead when has-session errors")
+	}
+	if IsSessionAlive("", "$1") || IsSessionAlive("/s", "") {
+		t.Fatal("empty socket/session must be dead")
+	}
+}
+
+func TestSessionLabelManualVsAuto(t *testing.T) {
+	withRun(t, func(args ...string) (string, error) { return "frontend\x1f1", nil })
+	if l, m := SessionLabel("/s", "$1"); l != "frontend" || !m {
+		t.Fatalf("manual: got (%q,%v)", l, m)
+	}
+	withRun(t, func(args ...string) (string, error) { return "some auto topic\x1f", nil })
+	if l, m := SessionLabel("/s", "$1"); l != "some auto topic" || m {
+		t.Fatalf("auto: got (%q,%v)", l, m)
+	}
+}
+
+func TestCaptureEnvNoTmux(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	c := CaptureEnv()
+	if c.SocketPath != "" || c.Project != "" || c.SessionID != "" {
+		t.Fatalf("no-tmux capture should be empty, got %+v", c)
+	}
+}
+
+func TestCaptureEnvPopulated(t *testing.T) {
+	t.Setenv("TMUX", "/private/tmp/tmux-501/proj-muster,123,0")
+	t.Setenv("TMUX_PANE", "%0")
+	withRun(t, func(args ...string) (string, error) {
+		last := args[len(args)-1]
+		switch {
+		case last == "#{session_id}":
+			return "$7", nil
+		case last == "#{session_name}":
+			return "muster-2", nil
+		default: // label format
+			return "backend\x1f1", nil
+		}
+	})
+	c := CaptureEnv()
+	if c.Project != "muster" || c.SessionID != "$7" || c.SessionName != "muster-2" ||
+		c.Label != "backend" || !c.LabelManual {
+		t.Fatalf("capture=%+v", c)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `TMPDIR=/tmp go test ./internal/tmuxenv/`
+Expected: FAIL (package/functions not defined).
+
+- [ ] **Step 3: Write the implementation**
+
+`internal/tmuxenv/tmuxenv.go`:
+
+```go
+// Package tmuxenv is muster's single point of contact with tmux from outside
+// the daemon: capturing the current pane's identity, deriving the project from
+// the per-project socket, checking session liveness, and reading the session
+// label. All tmux execution goes through Run, which tests override.
+package tmuxenv
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Run executes `tmux <args>` and returns trimmed stdout. Overridable in tests.
+var Run = func(args ...string) (string, error) {
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// Capture holds the identity fields for registering an agent from a tmux pane.
+// Every field is empty (LabelManual false) when not running inside tmux.
+type Capture struct {
+	SocketPath  string
+	PaneID      string
+	SessionID   string
+	SessionName string
+	Project     string
+	Label       string
+	LabelManual bool
+}
+
+// SocketFromEnv returns the tmux socket path from $TMUX ("<socket>,<pid>,<idx>").
+func SocketFromEnv() string {
+	tmux := os.Getenv("TMUX")
+	if tmux == "" {
+		return ""
+	}
+	return strings.SplitN(tmux, ",", 2)[0]
+}
+
+// ProjectFromSocket derives the project name from a per-project socket path
+// ("proj-<project>"). Returns "" for non-proj-managed sockets (e.g. "default").
+func ProjectFromSocket(socket string) string {
+	if socket == "" {
+		return ""
+	}
+	base := filepath.Base(socket)
+	if !strings.HasPrefix(base, "proj-") {
+		return ""
+	}
+	return strings.TrimPrefix(base, "proj-")
+}
+
+// LabelOption returns the tmux session option holding the label, defaulting to
+// "@claude_task", overridable via $MUSTER_LABEL_OPTION.
+func LabelOption() string {
+	if v := os.Getenv("MUSTER_LABEL_OPTION"); v != "" {
+		return v
+	}
+	return "@claude_task"
+}
+
+func query(socket, target, format string) string {
+	if socket == "" || target == "" {
+		return ""
+	}
+	out, err := Run("-S", socket, "display-message", "-p", "-t", target, format)
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+// IsSessionAlive reports whether the tmux session still exists on the socket.
+func IsSessionAlive(socket, sessionID string) bool {
+	if socket == "" || sessionID == "" {
+		return false
+	}
+	_, err := Run("-S", socket, "has-session", "-t", sessionID)
+	return err == nil
+}
+
+// SessionLabel reads the label option and its manual flag for target (a pane or
+// session) on socket. manual is true only when <option>_manual == "1".
+func SessionLabel(socket, target string) (string, bool) {
+	opt := LabelOption()
+	raw := query(socket, target, "#{"+opt+"}\x1f#{"+opt+"_manual}")
+	if raw == "" {
+		return "", false
+	}
+	parts := strings.SplitN(raw, "\x1f", 2)
+	label := parts[0]
+	manual := len(parts) > 1 && parts[1] == "1"
+	return label, manual
+}
+
+// CaptureEnv reads the current process's tmux environment into a Capture.
+func CaptureEnv() Capture {
+	socket := SocketFromEnv()
+	pane := os.Getenv("TMUX_PANE")
+	c := Capture{SocketPath: socket, PaneID: pane, Project: ProjectFromSocket(socket)}
+	if socket == "" || pane == "" {
+		return c
+	}
+	c.SessionID = query(socket, pane, "#{session_id}")
+	c.SessionName = query(socket, pane, "#{session_name}")
+	c.Label, c.LabelManual = SessionLabel(socket, pane)
+	return c
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `TMPDIR=/tmp go test ./internal/tmuxenv/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tmuxenv/
+git commit -m "feat(tmuxenv): canonical tmux capture, project, liveness, label"
+```
+
+---
+
+### Task 2: Repoint mcpserver to tmuxenv (one canonical capture)
+
+**Files:**
+- Modify: `internal/mcpserver/tools_registry.go`
+- Modify: `internal/mcpserver/tools_registry_test.go`
+
+**Interfaces:**
+- Consumes: `tmuxenv.CaptureEnv`, `tmuxenv.Run` (Task 1).
+- Produces: `register_agent` daemon call now also sends `project`, `label`, `label_manual`.
+
+- [ ] **Step 1: Update the test to inject `tmuxenv.Run`**
+
+Replace the body of `internal/mcpserver/tools_registry_test.go` with a version that drives capture through `tmuxenv` and asserts the new fields flow into the daemon call. The existing test set `TMUX`/`TMUX_PANE` and overrode the old `tmuxQuery`; now override `tmuxenv.Run`:
+
+```go
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+func TestRegisterAgentCapturesTmuxEnv(t *testing.T) {
+	t.Setenv("TMUX", "/private/tmp/tmux-501/proj-muster,123,0")
+	t.Setenv("TMUX_PANE", "%6")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_id}":
+			return "$5", nil
+		case "#{session_name}":
+			return "muster-2", nil
+		default:
+			return "backend\x1f1", nil
+		}
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var got map[string]any
+	prevDaemon := callDaemon
+	callDaemon = func(op string, args map[string]any) ([]byte, error) {
+		got = args
+		return []byte(`{}`), nil
+	}
+	t.Cleanup(func() { callDaemon = prevDaemon })
+
+	_, _, err := registerAgentHandler(nil, nil, RegisterAgentIn{Alias: "backend", Role: "producer", ModelType: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["socket_path"] != "/private/tmp/tmux-501/proj-muster" || got["session_id"] != "$5" ||
+		got["project"] != "muster" || got["label"] != "backend" || got["label_manual"] != true {
+		t.Fatalf("captured args = %+v", got)
+	}
+}
+```
+
+> Note: this assumes `callDaemon` is a package-level `var` so it can be stubbed. If it is currently a function declaration, change it to `var callDaemon = func(...) (...) {...}` in this task (mechanical). Verify its real signature in `internal/mcpserver` and match it exactly in the stub.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `TMPDIR=/tmp go test ./internal/mcpserver/ -run TestRegisterAgentCapturesTmuxEnv`
+Expected: FAIL (compile error / missing fields).
+
+- [ ] **Step 3: Rewrite `tools_registry.go` capture to use tmuxenv**
+
+Remove `tmuxSocketPath` and `tmuxQuery` entirely and drop the now-unused `os`/`os/exec`/`strings` imports (keep what's still used). Rewrite the handler:
+
+```go
+func registerAgentHandler(_ context.Context, _ *mcp.CallToolRequest, in RegisterAgentIn) (*mcp.CallToolResult, OKOut, error) {
+	c := tmuxenv.CaptureEnv()
+	sessionName := in.SessionName
+	if sessionName == "" {
+		sessionName = c.SessionName
+	}
+	_, err := callDaemon("register_agent", map[string]any{
+		"alias":        in.Alias,
+		"role":         in.Role,
+		"model_type":   in.ModelType,
+		"session_name": sessionName,
+		"session_id":   c.SessionID,
+		"socket_path":  c.SocketPath,
+		"pane_id":      c.PaneID,
+		"project":      c.Project,
+		"label":        c.Label,
+		"label_manual": c.LabelManual,
+	})
+	if err != nil {
+		return nil, OKOut{}, err
+	}
+	return nil, OKOut{OK: true, Detail: "registered " + in.Alias}, nil
+}
+```
+
+Add the import `"github.com/schuettc/muster/internal/tmuxenv"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `TMPDIR=/tmp go test ./internal/mcpserver/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpserver/
+git commit -m "refactor(mcpserver): capture via tmuxenv; send project/label"
+```
+
+---
+
+### Task 3: Store — project/label/label_manual columns, migration, DeleteAgent
+
+**Files:**
+- Modify: `internal/store/schema.sql`
+- Modify: `internal/store/store.go`
+- Modify: `internal/store/models.go`
+- Modify: `internal/store/agents.go`
+- Test: `internal/store/agents_test.go` (add cases; create the file if absent)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (Task 4): `store.Agent` fields `Project string`, `Label string`, `LabelManual bool`; `func (s *Store) DeleteAgent(alias string) error`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/store/agents_test.go` (match the package's existing test-store constructor; use whatever helper other store tests use to open a temp DB, e.g. `openTestStore(t)`):
+
+```go
+func TestAgentLabelAndDelete(t *testing.T) {
+	s := openTestStore(t) // existing helper in this package
+	if err := s.RegisterAgent(Agent{
+		Alias: "muster-2", Role: "peer", ModelType: "codex",
+		SocketPath: "/tmp/tmux-0/proj-muster", SessionID: "$1",
+		Project: "muster", Label: "frontend", LabelManual: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.GetAgent("muster-2")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.Project != "muster" || got.Label != "frontend" || !got.LabelManual {
+		t.Fatalf("round-trip=%+v", got)
+	}
+
+	// upsert refreshes label fields
+	if err := s.RegisterAgent(Agent{Alias: "muster-2", Label: "backend", LabelManual: false}); err != nil {
+		t.Fatal(err)
+	}
+	got, _, _ = s.GetAgent("muster-2")
+	if got.Label != "backend" || got.LabelManual {
+		t.Fatalf("after upsert=%+v", got)
+	}
+
+	// delete removes the row, leaves the table usable
+	if err := s.DeleteAgent("muster-2"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetAgent("muster-2"); ok {
+		t.Fatal("agent should be gone after DeleteAgent")
+	}
+	if err := s.DeleteAgent("nonexistent"); err != nil {
+		t.Fatalf("DeleteAgent of unknown alias must be a no-op, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `TMPDIR=/tmp go test ./internal/store/ -run TestAgentLabelAndDelete`
+Expected: FAIL (fields/method undefined).
+
+- [ ] **Step 3: Add the columns to fresh schema**
+
+In `internal/store/schema.sql`, add three columns to the `agents` table (after `session_id`):
+
+```sql
+    session_id    TEXT NOT NULL DEFAULT '',
+    project       TEXT NOT NULL DEFAULT '',
+    label         TEXT NOT NULL DEFAULT '',
+    label_manual  INTEGER NOT NULL DEFAULT 0,
+    registered_at INTEGER NOT NULL,
+    last_seen     INTEGER NOT NULL
+```
+
+- [ ] **Step 4: Add an idempotent migration to `store.go`**
+
+In `internal/store/store.go`, after the `db.Exec(schemaSQL)` block in `Open`, call `migrate(db)`:
+
+```go
+	if _, err := db.Exec(schemaSQL); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("apply schema: %w", err)
+	}
+	if err := migrate(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+```
+
+Add:
+
+```go
+// migrate applies additive column migrations to pre-existing databases. Each
+// ALTER is guarded so a re-run (column already present) is a no-op.
+func migrate(db *sql.DB) error {
+	alters := []string{
+		`ALTER TABLE agents ADD COLUMN project TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE agents ADD COLUMN label TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE agents ADD COLUMN label_manual INTEGER NOT NULL DEFAULT 0`,
+	}
+	for _, ddl := range alters {
+		if _, err := db.Exec(ddl); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
+	return nil
+}
+```
+
+Add `"strings"` to `store.go` imports.
+
+- [ ] **Step 5: Add the fields to the model**
+
+In `internal/store/models.go`, extend `Agent` (place the three after `SessionID`):
+
+```go
+	SessionID    string `json:"session_id"`
+	Project      string `json:"project"`
+	Label        string `json:"label"`
+	LabelManual  bool   `json:"label_manual"`
+	RegisteredAt int64  `json:"registered_at"`
+	LastSeen     int64  `json:"last_seen"`
+```
+
+- [ ] **Step 6: Update agents.go queries + add DeleteAgent**
+
+In `internal/store/agents.go`, update `RegisterAgent`, `ListAgents`, `GetAgent` to include the new columns, and add `DeleteAgent`:
+
+```go
+func (s *Store) RegisterAgent(a Agent) error {
+	now := clock.NowMillis()
+	_, err := s.db.Exec(`
+INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, project, label, label_manual, registered_at, last_seen)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(alias) DO UPDATE SET
+    role=excluded.role,
+    model_type=excluded.model_type,
+    socket_path=excluded.socket_path,
+    pane_id=excluded.pane_id,
+    session_name=excluded.session_name,
+    session_id=excluded.session_id,
+    project=excluded.project,
+    label=excluded.label,
+    label_manual=excluded.label_manual,
+    last_seen=excluded.last_seen`,
+		a.Alias, a.Role, a.ModelType, a.SocketPath, a.PaneID, a.SessionName, a.SessionID,
+		a.Project, a.Label, a.LabelManual, now, now)
+	return err
+}
+```
+
+`ListAgents` and `GetAgent`: add `project, label, label_manual` to the SELECT column list (after `session_id`) and to the `Scan` targets (`&a.Project, &a.Label, &a.LabelManual`). `database/sql` scans the INTEGER 0/1 into `*bool` via `driver.Bool`.
+
+```go
+// DeleteAgent removes an agent's registration by alias. Unknown alias is a
+// no-op (no error). Message/task history is unaffected — threads store the
+// alias as text, not a foreign key.
+func (s *Store) DeleteAgent(alias string) error {
+	_, err := s.db.Exec(`DELETE FROM agents WHERE alias=?`, alias)
+	return err
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `TMPDIR=/tmp go test ./internal/store/`
+Expected: PASS (new + existing).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/store/
+git commit -m "feat(store): project/label/label_manual columns + DeleteAgent + migration"
+```
+
+---
+
+### Task 4: Daemon — register_agent new args + deregister_agent op
+
+**Files:**
+- Modify: `internal/daemon/daemon.go`
+- Test: `internal/daemon/daemon_test.go`
+
+**Interfaces:**
+- Consumes: `store.Agent` new fields, `store.DeleteAgent` (Task 3).
+- Produces (Tasks 5, 6): daemon op `deregister_agent {alias}`; `register_agent` now persists `project`/`label`/`label_manual`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/daemon/daemon_test.go` (follow the existing `client.Call(sock, ...)` pattern used by the tests already in this file):
+
+```go
+func TestRegisterCapturesLabelAndDeregister(t *testing.T) {
+	sock := startTestDaemon(t) // existing helper
+	if _, err := client.Call(sock, proto.Request{Op: "register_agent", Args: map[string]any{
+		"alias": "muster-2", "role": "peer", "model_type": "codex",
+		"socket_path": "/s", "session_id": "$1",
+		"project": "muster", "label": "frontend", "label_manual": true,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Call(sock, proto.Request{Op: "get_agent", Args: map[string]any{"alias": "muster-2"}})
+	if err != nil || !resp.OK {
+		t.Fatalf("get_agent: %v %+v", err, resp)
+	}
+	// (decode resp.Data → agent; assert Project=="muster", Label=="frontend", LabelManual==true)
+
+	if _, err := client.Call(sock, proto.Request{Op: "deregister_agent", Args: map[string]any{"alias": "muster-2"}}); err != nil {
+		t.Fatal(err)
+	}
+	resp, _ = client.Call(sock, proto.Request{Op: "get_agent", Args: map[string]any{"alias": "muster-2"}})
+	// assert resp.Data.found == false
+}
+```
+
+Fill the decode/assert comments using the same JSON-decoding approach the other tests in this file already use for `get_agent` (`found`/`agent`).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `TMPDIR=/tmp go test ./internal/daemon/ -run TestRegisterCapturesLabelAndDeregister`
+Expected: FAIL (project not persisted; unknown op `deregister_agent`).
+
+- [ ] **Step 3: Add a bool arg helper**
+
+In `internal/daemon/daemon.go`, next to the existing `str`/`i64` arg helpers, add:
+
+```go
+// boolArg reads a bool arg, accepting a JSON bool or the strings "true"/"1"
+// (the debug CLI passes all args as strings).
+func boolArg(a map[string]any, key string) bool {
+	switch v := a[key].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "1"
+	default:
+		return false
+	}
+}
+```
+
+- [ ] **Step 4: Thread the new fields + add the op**
+
+In the `register_agent` case, extend the `store.Agent` literal:
+
+```go
+	case "register_agent":
+		err := d.s.RegisterAgent(store.Agent{
+			Alias: str(a, "alias"), Role: str(a, "role"), ModelType: str(a, "model_type"),
+			SocketPath: str(a, "socket_path"), PaneID: str(a, "pane_id"), SessionName: str(a, "session_name"),
+			SessionID: str(a, "session_id"),
+			Project:   str(a, "project"), Label: str(a, "label"), LabelManual: boolArg(a, "label_manual"),
+		})
+		if err != nil {
+			return fail(err)
+		}
+		return ok(nil)
+```
+
+Add a new case (next to `get_agent`):
+
+```go
+	case "deregister_agent":
+		if err := d.s.DeleteAgent(str(a, "alias")); err != nil {
+			return fail(err)
+		}
+		return ok(nil)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `TMPDIR=/tmp go test ./internal/daemon/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/daemon/
+git commit -m "feat(daemon): persist project/label; add deregister_agent op"
+```
+
+---
+
+### Task 5: humancli — register / deregister / gc commands
+
+**Files:**
+- Modify: `internal/humancli/humancli.go` (extend `agentRow`, extend `Dispatch`)
+- Create: `internal/humancli/identity.go` (the new commands)
+- Modify: `cmd/muster/main.go` (dispatch + usage)
+- Test: `internal/humancli/identity_test.go`
+
+**Interfaces:**
+- Consumes: `tmuxenv` (Task 1), daemon ops `register_agent`/`deregister_agent`/`list_agents` (Tasks 3–4), `callData` (existing).
+- Produces (Task 6): extended `agentRow` with `SocketPath`, `SessionID`, `Project`, `Label`, `LabelManual`.
+
+- [ ] **Step 1: Extend `agentRow`**
+
+In `internal/humancli/humancli.go`, extend the `agentRow` struct so list_agents rows carry what liveness/resolution need:
+
+```go
+type agentRow struct {
+	Alias       string `json:"alias"`
+	Role        string `json:"role"`
+	ModelType   string `json:"model_type"`
+	SocketPath  string `json:"socket_path"`
+	SessionID   string `json:"session_id"`
+	SessionName string `json:"session_name"`
+	Project     string `json:"project"`
+	Label       string `json:"label"`
+	LabelManual bool   `json:"label_manual"`
+	LastSeen    int64  `json:"last_seen"`
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+`internal/humancli/identity_test.go` — drive `register`/`deregister`/`gc` against a real temp daemon (reuse the humancli package's existing test daemon helper; if the package lacks one, start a `daemon.Serve` on a `mustertest.ShortHome()` socket exactly as other tests do) with `tmuxenv.Run` and env injected:
+
+```go
+func TestRegisterUsesAliasPrecedenceAndCaptures(t *testing.T) {
+	sock := startCLITestDaemon(t) // package helper (create if absent, mirroring daemon tests)
+	t.Setenv("TMUX", "/tmp/tmux-0/proj-muster,1,0")
+	t.Setenv("TMUX_PANE", "%0")
+	t.Setenv("MUSTER_ALIAS", "")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_id}":
+			return "$1", nil
+		case "#{session_name}":
+			return "muster-2", nil
+		default:
+			return "frontend\x1f1", nil
+		}
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	// no positional alias, no $MUSTER_ALIAS → alias falls back to session name
+	if err := cmdRegister([]string{"--model", "codex", "--role", "peer"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	// verify via list_agents that alias == "muster-2", project=="muster", label=="frontend"
+	agents := listAgentsForTest(t, sock)
+	if len(agents) != 1 || agents[0].Alias != "muster-2" || agents[0].Project != "muster" || agents[0].Label != "frontend" || !agents[0].LabelManual {
+		t.Fatalf("registered=%+v", agents)
+	}
+
+	// explicit positional alias wins over session name
+	buf.Reset()
+	if err := cmdRegister([]string{"backend", "--model", "codex"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	// now "backend" also present
+}
+
+func TestGCReapsOnlyDeadAgents(t *testing.T) {
+	sock := startCLITestDaemon(t)
+	// register two agents directly via the daemon: one "alive", one "dead"
+	registerViaDaemon(t, sock, "alive", "/s", "$ALIVE")
+	registerViaDaemon(t, sock, "dead", "/s", "$DEAD")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		// has-session succeeds only for $ALIVE
+		if len(args) >= 5 && args[1] == "has-session" && args[4] == "$ALIVE" {
+			return "", nil
+		}
+		if len(args) >= 1 && args[1] == "has-session" {
+			return "", fmt.Errorf("dead")
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdGC(&buf); err != nil {
+		t.Fatal(err)
+	}
+	agents := listAgentsForTest(t, sock)
+	if len(agents) != 1 || agents[0].Alias != "alive" {
+		t.Fatalf("after gc=%+v (want only 'alive')", agents)
+	}
+}
+```
+
+> The exact positions in `args` for `has-session` are `-S <socket> has-session -t <session>` → indices `0=-S,1=socket,2=has-session,3=-t,4=session`. Adjust the test matcher to those indices. Provide `startCLITestDaemon`, `listAgentsForTest`, `registerViaDaemon` as small local helpers (or reuse existing ones) — keep them in this test file.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `TMPDIR=/tmp go test ./internal/humancli/ -run 'TestRegister|TestGC'`
+Expected: FAIL (cmds undefined).
+
+- [ ] **Step 4: Implement the commands**
+
+`internal/humancli/identity.go`:
+
+```go
+package humancli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// cmdRegister registers the current tmux session as an agent. Alias precedence:
+// explicit positional arg → $MUSTER_ALIAS → tmux session name.
+func cmdRegister(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("register", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	role := fs.String("role", "", "this agent's role")
+	model := fs.String("model", "claude", "model backing this agent: claude or codex")
+	flagArgs, rest := splitFlagsAndPositional(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	c := tmuxenv.CaptureEnv()
+	alias := ""
+	switch {
+	case len(rest) > 0:
+		alias = rest[0]
+	case os.Getenv("MUSTER_ALIAS") != "":
+		alias = os.Getenv("MUSTER_ALIAS")
+	default:
+		alias = c.SessionName
+	}
+	if alias == "" {
+		return fmt.Errorf("cannot determine alias: not in a named tmux session; pass one explicitly or set $MUSTER_ALIAS")
+	}
+	if _, err := callData("register_agent", map[string]any{
+		"alias": alias, "role": *role, "model_type": *model,
+		"session_name": c.SessionName, "session_id": c.SessionID,
+		"socket_path": c.SocketPath, "pane_id": c.PaneID,
+		"project": c.Project, "label": c.Label, "label_manual": c.LabelManual,
+	}); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "registered %s (project %q, model %s)\n", alias, c.Project, *model)
+	return err
+}
+
+// registerBoolFlags: register has no bool flags, so splitFlagsAndPositional
+// treats --role/--model as value flags (correct). Nothing to add here.
+
+// cmdDeregister removes an agent's registration. Alias precedence mirrors
+// register: explicit arg → $MUSTER_ALIAS → tmux session name.
+func cmdDeregister(args []string, out io.Writer) error {
+	alias := ""
+	if len(args) > 0 {
+		alias = args[0]
+	} else if os.Getenv("MUSTER_ALIAS") != "" {
+		alias = os.Getenv("MUSTER_ALIAS")
+	} else {
+		alias = tmuxenv.CaptureEnv().SessionName
+	}
+	if alias == "" {
+		return fmt.Errorf("cannot determine alias to deregister")
+	}
+	if _, err := callData("deregister_agent", map[string]any{"alias": alias}); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "deregistered %s\n", alias)
+	return err
+}
+
+// cmdGC deregisters every agent whose tmux session is no longer alive.
+func cmdGC(out io.Writer) error {
+	raw, err := callData("list_agents", nil)
+	if err != nil {
+		return err
+	}
+	var agents []agentRow
+	if err := json.Unmarshal(raw, &agents); err != nil {
+		return err
+	}
+	reaped := 0
+	for _, a := range agents {
+		if tmuxenv.IsSessionAlive(a.SocketPath, a.SessionID) {
+			continue
+		}
+		if _, err := callData("deregister_agent", map[string]any{"alias": a.Alias}); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(out, "reaped %s (dead session)\n", a.Alias); err != nil {
+			return err
+		}
+		reaped++
+	}
+	_, err = fmt.Fprintf(out, "gc: reaped %d\n", reaped)
+	return err
+}
+```
+
+Add `"encoding/json"` to this file's imports (used by `cmdGC`).
+
+- [ ] **Step 5: Wire into `Dispatch` and `main.go`**
+
+In `internal/humancli/humancli.go` `Dispatch`, add cases:
+
+```go
+	case "register":
+		return cmdRegister(args[1:], out)
+	case "deregister":
+		return cmdDeregister(args[1:], out)
+	case "gc":
+		return cmdGC(out)
+```
+
+Update the `Dispatch` usage string to include `register|deregister|gc`.
+
+In `cmd/muster/main.go`, add the three verbs to the humancli case and the usage banners:
+
+```go
+	case "agents", "inbox", "send", "tasks", "nudge", "register", "deregister", "gc":
+		if err := humancli.Dispatch(os.Args[1:], os.Stdout); err != nil {
+```
+
+Update both `usage:` strings in `main.go` to list the new verbs.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `TMPDIR=/tmp go test ./internal/humancli/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/humancli/ cmd/muster/main.go
+git commit -m "feat(cli): register/deregister/gc commands"
+```
+
+---
+
+### Task 6: humancli — project-scoped resolver + agents enrichment + wiring
+
+**Files:**
+- Create: `internal/humancli/resolve.go`
+- Modify: `internal/humancli/humancli.go` (`cmdAgents`, `cmdSend`, `cmdInbox`, `cmdTasks`, `cmdNudge`)
+- Test: `internal/humancli/resolve_test.go`
+
+**Interfaces:**
+- Consumes: extended `agentRow` (Task 5), `tmuxenv` (Task 1).
+- Produces: `ResolveTarget`, `enrichAgents`, used by all target-taking commands.
+
+- [ ] **Step 1: Write the failing test**
+
+`internal/humancli/resolve_test.go` — pure unit test of the resolver over in-memory enriched agents (no daemon needed):
+
+```go
+package humancli
+
+import "testing"
+
+func agents() []enrichedAgent {
+	return []enrichedAgent{
+		{agentRow: agentRow{Alias: "muster", Project: "muster"}, Live: true, EffLabel: "backend", EffManual: true},
+		{agentRow: agentRow{Alias: "muster-2", Project: "muster"}, Live: true, EffLabel: "frontend", EffManual: true},
+		{agentRow: agentRow{Alias: "timewalk", Project: "timewalk"}, Live: true, EffLabel: "frontend", EffManual: true},
+		{agentRow: agentRow{Alias: "auto1", Project: "muster"}, Live: true, EffLabel: "some topic", EffManual: false},
+	}
+}
+
+func TestResolveExactAliasWins(t *testing.T) {
+	got, err := ResolveTarget(agents(), "timewalk", "muster")
+	if err != nil || got != "timewalk" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestResolveBareLabelInCallerProject(t *testing.T) {
+	got, err := ResolveTarget(agents(), "frontend", "muster")
+	if err != nil || got != "muster-2" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestResolveBareLabelCrossProjectIsError(t *testing.T) {
+	// caller in "scratch": "frontend" exists only in muster & timewalk → must error, not guess
+	if _, err := ResolveTarget(agents(), "frontend", "scratch"); err == nil {
+		t.Fatal("want error for cross-project bare label")
+	}
+}
+
+func TestResolveQualified(t *testing.T) {
+	got, err := ResolveTarget(agents(), "timewalk:frontend", "muster")
+	if err != nil || got != "timewalk" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestResolveAutoTopicNotAddressable(t *testing.T) {
+	if _, err := ResolveTarget(agents(), "some topic", "muster"); err == nil {
+		t.Fatal("auto (non-manual) labels must not be addressable")
+	}
+}
+
+func TestResolveUnknown(t *testing.T) {
+	if _, err := ResolveTarget(agents(), "nope", "muster"); err == nil {
+		t.Fatal("want unknown-agent error")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `TMPDIR=/tmp go test ./internal/humancli/ -run TestResolve`
+Expected: FAIL (types/func undefined).
+
+- [ ] **Step 3: Implement resolver + enrichment**
+
+`internal/humancli/resolve.go`:
+
+```go
+package humancli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// enrichedAgent is an agentRow with live tmux-derived state overlaid.
+type enrichedAgent struct {
+	agentRow
+	Live      bool
+	EffLabel  string // live label if alive, else stored snapshot
+	EffManual bool   // live manual flag if alive, else stored
+}
+
+// enrichAgents overlays liveness + live label onto each row. For a live
+// session the label is re-read from tmux; for a dead one the stored snapshot
+// stands in.
+func enrichAgents(rows []agentRow) []enrichedAgent {
+	out := make([]enrichedAgent, 0, len(rows))
+	for _, a := range rows {
+		e := enrichedAgent{agentRow: a, EffLabel: a.Label, EffManual: a.LabelManual}
+		e.Live = tmuxenv.IsSessionAlive(a.SocketPath, a.SessionID)
+		if e.Live {
+			e.EffLabel, e.EffManual = tmuxenv.SessionLabel(a.SocketPath, a.SessionID)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// callerProject derives the calling shell's project from its own $TMUX socket.
+func callerProject() string {
+	return tmuxenv.ProjectFromSocket(tmuxenv.SocketFromEnv())
+}
+
+// ResolveTarget maps a user-supplied target to a unique agent alias, scoped to
+// caller's project. Rules (in order): exact alias; qualified proj:label; bare
+// addressable label within callerProject. Never silently crosses projects.
+func ResolveTarget(agents []enrichedAgent, given, caller string) (string, error) {
+	// 1. exact alias (globally unique)
+	for _, a := range agents {
+		if a.Alias == given {
+			return a.Alias, nil
+		}
+	}
+	// 2. qualified proj:label
+	if proj, label, ok := strings.Cut(given, ":"); ok {
+		var hits []string
+		for _, a := range agents {
+			if a.Project == proj && a.EffManual && a.EffLabel == label {
+				hits = append(hits, a.Alias)
+			}
+		}
+		return uniqueOrErr(hits, given)
+	}
+	// 3. bare label — restrict to caller's project
+	var inProject, elsewhere []string
+	for _, a := range agents {
+		if a.EffManual && a.EffLabel == given {
+			if a.Project == caller {
+				inProject = append(inProject, a.Alias)
+			} else {
+				elsewhere = append(elsewhere, qualify(a.Project, given))
+			}
+		}
+	}
+	if len(inProject) > 0 {
+		return uniqueOrErr(inProject, given)
+	}
+	if len(elsewhere) > 0 {
+		sort.Strings(elsewhere)
+		return "", fmt.Errorf("label %q is not in your project; qualify it: %s", given, strings.Join(elsewhere, ", "))
+	}
+	return "", fmt.Errorf("unknown agent %q", given)
+}
+
+func uniqueOrErr(hits []string, given string) (string, error) {
+	switch len(hits) {
+	case 1:
+		return hits[0], nil
+	case 0:
+		return "", fmt.Errorf("unknown agent %q", given)
+	default:
+		sort.Strings(hits)
+		return "", fmt.Errorf("%q is ambiguous: %s", given, strings.Join(hits, ", "))
+	}
+}
+
+func qualify(project, label string) string {
+	if project == "" {
+		return label
+	}
+	return project + ":" + label
+}
+
+// resolveVia lists agents, enriches them, and resolves given to an alias.
+func resolveVia(given string) (string, error) {
+	raw, err := callData("list_agents", nil)
+	if err != nil {
+		return "", err
+	}
+	var rows []agentRow
+	if err := jsonUnmarshal(raw, &rows); err != nil {
+		return "", err
+	}
+	return ResolveTarget(enrichAgents(rows), given, callerProject())
+}
+```
+
+> `jsonUnmarshal` here means `json.Unmarshal` — import `"encoding/json"` and call it directly (the alias is only to keep this snippet terse; write real `json.Unmarshal`).
+
+- [ ] **Step 4: Rewrite `cmdAgents` to group + show LABEL/LIVE**
+
+Replace `cmdAgents` in `humancli.go`:
+
+```go
+func cmdAgents(out io.Writer) error {
+	raw, err := callData("list_agents", nil)
+	if err != nil {
+		return err
+	}
+	var rows []agentRow
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return err
+	}
+	agents := enrichAgents(rows)
+	sort.Slice(agents, func(i, j int) bool {
+		if agents[i].Project != agents[j].Project {
+			return agents[i].Project < agents[j].Project
+		}
+		return agents[i].Alias < agents[j].Alias
+	})
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "PROJECT\tALIAS\tLABEL\tMODEL\tLIVE"); err != nil {
+		return err
+	}
+	for _, a := range agents {
+		proj := a.Project
+		if proj == "" {
+			proj = "(none)"
+		}
+		label := a.EffLabel
+		switch {
+		case label == "":
+			label = "—"
+		case !a.EffManual:
+			label = "(" + label + ")" // auto-topic: shown but not addressable
+		}
+		live := "✗"
+		if a.Live {
+			live = "●"
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", proj, a.Alias, label, a.ModelType, live); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+```
+
+Add `"sort"` to `humancli.go` imports.
+
+- [ ] **Step 5: Route target-taking commands through the resolver**
+
+- `cmdSend`: when `toKind == "agent"` (not role/broadcast), replace `toTarget = rest[0]` with a resolved alias:
+  ```go
+  toTarget = rest[0]
+  if toKind == "agent" {
+  	resolved, err := resolveVia(rest[0])
+  	if err != nil {
+  		return err
+  	}
+  	toTarget = resolved
+  }
+  ```
+- `cmdInbox` / `cmdTasks`: resolve `args[0]` before `printThreads`:
+  ```go
+  alias, err := resolveVia(args[0])
+  if err != nil {
+  	return err
+  }
+  return printThreads(out, alias, <false|true>)
+  ```
+- `cmdNudge`: resolve `rest[0]` to `alias` before the `get_agent` call:
+  ```go
+  alias, err := resolveVia(rest[0])
+  if err != nil {
+  	return err
+  }
+  ```
+  (replace the current `alias := rest[0]`).
+
+Update the `usage:` strings for inbox/tasks/nudge/send to read `<alias|label|proj:label>`.
+
+- [ ] **Step 6: Run the full package + verify**
+
+Run: `TMPDIR=/tmp go test ./internal/humancli/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/humancli/
+git commit -m "feat(cli): project-scoped target resolver; agents shows label+liveness"
+```
+
+---
+
+### Task 7: Docs — README CLI + hook snippets
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:** none (docs).
+
+- [ ] **Step 1: Update the CLI section**
+
+In `README.md`, in the CLI section, document the new commands and addressing. Add:
+
+```markdown
+### Registering & liveness
+
+Agents can self-register (so a shell hook can do it at session start):
+
+    muster register [alias] --role <r> --model <claude|codex>
+    muster deregister [alias]
+    muster gc                 # reap agents whose tmux session is gone
+
+`register` captures the tmux pane automatically. Alias precedence: explicit
+arg → `$MUSTER_ALIAS` → tmux session name.
+
+`muster agents` shows each agent's **project** (derived from the per-project
+tmux socket) and its live **label** — the manually-pinned `@claude_task`
+session option (`prefix T`). Auto-topics are shown parenthesized and are not
+addressable.
+
+### Addressing
+
+Any command that takes a target — `send`, `nudge`, `inbox`, `tasks` — accepts:
+
+- an **alias** (the tmux session name, globally unique): `muster nudge muster-2`
+- a **label**, resolved within your current project: `muster send frontend "…"`
+- a **qualified label** to cross projects: `muster send timewalk:frontend "…"`
+
+A bare label never silently crosses projects; if it's ambiguous or only exists
+elsewhere, muster errors and lists the `proj:label` candidates.
+```
+
+- [ ] **Step 2: Document the hooks**
+
+Add a short subsection noting the SessionStart/SessionEnd hook wiring (Claude `settings.json`, Codex config) runs `muster register --model <t> || true` / `muster deregister || true`, and that the actual dotfiles wiring is maintained separately.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): register/deregister/gc + project-scoped addressing"
+```
+
+---
+
+## Final verification
+
+After all tasks: `TMPDIR=/tmp GODEBUG=netdns=go just verify` must pass (fmt, lint, `go test -race`, build). Then the whole-branch Opus review, then merge `feat/session-identity → dev` via PR.

--- a/docs/superpowers/specs/2026-07-14-session-identity-design.md
+++ b/docs/superpowers/specs/2026-07-14-session-identity-design.md
@@ -1,0 +1,157 @@
+# Session Identity: auto-register, tmux liveness, addressable labels — Design
+
+**Status:** approved 2026-07-14. Post-v0.1.0 (Milestone F).
+
+## Goal
+
+Make muster's agent registry **self-maintaining** and **human-legible** by leaning
+on the two facts that define muster's architecture: the **daemon is the API**
+(the CLI is a peer client of it, not a client of the MCP server) and **tmux is
+the substrate** (always present; queryable at any time). Concretely:
+
+1. A plain CLI command registers an agent (so a shell hook can auto-register it),
+   capturing the tmux pane reliably from the shell environment.
+2. The agent list tells the truth about who is alive, by asking tmux — no
+   heartbeats, no reaping timers.
+3. Agents are surfaced and addressed by their **tmux label** (the `@claude_task`
+   session option the operator sets with `prefix T`, e.g. `frontend`/`backend`),
+   so nobody has to remember that `muster-2` is the frontend.
+
+## Non-goals / deferred
+
+- **Hook wiring lives in dotfiles** — the user asked not to touch dotfiles yet.
+  This spec delivers the muster-side surface (`muster register`/`deregister`) and
+  *documents* the SessionStart/SessionEnd hook snippets; actual `settings.json` /
+  Codex-config wiring is a separate dotfiles change. Everything here is testable
+  by running `muster register` manually (simulating the hook).
+- Idle-agent auto-inbox on the `Stop` hook, `muster watch`, the status-bar unread
+  segment, and the v3 TUI remain future roadmap items.
+
+## Architecture
+
+The core stays as-is; changes are additive.
+
+- **`internal/tmuxenv` (new, extracted):** the single canonical place for tmux
+  interaction from outside the daemon. Moves `tmuxSocketPath` / `tmuxQuery` and
+  the pane-capture assembly out of `internal/mcpserver/tools_registry.go`; adds
+  `IsSessionAlive` and `SessionLabel`. Both the MCP `register_agent` tool and the
+  new CLI use it — one capture path, no drift. `tmuxQuery`/the command runner
+  stays injectable for tests.
+- **`internal/store`:** `Agent` gains a `Label` field + `label` column; a small
+  idempotent migration adds the column to existing databases. New
+  `DeleteAgent(alias)`.
+- **`internal/daemon`:** one new op, `deregister_agent`. The daemon core remains
+  tmux-agnostic — tmux is only ever touched through the CLI layer or the injected
+  `wake.Notifier`.
+- **`internal/humancli`:** new `register`, `deregister`, `gc` commands; `agents`
+  enriched with `LABEL` + `LIVE`; one canonical **target resolver** (alias-or-label)
+  reused by `send`, `nudge`, `inbox`, `tasks`.
+
+## Data model
+
+`agents` gains one column:
+
+```sql
+label TEXT NOT NULL DEFAULT ''    -- snapshot of @claude_task at register time
+```
+
+`entries.from_agent` and `threads.*` store the alias as **text**, not a foreign
+key to `agents`. Therefore deleting an agent row (deregister / gc) never breaks
+message or task history — threads addressed to a since-removed alias remain
+intact and readable. The `label` stored on the agent is only a **fallback
+snapshot**; the live value is read from tmux whenever the session is alive.
+
+## Identity model
+
+- **`alias`** — the stable routing key. It must not change under the operator, so
+  it is NOT derived from the mutable label. Resolution precedence in
+  `muster register`: explicit positional arg → `$MUSTER_ALIAS` → tmux session
+  name (`#{session_name}`). For two tabs in one repo this yields stable unique
+  keys like `muster` / `muster-2`.
+- **`label`** — the human name. Read **live** from the tmux session option
+  `@claude_task` at list/resolve time (falling back to the stored snapshot when
+  the session is dead). The option name defaults to `@claude_task` and is
+  overridable via `$MUSTER_LABEL_OPTION` (knob, not hard-weld to the dotfiles
+  convention).
+
+### Canonical target resolution
+
+A single `ResolveTarget(agents, given) → alias` function, used by every command
+that takes an agent target:
+
+1. If `given` exactly matches an agent `alias` → that alias (alias always wins).
+2. Else if exactly one live agent has `label == given` → that agent's alias.
+3. Else if multiple agents share that label → error listing the candidate aliases.
+4. Else → "unknown agent" error.
+
+So the operator types `muster send frontend "…"` and it routes to `muster-2`,
+while the underlying alias never shifts if they relabel with `prefix T`.
+
+## Liveness
+
+`tmuxenv.IsSessionAlive(socketPath, sessionID) bool` runs
+`tmux -S <socket> has-session -t <session_id>` (exit 0 = alive). Performed in the
+**CLI layer**, once per agent, so the daemon stays pure. An agent with an empty
+socket/session (registered outside tmux) is reported dead/unknown, not alive.
+
+- `muster agents` → list from daemon, enrich each row with live label + liveness:
+
+  ```
+  ALIAS      LABEL       MODEL   LIVE
+  muster     backend     claude  ●
+  muster-2   frontend    codex   ●
+  stale      —           codex   ✗
+  ```
+
+- `muster gc` → list, and for every dead agent call `deregister_agent`. Prints
+  what it reaped (never silently). Fixes the stale-agent problem (leftover
+  registrations pointing at panes that no longer exist).
+
+## CLI surface
+
+```bash
+muster register [alias] --role <r> --model <claude|codex>  # capture pane, upsert
+muster deregister [alias]                                  # remove registration
+muster gc                                                  # reap dead agents
+muster agents                                              # now shows LABEL + LIVE
+muster send <alias|label> "msg" --from me                  # target resolver
+muster nudge <alias|label>                                 # target resolver
+muster inbox <alias|label>                                 # target resolver
+muster tasks <alias|label>                                 # target resolver
+```
+
+`register` run outside tmux still succeeds (addressable, empty pane fields → no
+wake target). `deregister` of an unknown alias is a no-op success. Both are safe
+to wrap `|| true` in a hook so they never block session start/end.
+
+## Hook integration (documented; dotfiles wiring deferred)
+
+- **Claude Code** — `settings.json`:
+  `SessionStart` (matcher `startup|resume`) → `muster register --model claude || true`;
+  `SessionEnd` → `muster deregister || true`.
+- **Codex** — equivalent SessionStart/SessionEnd hook entries → same commands
+  with `--model codex`.
+
+Because the hook runs in the pane shell, `$TMUX`/`$TMUX_PANE` are present, so the
+capture is more reliable than the MCP subprocess ever was.
+
+## Error handling
+
+- Missing tmux binary / dead socket → `IsSessionAlive` false, `SessionLabel` "".
+- `register` with no tmux env → registers with empty socket/pane/session/label.
+- Ambiguous label in `ResolveTarget` → explicit error naming the candidates.
+- Migration: `ALTER TABLE agents ADD COLUMN label …` guarded so re-running (column
+  already present) is a no-op — the live `bus.db` upgrades in place, no wipe.
+
+## Testing
+
+- **tmuxenv:** injected command runner — capture assembly; `IsSessionAlive`
+  alive/dead/error; `SessionLabel` present/empty/custom option name.
+- **store:** migration adds column idempotently; `RegisterAgent` upsert sets/updates
+  `label`; `DeleteAgent` removes the row and leaves `entries`/`threads` intact.
+- **daemon:** `deregister_agent` op removes the agent; unknown alias no-ops.
+- **humancli:** against the existing `startTestDaemon` harness with injected tmux —
+  `register` alias precedence + captured fields; `deregister`; `gc` removes only
+  dead agents; `agents` shows live label + liveness; `ResolveTarget` by alias, by
+  label, ambiguous, unknown.
+- All green under `just verify` (`go test -race`, macOS + Linux).

--- a/docs/superpowers/specs/2026-07-14-session-identity-design.md
+++ b/docs/superpowers/specs/2026-07-14-session-identity-design.md
@@ -15,7 +15,8 @@ the substrate** (always present; queryable at any time). Concretely:
    heartbeats, no reaping timers.
 3. Agents are surfaced and addressed by their **tmux label** (the `@claude_task`
    session option the operator sets with `prefix T`, e.g. `frontend`/`backend`),
-   so nobody has to remember that `muster-2` is the frontend.
+   scoped to their **project**, so nobody has to remember that `muster-2` is the
+   frontend — and `send frontend` never silently hits the wrong project's frontend.
 
 ## Non-goals / deferred
 
@@ -34,12 +35,14 @@ The core stays as-is; changes are additive.
 - **`internal/tmuxenv` (new, extracted):** the single canonical place for tmux
   interaction from outside the daemon. Moves `tmuxSocketPath` / `tmuxQuery` and
   the pane-capture assembly out of `internal/mcpserver/tools_registry.go`; adds
-  `IsSessionAlive` and `SessionLabel`. Both the MCP `register_agent` tool and the
+  `ProjectFromSocket` (strip `proj-` from the socket basename), `IsSessionAlive`,
+  and `SessionLabel` (returns the `@claude_task` value and whether it's manually
+  pinned via `@claude_task_manual`). Both the MCP `register_agent` tool and the
   new CLI use it — one capture path, no drift. `tmuxQuery`/the command runner
   stays injectable for tests.
-- **`internal/store`:** `Agent` gains a `Label` field + `label` column; a small
-  idempotent migration adds the column to existing databases. New
-  `DeleteAgent(alias)`.
+- **`internal/store`:** `Agent` gains `Project` / `Label` / `LabelManual` fields +
+  matching columns; a small idempotent migration adds the columns to existing
+  databases. New `DeleteAgent(alias)`.
 - **`internal/daemon`:** one new op, `deregister_agent`. The daemon core remains
   tmux-agnostic — tmux is only ever touched through the CLI layer or the injected
   `wake.Notifier`.
@@ -49,43 +52,70 @@ The core stays as-is; changes are additive.
 
 ## Data model
 
-`agents` gains one column:
+`agents` gains three columns:
 
 ```sql
-label TEXT NOT NULL DEFAULT ''    -- snapshot of @claude_task at register time
+project      TEXT    NOT NULL DEFAULT ''   -- derived from the tmux socket (proj-<project>)
+label        TEXT    NOT NULL DEFAULT ''   -- snapshot of @claude_task at register time
+label_manual INTEGER NOT NULL DEFAULT 0    -- 1 if @claude_task_manual (deliberately pinned)
 ```
 
 `entries.from_agent` and `threads.*` store the alias as **text**, not a foreign
 key to `agents`. Therefore deleting an agent row (deregister / gc) never breaks
 message or task history — threads addressed to a since-removed alias remain
-intact and readable. The `label` stored on the agent is only a **fallback
-snapshot**; the live value is read from tmux whenever the session is alive.
+intact and readable. `label`/`label_manual`/`project` stored on the agent are a
+**fallback snapshot** (for display/addressing when the session is dead); the live
+values are read from tmux whenever the session is alive.
 
 ## Identity model
 
-- **`alias`** — the stable routing key. It must not change under the operator, so
-  it is NOT derived from the mutable label. Resolution precedence in
-  `muster register`: explicit positional arg → `$MUSTER_ALIAS` → tmux session
-  name (`#{session_name}`). For two tabs in one repo this yields stable unique
-  keys like `muster` / `muster-2`.
-- **`label`** — the human name. Read **live** from the tmux session option
-  `@claude_task` at list/resolve time (falling back to the stored snapshot when
-  the session is dead). The option name defaults to `@claude_task` and is
-  overridable via `$MUSTER_LABEL_OPTION` (knob, not hard-weld to the dotfiles
-  convention).
+Three fields make up an agent's identity — one stable key, one scope, one human
+handle:
+
+- **`alias`** — the stable, **globally unique** routing key. It never changes
+  under the operator, so it is NOT derived from the mutable label. Resolution
+  precedence in `muster register`: explicit positional arg → `$MUSTER_ALIAS` →
+  tmux session name (`#{session_name}`). Session names are already unique across
+  projects (`muster-2`, `timewalk-2`), so an alias always addresses exactly one
+  agent, from anywhere.
+- **`project`** — the scope. Derived from the tmux **socket**: your setup runs
+  one server per project on socket `proj-<project>`, so
+  `project = basename(socketPath)` with the `proj-` prefix stripped. Empty when
+  the session isn't proj-managed (ad-hoc `tat`/legacy server, or no tmux). This
+  costs nothing — muster already captures `socket_path` at register.
+- **`label`** — the human name (`frontend`/`backend`), read **live** from the tmux
+  session option `@claude_task` (falling back to the stored snapshot when the
+  session is dead). Option name defaults to `@claude_task`, overridable via
+  `$MUSTER_LABEL_OPTION`. A label is **addressable only when manually pinned**
+  (`@claude_task_manual = 1`, i.e. set via `prefix T`). This matters because
+  `@claude_task` auto-populates with Claude's rolling conversation topic every
+  turn unless pinned — an auto-topic is shown for display but is never a routing
+  target.
 
 ### Canonical target resolution
 
-A single `ResolveTarget(agents, given) → alias` function, used by every command
-that takes an agent target:
+A single `ResolveTarget(agents, given, callerProject) → alias` function, used by
+every command that takes an agent target. `callerProject` is derived from the
+CLI's own `$TMUX` socket at call time.
 
-1. If `given` exactly matches an agent `alias` → that alias (alias always wins).
-2. Else if exactly one live agent has `label == given` → that agent's alias.
-3. Else if multiple agents share that label → error listing the candidate aliases.
-4. Else → "unknown agent" error.
+1. **Exact alias** — if `given` matches an agent `alias`, use it (alias wins;
+   works cross-project since aliases are globally unique).
+2. **Qualified label** — if `given` is `proj:label`, match agents where
+   `project == proj` and addressable-label `== label`. One → its alias; several →
+   error listing candidates; none → error.
+3. **Bare label** — candidates = agents whose addressable-label `== given`:
+   - Restrict to `callerProject` first: exactly one there → use it; several there
+     → error.
+   - None in `callerProject` but some elsewhere → error telling the operator to
+     qualify it (list the candidates as `proj:label`). **Never silently cross
+     project boundaries.**
+   - None anywhere → "unknown agent" error.
 
-So the operator types `muster send frontend "…"` and it routes to `muster-2`,
-while the underlying alias never shifts if they relabel with `prefix T`.
+So from within the `muster` project, `muster send frontend "…"` routes to
+muster's frontend; to reach another project you write `muster send
+timewalk:frontend`. (`:` is the qualifier, not `/`, because `/` already denotes a
+worktree session like `timewalk/feature-x`.) The underlying alias never shifts if
+you relabel with `prefix T`.
 
 ## Liveness
 
@@ -94,14 +124,19 @@ while the underlying alias never shifts if they relabel with `prefix T`.
 **CLI layer**, once per agent, so the daemon stays pure. An agent with an empty
 socket/session (registered outside tmux) is reported dead/unknown, not alive.
 
-- `muster agents` → list from daemon, enrich each row with live label + liveness:
+- `muster agents` → list from daemon, enrich each row with live label + liveness,
+  grouped by project:
 
   ```
-  ALIAS      LABEL       MODEL   LIVE
-  muster     backend     claude  ●
-  muster-2   frontend    codex   ●
-  stale      —           codex   ✗
+  PROJECT    ALIAS      LABEL       MODEL   LIVE
+  muster     muster     backend     claude  ●
+  muster     muster-2   frontend    codex   ●
+  timewalk   timewalk   frontend    claude  ●
+  (none)     stale      —           codex   ✗
   ```
+
+  A non-addressable auto-topic is dimmed/parenthesized so it's clearly not a
+  routing handle.
 
 - `muster gc` → list, and for every dead agent call `deregister_agent`. Prints
   what it reaped (never silently). Fixes the stale-agent problem (leftover
@@ -114,10 +149,10 @@ muster register [alias] --role <r> --model <claude|codex>  # capture pane, upser
 muster deregister [alias]                                  # remove registration
 muster gc                                                  # reap dead agents
 muster agents                                              # now shows LABEL + LIVE
-muster send <alias|label> "msg" --from me                  # target resolver
-muster nudge <alias|label>                                 # target resolver
-muster inbox <alias|label>                                 # target resolver
-muster tasks <alias|label>                                 # target resolver
+muster send <alias|label|proj:label> "msg" --from me       # target resolver
+muster nudge <alias|label|proj:label>                      # target resolver
+muster inbox <alias|label|proj:label>                      # target resolver
+muster tasks <alias|label|proj:label>                      # target resolver
 ```
 
 `register` run outside tmux still succeeds (addressable, empty pane fields → no
@@ -138,20 +173,27 @@ capture is more reliable than the MCP subprocess ever was.
 ## Error handling
 
 - Missing tmux binary / dead socket → `IsSessionAlive` false, `SessionLabel` "".
-- `register` with no tmux env → registers with empty socket/pane/session/label.
-- Ambiguous label in `ResolveTarget` → explicit error naming the candidates.
-- Migration: `ALTER TABLE agents ADD COLUMN label …` guarded so re-running (column
-  already present) is a no-op — the live `bus.db` upgrades in place, no wipe.
+- `register` with no tmux env → registers with empty socket/pane/session/label
+  and empty `project` (still addressable by alias).
+- Ambiguous or cross-project bare label in `ResolveTarget` → explicit error naming
+  the candidates as `proj:label`; never a silent guess or a silent cross-project hop.
+- Migration: each `ALTER TABLE agents ADD COLUMN …` (project, label, label_manual)
+  guarded so re-running (column already present) is a no-op — the live `bus.db`
+  upgrades in place, no wipe.
 
 ## Testing
 
-- **tmuxenv:** injected command runner — capture assembly; `IsSessionAlive`
-  alive/dead/error; `SessionLabel` present/empty/custom option name.
-- **store:** migration adds column idempotently; `RegisterAgent` upsert sets/updates
-  `label`; `DeleteAgent` removes the row and leaves `entries`/`threads` intact.
+- **tmuxenv:** injected command runner — capture assembly; `ProjectFromSocket`
+  (`proj-x` → `x`, non-proj socket → ""); `IsSessionAlive` alive/dead/error;
+  `SessionLabel` present/empty/manual-vs-auto/custom option name.
+- **store:** migration adds columns idempotently; `RegisterAgent` upsert
+  sets/updates `project`/`label`/`label_manual`; `DeleteAgent` removes the row and
+  leaves `entries`/`threads` intact.
 - **daemon:** `deregister_agent` op removes the agent; unknown alias no-ops.
 - **humancli:** against the existing `startTestDaemon` harness with injected tmux —
-  `register` alias precedence + captured fields; `deregister`; `gc` removes only
-  dead agents; `agents` shows live label + liveness; `ResolveTarget` by alias, by
-  label, ambiguous, unknown.
+  `register` alias precedence + captured project/label; `deregister`; `gc` removes
+  only dead agents; `agents` grouped with live label + liveness; `ResolveTarget`
+  by exact alias, bare label in caller project, qualified `proj:label`,
+  cross-project-without-qualifier error, ambiguous error, unknown error,
+  auto-topic-label-not-addressable.
 - All green under `just verify` (`go test -race`, macOS + Linux).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -79,6 +79,19 @@ func i64(m map[string]any, k string) int64 {
 	return 0
 }
 
+// boolArg reads a bool arg, accepting a JSON bool or the strings "true"/"1"
+// (the debug CLI passes all args as strings).
+func boolArg(a map[string]any, key string) bool {
+	switch v := a[key].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "1"
+	default:
+		return false
+	}
+}
+
 func ok(data any) proto.Response    { return proto.Response{OK: true, Data: data} }
 func fail(err error) proto.Response { return proto.Response{Error: err.Error()} }
 
@@ -134,6 +147,7 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			Alias: str(a, "alias"), Role: str(a, "role"), ModelType: str(a, "model_type"),
 			SocketPath: str(a, "socket_path"), PaneID: str(a, "pane_id"), SessionName: str(a, "session_name"),
 			SessionID: str(a, "session_id"),
+			Project:   str(a, "project"), Label: str(a, "label"), LabelManual: boolArg(a, "label_manual"),
 		})
 		if err != nil {
 			return fail(err)
@@ -218,6 +232,11 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			return fail(err)
 		}
 		return ok(map[string]any{"found": found, "agent": ag})
+	case "deregister_agent":
+		if err := d.s.DeleteAgent(str(a, "alias")); err != nil {
+			return fail(err)
+		}
+		return ok(nil)
 	default:
 		return proto.Response{Error: "unknown op: " + req.Op}
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,15 +1,39 @@
 package daemon
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/schuettc/muster/internal/client"
 	"github.com/schuettc/muster/internal/mustertest"
+	"github.com/schuettc/muster/internal/paths"
 	"github.com/schuettc/muster/internal/proto"
 	"github.com/schuettc/muster/internal/store"
 )
+
+// startTestDaemon boots a real in-process daemon on a temp socket.
+func startTestDaemon(t *testing.T) string {
+	t.Helper()
+	dir, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	t.Setenv("MUSTER_HOME", dir)
+	s, err := store.Open(filepath.Join(dir, "bus.db"))
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	d, err := Serve(paths.SocketPath(), s, nil)
+	if err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	return paths.SocketPath()
+}
 
 func TestDaemonRegisterAndList(t *testing.T) {
 	dir, cleanup, err := mustertest.ShortHome()
@@ -104,5 +128,54 @@ func TestTaskClaimAcceptsStringThreadID(t *testing.T) {
 	}
 	if !claim.OK {
 		t.Fatalf("expected task_claim to succeed with string thread_id, got resp=%+v", claim)
+	}
+}
+
+// decodeGetAgent re-marshals a get_agent response's Data (already a
+// map[string]any from the wire) into a typed found/agent pair, matching the
+// approach internal/humancli uses for the same response shape.
+func decodeGetAgent(t *testing.T, resp proto.Response) (store.Agent, bool) {
+	t.Helper()
+	raw, err := json.Marshal(resp.Data)
+	if err != nil {
+		t.Fatalf("marshal resp.Data: %v", err)
+	}
+	var res struct {
+		Found bool        `json:"found"`
+		Agent store.Agent `json:"agent"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		t.Fatalf("unmarshal get_agent response: %v", err)
+	}
+	return res.Agent, res.Found
+}
+
+func TestRegisterCapturesLabelAndDeregister(t *testing.T) {
+	sock := startTestDaemon(t) // existing helper
+	if _, err := client.Call(sock, proto.Request{Op: "register_agent", Args: map[string]any{
+		"alias": "muster-2", "role": "peer", "model_type": "codex",
+		"socket_path": "/s", "session_id": "$1",
+		"project": "muster", "label": "frontend", "label_manual": true,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Call(sock, proto.Request{Op: "get_agent", Args: map[string]any{"alias": "muster-2"}})
+	if err != nil || !resp.OK {
+		t.Fatalf("get_agent: %v %+v", err, resp)
+	}
+	ag, found := decodeGetAgent(t, resp)
+	if !found || ag.Project != "muster" || ag.Label != "frontend" || !ag.LabelManual {
+		t.Fatalf("expected project/label/label_manual to round-trip, got found=%v agent=%+v", found, ag)
+	}
+
+	if _, err := client.Call(sock, proto.Request{Op: "deregister_agent", Args: map[string]any{"alias": "muster-2"}}); err != nil {
+		t.Fatal(err)
+	}
+	resp, err = client.Call(sock, proto.Request{Op: "get_agent", Args: map[string]any{"alias": "muster-2"}})
+	if err != nil || !resp.OK {
+		t.Fatalf("get_agent after deregister: %v %+v", err, resp)
+	}
+	if _, found := decodeGetAgent(t, resp); found {
+		t.Fatal("expected agent to be gone after deregister_agent")
 	}
 }

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -32,7 +32,12 @@ type agentRow struct {
 	Alias       string `json:"alias"`
 	Role        string `json:"role"`
 	ModelType   string `json:"model_type"`
+	SocketPath  string `json:"socket_path"`
+	SessionID   string `json:"session_id"`
 	SessionName string `json:"session_name"`
+	Project     string `json:"project"`
+	Label       string `json:"label"`
+	LabelManual bool   `json:"label_manual"`
 	LastSeen    int64  `json:"last_seen"`
 }
 
@@ -67,7 +72,7 @@ func callData(op string, args map[string]any) (json.RawMessage, error) {
 // Dispatch routes an operator subcommand. args[0] is the subcommand name.
 func Dispatch(args []string, out io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: muster <agents|inbox|send|tasks|nudge> [args]")
+		return fmt.Errorf("usage: muster <agents|inbox|send|tasks|nudge|register|deregister|gc> [args]")
 	}
 	switch args[0] {
 	case "agents":
@@ -80,6 +85,12 @@ func Dispatch(args []string, out io.Writer) error {
 		return cmdTasks(args[1:], out)
 	case "nudge":
 		return cmdNudge(args[1:], out)
+	case "register":
+		return cmdRegister(args[1:], out)
+	case "deregister":
+		return cmdDeregister(args[1:], out)
+	case "gc":
+		return cmdGC(out)
 	default:
 		return fmt.Errorf("unknown command %q", args[0])
 	}
@@ -165,7 +176,19 @@ var sendBoolFlags = map[string]bool{"role": true, "broadcast": true}
 // and positional arguments, regardless of whether flags appear before or
 // after the positionals — Go's flag.Parse otherwise stops at the first
 // non-flag token, which breaks `send <target> <body> [--from X ...]`.
-func splitFlagsAndPositional(args []string) (flagArgs, positional []string) {
+//
+// boolFlags names the calling command's no-value flags (so the following
+// token isn't mistaken for that flag's value); when omitted it defaults to
+// sendBoolFlags for backward compatibility with cmdSend's original call
+// site. Commands whose flags are all value flags (e.g. register's
+// --role/--model) must pass an explicit empty set rather than rely on that
+// default, since flag names collide across commands (send's --role is
+// boolean; register's --role takes a value).
+func splitFlagsAndPositional(args []string, boolFlags ...map[string]bool) (flagArgs, positional []string) {
+	bf := sendBoolFlags
+	if len(boolFlags) > 0 {
+		bf = boolFlags[0]
+	}
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		if !strings.HasPrefix(a, "-") {
@@ -179,7 +202,7 @@ func splitFlagsAndPositional(args []string) (flagArgs, positional []string) {
 		if hasValue {
 			name = name[:idx]
 		}
-		if !hasValue && !sendBoolFlags[name] && i+1 < len(args) {
+		if !hasValue && !bf[name] && i+1 < len(args) {
 			i++
 			flagArgs = append(flagArgs, args[i])
 		}

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -96,21 +97,45 @@ func Dispatch(args []string, out io.Writer) error {
 	}
 }
 
+// cmdAgents lists registered agents grouped by project, showing each
+// agent's addressable label and live tmux session status.
 func cmdAgents(out io.Writer) error {
 	raw, err := callData("list_agents", nil)
 	if err != nil {
 		return err
 	}
-	var agents []agentRow
-	if err := json.Unmarshal(raw, &agents); err != nil {
+	var rows []agentRow
+	if err := json.Unmarshal(raw, &rows); err != nil {
 		return err
 	}
+	agents := enrichAgents(rows)
+	sort.Slice(agents, func(i, j int) bool {
+		if agents[i].Project != agents[j].Project {
+			return agents[i].Project < agents[j].Project
+		}
+		return agents[i].Alias < agents[j].Alias
+	})
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "ALIAS\tROLE\tMODEL\tSESSION"); err != nil {
+	if _, err := fmt.Fprintln(tw, "PROJECT\tALIAS\tLABEL\tMODEL\tLIVE"); err != nil {
 		return err
 	}
 	for _, a := range agents {
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", a.Alias, a.Role, a.ModelType, a.SessionName); err != nil {
+		proj := a.Project
+		if proj == "" {
+			proj = "(none)"
+		}
+		label := a.EffLabel
+		switch {
+		case label == "":
+			label = "—"
+		case !a.EffManual:
+			label = "(" + label + ")" // auto-topic: shown but not addressable
+		}
+		live := "✗"
+		if a.Live {
+			live = "●"
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", proj, a.Alias, label, a.ModelType, live); err != nil {
 			return err
 		}
 	}
@@ -146,9 +171,16 @@ func cmdSend(args []string, out io.Writer) error {
 		body = strings.Join(rest, " ")
 	} else {
 		if len(rest) < 2 {
-			return fmt.Errorf("usage: muster send <target> <body> [--from X --subject S --ref R --role --broadcast]")
+			return fmt.Errorf("usage: muster send <alias|label|proj:label> <body> [--from X --subject S --ref R --role --broadcast]")
 		}
 		toTarget = rest[0]
+		if toKind == "agent" {
+			resolved, err := resolveVia(rest[0])
+			if err != nil {
+				return err
+			}
+			toTarget = resolved
+		}
 		body = strings.Join(rest[1:], " ")
 	}
 	raw, err := callData("send_message", map[string]any{
@@ -213,17 +245,25 @@ func splitFlagsAndPositional(args []string, boolFlags ...map[string]bool) (flagA
 // cmdInbox prints the given alias's threads.
 func cmdInbox(args []string, out io.Writer) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: muster inbox <alias>")
+		return fmt.Errorf("usage: muster inbox <alias|label|proj:label>")
 	}
-	return printThreads(out, args[0], false)
+	alias, err := resolveVia(args[0])
+	if err != nil {
+		return err
+	}
+	return printThreads(out, alias, false)
 }
 
 // cmdTasks prints the given alias's inbox filtered to kind=task threads.
 func cmdTasks(args []string, out io.Writer) error {
 	if len(args) < 1 {
-		return fmt.Errorf("usage: muster tasks <alias>")
+		return fmt.Errorf("usage: muster tasks <alias|label|proj:label>")
 	}
-	return printThreads(out, args[0], true)
+	alias, err := resolveVia(args[0])
+	if err != nil {
+		return err
+	}
+	return printThreads(out, alias, true)
 }
 
 // printThreads fetches an alias's inbox and prints it; if tasksOnly, only
@@ -267,9 +307,12 @@ func cmdNudge(args []string, out io.Writer) error {
 	}
 	rest := fs.Args()
 	if len(rest) != 1 {
-		return fmt.Errorf("usage: muster nudge <alias> [--no-submit]")
+		return fmt.Errorf("usage: muster nudge <alias|label|proj:label> [--no-submit]")
 	}
-	alias := rest[0]
+	alias, err := resolveVia(rest[0])
+	if err != nil {
+		return err
+	}
 	raw, err := callData("get_agent", map[string]any{"alias": alias})
 	if err != nil {
 		return err

--- a/internal/humancli/humancli_test.go
+++ b/internal/humancli/humancli_test.go
@@ -48,7 +48,7 @@ func TestAgentsCommandListsRegistered(t *testing.T) {
 		t.Fatalf("agents: %v", err)
 	}
 	out := buf.String()
-	if !strings.Contains(out, "backend") || !strings.Contains(out, "consumer") || !strings.Contains(out, "producer") {
+	if !strings.Contains(out, "backend") || !strings.Contains(out, "consumer") || !strings.Contains(out, "claude") || !strings.Contains(out, "codex") {
 		t.Fatalf("agents output missing rows:\n%s", out)
 	}
 }

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -53,11 +53,12 @@ func cmdRegister(args []string, out io.Writer) error {
 // register: explicit arg → $MUSTER_ALIAS → tmux session name.
 func cmdDeregister(args []string, out io.Writer) error {
 	alias := ""
-	if len(args) > 0 {
+	switch {
+	case len(args) > 0:
 		alias = args[0]
-	} else if os.Getenv("MUSTER_ALIAS") != "" {
+	case os.Getenv("MUSTER_ALIAS") != "":
 		alias = os.Getenv("MUSTER_ALIAS")
-	} else {
+	default:
 		alias = tmuxenv.CaptureEnv().SessionName
 	}
 	if alias == "" {

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -1,0 +1,98 @@
+package humancli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// cmdRegister registers the current tmux session as an agent. Alias precedence:
+// explicit positional arg → $MUSTER_ALIAS → tmux session name.
+func cmdRegister(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("register", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	role := fs.String("role", "", "this agent's role")
+	model := fs.String("model", "claude", "model backing this agent: claude or codex")
+	// register has no boolean flags: --role and --model both take values, so
+	// pass an empty bool-flags set (an implicit default would wrongly reuse
+	// send's --role, which IS boolean there).
+	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{})
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	c := tmuxenv.CaptureEnv()
+	alias := ""
+	switch {
+	case len(rest) > 0:
+		alias = rest[0]
+	case os.Getenv("MUSTER_ALIAS") != "":
+		alias = os.Getenv("MUSTER_ALIAS")
+	default:
+		alias = c.SessionName
+	}
+	if alias == "" {
+		return fmt.Errorf("cannot determine alias: not in a named tmux session; pass one explicitly or set $MUSTER_ALIAS")
+	}
+	if _, err := callData("register_agent", map[string]any{
+		"alias": alias, "role": *role, "model_type": *model,
+		"session_name": c.SessionName, "session_id": c.SessionID,
+		"socket_path": c.SocketPath, "pane_id": c.PaneID,
+		"project": c.Project, "label": c.Label, "label_manual": c.LabelManual,
+	}); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "registered %s (project %q, model %s)\n", alias, c.Project, *model)
+	return err
+}
+
+// cmdDeregister removes an agent's registration. Alias precedence mirrors
+// register: explicit arg → $MUSTER_ALIAS → tmux session name.
+func cmdDeregister(args []string, out io.Writer) error {
+	alias := ""
+	if len(args) > 0 {
+		alias = args[0]
+	} else if os.Getenv("MUSTER_ALIAS") != "" {
+		alias = os.Getenv("MUSTER_ALIAS")
+	} else {
+		alias = tmuxenv.CaptureEnv().SessionName
+	}
+	if alias == "" {
+		return fmt.Errorf("cannot determine alias to deregister")
+	}
+	if _, err := callData("deregister_agent", map[string]any{"alias": alias}); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(out, "deregistered %s\n", alias)
+	return err
+}
+
+// cmdGC deregisters every agent whose tmux session is no longer alive.
+func cmdGC(out io.Writer) error {
+	raw, err := callData("list_agents", nil)
+	if err != nil {
+		return err
+	}
+	var agents []agentRow
+	if err := json.Unmarshal(raw, &agents); err != nil {
+		return err
+	}
+	reaped := 0
+	for _, a := range agents {
+		if tmuxenv.IsSessionAlive(a.SocketPath, a.SessionID) {
+			continue
+		}
+		if _, err := callData("deregister_agent", map[string]any{"alias": a.Alias}); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(out, "reaped %s (dead session)\n", a.Alias); err != nil {
+			return err
+		}
+		reaped++
+	}
+	_, err = fmt.Fprintf(out, "gc: reaped %d\n", reaped)
+	return err
+}

--- a/internal/humancli/identity_test.go
+++ b/internal/humancli/identity_test.go
@@ -1,0 +1,133 @@
+package humancli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// startCLITestDaemon boots a real in-process daemon on a temp socket and
+// returns the socket path (kept for parity with the brief's helper name;
+// callData always targets paths.SocketPath(), which is set to agree with it).
+func startCLITestDaemon(t *testing.T) string {
+	t.Helper()
+	startTestDaemon(t)
+	return ""
+}
+
+// listAgentsForTest fetches list_agents through the same callData path the
+// commands use, decoded into agentRow.
+func listAgentsForTest(t *testing.T, _ string) []agentRow {
+	t.Helper()
+	raw, err := callData("list_agents", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var agents []agentRow
+	if err := json.Unmarshal(raw, &agents); err != nil {
+		t.Fatal(err)
+	}
+	return agents
+}
+
+// registerViaDaemon registers an agent directly through the daemon op,
+// bypassing tmux capture, so gc tests can set up known-alive/known-dead rows.
+func registerViaDaemon(t *testing.T, _ string, alias, socketPath, sessionID string) {
+	t.Helper()
+	if _, err := callData("register_agent", map[string]any{
+		"alias": alias, "socket_path": socketPath, "session_id": sessionID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRegisterUsesAliasPrecedenceAndCaptures(t *testing.T) {
+	sock := startCLITestDaemon(t)
+	t.Setenv("TMUX", "/tmp/tmux-0/proj-muster,1,0")
+	t.Setenv("TMUX_PANE", "%0")
+	t.Setenv("MUSTER_ALIAS", "")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_id}":
+			return "$1", nil
+		case "#{session_name}":
+			return "muster-2", nil
+		default:
+			return "frontend\x1f1", nil
+		}
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	// no positional alias, no $MUSTER_ALIAS → alias falls back to session name
+	if err := cmdRegister([]string{"--model", "codex", "--role", "peer"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	// verify via list_agents that alias == "muster-2", project=="muster", label=="frontend"
+	agents := listAgentsForTest(t, sock)
+	if len(agents) != 1 || agents[0].Alias != "muster-2" || agents[0].Project != "muster" || agents[0].Label != "frontend" || !agents[0].LabelManual {
+		t.Fatalf("registered=%+v", agents)
+	}
+
+	// explicit positional alias wins over session name
+	buf.Reset()
+	if err := cmdRegister([]string{"backend", "--model", "codex"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	agents = listAgentsForTest(t, sock)
+	found := false
+	for _, a := range agents {
+		if a.Alias == "backend" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'backend' among registered agents: %+v", agents)
+	}
+}
+
+func TestDeregisterUsesAliasPrecedence(t *testing.T) {
+	sock := startCLITestDaemon(t)
+	registerViaDaemon(t, sock, "gone", "/s", "$1")
+
+	var buf bytes.Buffer
+	if err := cmdDeregister([]string{"gone"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	agents := listAgentsForTest(t, sock)
+	if len(agents) != 0 {
+		t.Fatalf("expected no agents after deregister, got %+v", agents)
+	}
+}
+
+func TestGCReapsOnlyDeadAgents(t *testing.T) {
+	sock := startCLITestDaemon(t)
+	// register two agents directly via the daemon: one "alive", one "dead"
+	registerViaDaemon(t, sock, "alive", "/s", "$ALIVE")
+	registerViaDaemon(t, sock, "dead", "/s", "$DEAD")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		// has-session succeeds only for $ALIVE
+		if len(args) >= 5 && args[2] == "has-session" && args[4] == "$ALIVE" {
+			return "", nil
+		}
+		if len(args) >= 3 && args[2] == "has-session" {
+			return "", fmt.Errorf("dead")
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdGC(&buf); err != nil {
+		t.Fatal(err)
+	}
+	agents := listAgentsForTest(t, sock)
+	if len(agents) != 1 || agents[0].Alias != "alive" {
+		t.Fatalf("after gc=%+v (want only 'alive')", agents)
+	}
+}

--- a/internal/humancli/resolve.go
+++ b/internal/humancli/resolve.go
@@ -1,0 +1,112 @@
+package humancli
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// enrichedAgent is an agentRow with live tmux-derived state overlaid.
+type enrichedAgent struct {
+	agentRow
+	Live      bool
+	EffLabel  string // live label if alive, else stored snapshot
+	EffManual bool   // live manual flag if alive, else stored
+}
+
+// enrichAgents overlays liveness + live label onto each row. For a live
+// session the label is re-read from tmux; for a dead one the stored snapshot
+// stands in.
+func enrichAgents(rows []agentRow) []enrichedAgent {
+	out := make([]enrichedAgent, 0, len(rows))
+	for _, a := range rows {
+		e := enrichedAgent{agentRow: a, EffLabel: a.Label, EffManual: a.LabelManual}
+		e.Live = tmuxenv.IsSessionAlive(a.SocketPath, a.SessionID)
+		if e.Live {
+			e.EffLabel, e.EffManual = tmuxenv.SessionLabel(a.SocketPath, a.SessionID)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// callerProject derives the calling shell's project from its own $TMUX socket.
+func callerProject() string {
+	return tmuxenv.ProjectFromSocket(tmuxenv.SocketFromEnv())
+}
+
+// ResolveTarget maps a user-supplied target to a unique agent alias, scoped to
+// caller's project. Rules (in order): exact alias; qualified proj:label; bare
+// addressable label within callerProject. Never silently crosses projects.
+func ResolveTarget(agents []enrichedAgent, given, caller string) (string, error) {
+	// 1. exact alias (globally unique)
+	for _, a := range agents {
+		if a.Alias == given {
+			return a.Alias, nil
+		}
+	}
+	// 2. qualified proj:label
+	if proj, label, ok := strings.Cut(given, ":"); ok {
+		var hits []string
+		for _, a := range agents {
+			if a.Project == proj && a.EffManual && a.EffLabel == label {
+				hits = append(hits, a.Alias)
+			}
+		}
+		return uniqueOrErr(hits, given)
+	}
+	// 3. bare label — restrict to caller's project
+	var inProject, elsewhere []string
+	for _, a := range agents {
+		if a.EffManual && a.EffLabel == given {
+			if a.Project == caller {
+				inProject = append(inProject, a.Alias)
+			} else {
+				elsewhere = append(elsewhere, qualify(a.Project, given))
+			}
+		}
+	}
+	if len(inProject) > 0 {
+		return uniqueOrErr(inProject, given)
+	}
+	if len(elsewhere) > 0 {
+		sort.Strings(elsewhere)
+		return "", fmt.Errorf("label %q is not in your project; qualify it: %s", given, strings.Join(elsewhere, ", "))
+	}
+	return "", fmt.Errorf("unknown agent %q", given)
+}
+
+func uniqueOrErr(hits []string, given string) (string, error) {
+	switch len(hits) {
+	case 1:
+		return hits[0], nil
+	case 0:
+		return "", fmt.Errorf("unknown agent %q", given)
+	default:
+		sort.Strings(hits)
+		return "", fmt.Errorf("%q is ambiguous: %s", given, strings.Join(hits, ", "))
+	}
+}
+
+func qualify(project, label string) string {
+	if project == "" {
+		return label
+	}
+	return project + ":" + label
+}
+
+// resolveVia lists agents, enriches them, and resolves given to an alias.
+func resolveVia(given string) (string, error) {
+	raw, err := callData("list_agents", nil)
+	if err != nil {
+		return "", err
+	}
+	var rows []agentRow
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return "", err
+	}
+	return ResolveTarget(enrichAgents(rows), given, callerProject())
+}

--- a/internal/humancli/resolve_test.go
+++ b/internal/humancli/resolve_test.go
@@ -1,0 +1,52 @@
+package humancli
+
+import "testing"
+
+func agents() []enrichedAgent {
+	return []enrichedAgent{
+		{agentRow: agentRow{Alias: "muster", Project: "muster"}, Live: true, EffLabel: "backend", EffManual: true},
+		{agentRow: agentRow{Alias: "muster-2", Project: "muster"}, Live: true, EffLabel: "frontend", EffManual: true},
+		{agentRow: agentRow{Alias: "timewalk", Project: "timewalk"}, Live: true, EffLabel: "frontend", EffManual: true},
+		{agentRow: agentRow{Alias: "auto1", Project: "muster"}, Live: true, EffLabel: "some topic", EffManual: false},
+	}
+}
+
+func TestResolveExactAliasWins(t *testing.T) {
+	got, err := ResolveTarget(agents(), "timewalk", "muster")
+	if err != nil || got != "timewalk" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestResolveBareLabelInCallerProject(t *testing.T) {
+	got, err := ResolveTarget(agents(), "frontend", "muster")
+	if err != nil || got != "muster-2" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestResolveBareLabelCrossProjectIsError(t *testing.T) {
+	// caller in "scratch": "frontend" exists only in muster & timewalk → must error, not guess
+	if _, err := ResolveTarget(agents(), "frontend", "scratch"); err == nil {
+		t.Fatal("want error for cross-project bare label")
+	}
+}
+
+func TestResolveQualified(t *testing.T) {
+	got, err := ResolveTarget(agents(), "timewalk:frontend", "muster")
+	if err != nil || got != "timewalk" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestResolveAutoTopicNotAddressable(t *testing.T) {
+	if _, err := ResolveTarget(agents(), "some topic", "muster"); err == nil {
+		t.Fatal("auto (non-manual) labels must not be addressable")
+	}
+}
+
+func TestResolveUnknown(t *testing.T) {
+	if _, err := ResolveTarget(agents(), "nope", "muster"); err == nil {
+		t.Fatal("want unknown-agent error")
+	}
+}

--- a/internal/mcpserver/call.go
+++ b/internal/mcpserver/call.go
@@ -12,8 +12,8 @@ import (
 
 // callDaemon sends one op to the daemon (lazily starting it) and returns the
 // response Data as JSON, or an error if the transport failed or the daemon
-// reported !OK.
-func callDaemon(op string, args map[string]any) (json.RawMessage, error) {
+// reported !OK. It is a package-level var so tests can stub it.
+var callDaemon = func(op string, args map[string]any) (json.RawMessage, error) {
 	resp, err := client.Call(paths.SocketPath(), proto.Request{Op: op, Args: args})
 	if err != nil {
 		return nil, err

--- a/internal/mcpserver/tools_registry.go
+++ b/internal/mcpserver/tools_registry.go
@@ -3,11 +3,9 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
-	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
 // RegisterAgentIn is the input to register_agent. socket_path/pane_id are NOT
@@ -34,43 +32,23 @@ type ListAgentsOut struct {
 	Agents []AgentView `json:"agents" jsonschema:"the registered agents"`
 }
 
-// tmuxSocketPath extracts the socket path from $TMUX ("<socket>,<pid>,<session>").
-func tmuxSocketPath() string {
-	tmux := os.Getenv("TMUX")
-	if tmux == "" {
-		return ""
-	}
-	return strings.SplitN(tmux, ",", 2)[0]
-}
-
-// tmuxQuery resolves a tmux format for a pane, socket-aware. Overridable in tests.
-var tmuxQuery = func(socket, pane, format string) string {
-	if socket == "" || pane == "" {
-		return ""
-	}
-	out, err := exec.Command("tmux", "-S", socket, "display-message", "-p", "-t", pane, format).Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
-}
-
 func registerAgentHandler(_ context.Context, _ *mcp.CallToolRequest, in RegisterAgentIn) (*mcp.CallToolResult, OKOut, error) {
-	socket := tmuxSocketPath()
-	pane := os.Getenv("TMUX_PANE")
-	sessionID := tmuxQuery(socket, pane, "#{session_id}")
+	c := tmuxenv.CaptureEnv()
 	sessionName := in.SessionName
 	if sessionName == "" {
-		sessionName = tmuxQuery(socket, pane, "#{session_name}")
+		sessionName = c.SessionName
 	}
 	_, err := callDaemon("register_agent", map[string]any{
 		"alias":        in.Alias,
 		"role":         in.Role,
 		"model_type":   in.ModelType,
 		"session_name": sessionName,
-		"session_id":   sessionID,
-		"socket_path":  socket,
-		"pane_id":      pane,
+		"session_id":   c.SessionID,
+		"socket_path":  c.SocketPath,
+		"pane_id":      c.PaneID,
+		"project":      c.Project,
+		"label":        c.Label,
+		"label_manual": c.LabelManual,
 	})
 	if err != nil {
 		return nil, OKOut{}, err

--- a/internal/mcpserver/tools_registry_test.go
+++ b/internal/mcpserver/tools_registry_test.go
@@ -1,6 +1,7 @@
 package mcpserver
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -25,13 +26,13 @@ func TestRegisterAgentCapturesTmuxEnv(t *testing.T) {
 
 	var got map[string]any
 	prevDaemon := callDaemon
-	callDaemon = func(op string, args map[string]any) (json.RawMessage, error) {
+	callDaemon = func(_ string, args map[string]any) (json.RawMessage, error) {
 		got = args
 		return []byte(`{}`), nil
 	}
 	t.Cleanup(func() { callDaemon = prevDaemon })
 
-	_, _, err := registerAgentHandler(nil, nil, RegisterAgentIn{Alias: "backend", Role: "producer", ModelType: "claude"})
+	_, _, err := registerAgentHandler(context.TODO(), nil, RegisterAgentIn{Alias: "backend", Role: "producer", ModelType: "claude"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcpserver/tools_registry_test.go
+++ b/internal/mcpserver/tools_registry_test.go
@@ -1,69 +1,42 @@
 package mcpserver
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
 func TestRegisterAgentCapturesTmuxEnv(t *testing.T) {
-	startTestDaemon(t)
-	t.Setenv("TMUX", "/private/tmp/tmux-501/proj-bettor-help,123,4")
+	t.Setenv("TMUX", "/private/tmp/tmux-501/proj-muster,123,0")
 	t.Setenv("TMUX_PANE", "%6")
-
-	_, out, err := registerAgentHandler(context.Background(), nil, RegisterAgentIn{
-		Alias: "backend", Role: "producer", ModelType: "claude",
-	})
-	if err != nil {
-		t.Fatalf("register handler: %v", err)
-	}
-	if !out.OK {
-		t.Fatalf("expected ok")
-	}
-
-	// Verify via list that the socket/pane were captured from the env.
-	_, listOut, err := listAgentsHandler(context.Background(), nil, ListAgentsIn{})
-	if err != nil {
-		t.Fatalf("list handler: %v", err)
-	}
-	if len(listOut.Agents) != 1 {
-		t.Fatalf("expected 1 agent, got %d", len(listOut.Agents))
-	}
-	if listOut.Agents[0].Alias != "backend" {
-		t.Fatalf("unexpected agent: %+v", listOut.Agents[0])
-	}
-	if listOut.Agents[0].ModelType != "claude" {
-		t.Fatalf("unexpected model_type: %+v", listOut.Agents[0])
-	}
-}
-
-func TestRegisterAgentResolvesSessionID(t *testing.T) {
-	startTestDaemon(t)
-	t.Setenv("TMUX", "/private/tmp/tmux-501/proj-muster,123,4")
-	t.Setenv("TMUX_PANE", "%2")
-	// stub the tmux query so we don't need a real tmux
-	orig := tmuxQuery
-	tmuxQuery = func(_, _, format string) string {
-		switch format {
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
 		case "#{session_id}":
-			return "$7"
+			return "$5", nil
 		case "#{session_name}":
-			return "muster-2"
+			return "muster-2", nil
+		default:
+			return "backend\x1f1", nil
 		}
-		return ""
 	}
-	t.Cleanup(func() { tmuxQuery = orig })
+	t.Cleanup(func() { tmuxenv.Run = prev })
 
-	if _, _, err := registerAgentHandler(context.Background(), nil, RegisterAgentIn{Alias: "reviewer", Role: "reviewer", ModelType: "codex"}); err != nil {
-		t.Fatalf("register: %v", err)
+	var got map[string]any
+	prevDaemon := callDaemon
+	callDaemon = func(op string, args map[string]any) (json.RawMessage, error) {
+		got = args
+		return []byte(`{}`), nil
 	}
-	raw, err := callDaemon("list_agents", nil)
+	t.Cleanup(func() { callDaemon = prevDaemon })
+
+	_, _, err := registerAgentHandler(nil, nil, RegisterAgentIn{Alias: "backend", Role: "producer", ModelType: "claude"})
 	if err != nil {
-		t.Fatalf("list: %v", err)
+		t.Fatal(err)
 	}
-	var agents []AgentView
-	_ = json.Unmarshal(raw, &agents)
-	if len(agents) != 1 || agents[0].SessionName != "muster-2" {
-		t.Fatalf("session_name not captured: %+v", agents)
+	if got["socket_path"] != "/private/tmp/tmux-501/proj-muster" || got["session_id"] != "$5" ||
+		got["project"] != "muster" || got["label"] != "backend" || got["label_manual"] != true {
+		t.Fatalf("captured args = %+v", got)
 	}
 }

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -12,8 +12,8 @@ import (
 func (s *Store) RegisterAgent(a Agent) error {
 	now := clock.NowMillis()
 	_, err := s.db.Exec(`
-INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, registered_at, last_seen)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, project, label, label_manual, registered_at, last_seen)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(alias) DO UPDATE SET
     role=excluded.role,
     model_type=excluded.model_type,
@@ -21,15 +21,19 @@ ON CONFLICT(alias) DO UPDATE SET
     pane_id=excluded.pane_id,
     session_name=excluded.session_name,
     session_id=excluded.session_id,
+    project=excluded.project,
+    label=excluded.label,
+    label_manual=excluded.label_manual,
     last_seen=excluded.last_seen`,
-		a.Alias, a.Role, a.ModelType, a.SocketPath, a.PaneID, a.SessionName, a.SessionID, now, now)
+		a.Alias, a.Role, a.ModelType, a.SocketPath, a.PaneID, a.SessionName, a.SessionID,
+		a.Project, a.Label, a.LabelManual, now, now)
 	return err
 }
 
 // ListAgents returns all agents ordered by alias.
 func (s *Store) ListAgents() ([]Agent, error) {
 	rows, err := s.db.Query(`
-SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, registered_at, last_seen
+SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, project, label, label_manual, registered_at, last_seen
 FROM agents ORDER BY alias`)
 	if err != nil {
 		return nil, err
@@ -38,7 +42,7 @@ FROM agents ORDER BY alias`)
 	var out []Agent
 	for rows.Next() {
 		var a Agent
-		if err := rows.Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.RegisteredAt, &a.LastSeen); err != nil {
+		if err := rows.Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen); err != nil {
 			return nil, err
 		}
 		out = append(out, a)
@@ -50,9 +54,9 @@ FROM agents ORDER BY alias`)
 func (s *Store) GetAgent(alias string) (Agent, bool, error) {
 	var a Agent
 	err := s.db.QueryRow(`
-SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, registered_at, last_seen
+SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, project, label, label_manual, registered_at, last_seen
 FROM agents WHERE alias=?`, alias).
-		Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.RegisteredAt, &a.LastSeen)
+		Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Agent{}, false, nil
 	}
@@ -65,5 +69,13 @@ FROM agents WHERE alias=?`, alias).
 // TouchAgent bumps last_seen. No error if the agent is unknown.
 func (s *Store) TouchAgent(alias string) error {
 	_, err := s.db.Exec(`UPDATE agents SET last_seen=? WHERE alias=?`, clock.NowMillis(), alias)
+	return err
+}
+
+// DeleteAgent removes an agent's registration by alias. Unknown alias is a
+// no-op (no error). Message/task history is unaffected — threads store the
+// alias as text, not a foreign key.
+func (s *Store) DeleteAgent(alias string) error {
+	_, err := s.db.Exec(`DELETE FROM agents WHERE alias=?`, alias)
 	return err
 }

--- a/internal/store/agents_test.go
+++ b/internal/store/agents_test.go
@@ -60,3 +60,41 @@ func TestRegisterAgentRoundTripsSessionIDAndGetAgent(t *testing.T) {
 		t.Fatalf("GetAgent should report ok=false for unknown alias")
 	}
 }
+
+func TestAgentLabelAndDelete(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{
+		Alias: "muster-2", Role: "peer", ModelType: "codex",
+		SocketPath: "/tmp/tmux-0/proj-muster", SessionID: "$1",
+		Project: "muster", Label: "frontend", LabelManual: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.GetAgent("muster-2")
+	if err != nil || !ok {
+		t.Fatalf("get: ok=%v err=%v", ok, err)
+	}
+	if got.Project != "muster" || got.Label != "frontend" || !got.LabelManual {
+		t.Fatalf("round-trip=%+v", got)
+	}
+
+	// upsert refreshes label fields
+	if err := s.RegisterAgent(Agent{Alias: "muster-2", Label: "backend", LabelManual: false}); err != nil {
+		t.Fatal(err)
+	}
+	got, _, _ = s.GetAgent("muster-2")
+	if got.Label != "backend" || got.LabelManual {
+		t.Fatalf("after upsert=%+v", got)
+	}
+
+	// delete removes the row, leaves the table usable
+	if err := s.DeleteAgent("muster-2"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetAgent("muster-2"); ok {
+		t.Fatal("agent should be gone after DeleteAgent")
+	}
+	if err := s.DeleteAgent("nonexistent"); err != nil {
+		t.Fatalf("DeleteAgent of unknown alias must be a no-op, got %v", err)
+	}
+}

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -9,6 +9,9 @@ type Agent struct {
 	PaneID       string `json:"pane_id"`
 	SessionName  string `json:"session_name"`
 	SessionID    string `json:"session_id"`
+	Project      string `json:"project"`
+	Label        string `json:"label"`
+	LabelManual  bool   `json:"label_manual"`
 	RegisteredAt int64  `json:"registered_at"`
 	LastSeen     int64  `json:"last_seen"`
 }

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -6,6 +6,9 @@ CREATE TABLE IF NOT EXISTS agents (
     pane_id       TEXT NOT NULL DEFAULT '',
     session_name  TEXT NOT NULL DEFAULT '',
     session_id    TEXT NOT NULL DEFAULT '',
+    project       TEXT NOT NULL DEFAULT '',
+    label         TEXT NOT NULL DEFAULT '',
+    label_manual  INTEGER NOT NULL DEFAULT 0,
     registered_at INTEGER NOT NULL,
     last_seen     INTEGER NOT NULL
 );

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	_ "embed"
 	"fmt"
+	"strings"
 
 	_ "modernc.org/sqlite" // registers the "sqlite" database/sql driver
 )
@@ -28,7 +29,27 @@ func Open(dbPath string) (*Store, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("apply schema: %w", err)
 	}
+	if err := migrate(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
 	return &Store{db: db}, nil
+}
+
+// migrate applies additive column migrations to pre-existing databases. Each
+// ALTER is guarded so a re-run (column already present) is a no-op.
+func migrate(db *sql.DB) error {
+	alters := []string{
+		`ALTER TABLE agents ADD COLUMN project TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE agents ADD COLUMN label TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE agents ADD COLUMN label_manual INTEGER NOT NULL DEFAULT 0`,
+	}
+	for _, ddl := range alters {
+		if _, err := db.Exec(ddl); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+			return err
+		}
+	}
+	return nil
 }
 
 // DB exposes the underlying handle (tests + store methods).

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -29,3 +29,35 @@ func TestOpenCreatesSchema(t *testing.T) {
 		t.Fatalf("expected 4 tables, got %d", n)
 	}
 }
+
+func TestOpenMigrationIsIdempotent(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "bus.db")
+
+	s1, err := Open(db)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Re-opening the same (already-migrated) DB re-runs migrate(); the
+	// ADD COLUMN statements must be no-ops, not errors.
+	s2, err := Open(db)
+	if err != nil {
+		t.Fatalf("second Open (re-migrate) failed: %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+
+	// The table must still be fully usable after the repeated migration.
+	if err := s2.RegisterAgent(Agent{Alias: "a", Project: "p", Label: "l", LabelManual: true}); err != nil {
+		t.Fatalf("RegisterAgent after re-migrate: %v", err)
+	}
+	got, ok, err := s2.GetAgent("a")
+	if err != nil || !ok {
+		t.Fatalf("GetAgent after re-migrate: ok=%v err=%v", ok, err)
+	}
+	if got.Project != "p" || got.Label != "l" || !got.LabelManual {
+		t.Fatalf("round-trip after re-migrate=%+v", got)
+	}
+}

--- a/internal/tmuxenv/tmuxenv.go
+++ b/internal/tmuxenv/tmuxenv.go
@@ -1,0 +1,112 @@
+// Package tmuxenv is muster's single point of contact with tmux from outside
+// the daemon: capturing the current pane's identity, deriving the project from
+// the per-project socket, checking session liveness, and reading the session
+// label. All tmux execution goes through Run, which tests override.
+package tmuxenv
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Run executes `tmux <args>` and returns trimmed stdout. Overridable in tests.
+var Run = func(args ...string) (string, error) {
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// Capture holds the identity fields for registering an agent from a tmux pane.
+// Every field is empty (LabelManual false) when not running inside tmux.
+type Capture struct {
+	SocketPath  string
+	PaneID      string
+	SessionID   string
+	SessionName string
+	Project     string
+	Label       string
+	LabelManual bool
+}
+
+// SocketFromEnv returns the tmux socket path from $TMUX ("<socket>,<pid>,<idx>").
+func SocketFromEnv() string {
+	tmux := os.Getenv("TMUX")
+	if tmux == "" {
+		return ""
+	}
+	return strings.SplitN(tmux, ",", 2)[0]
+}
+
+// ProjectFromSocket derives the project name from a per-project socket path
+// ("proj-<project>"). Returns "" for non-proj-managed sockets (e.g. "default").
+func ProjectFromSocket(socket string) string {
+	if socket == "" {
+		return ""
+	}
+	base := filepath.Base(socket)
+	if !strings.HasPrefix(base, "proj-") {
+		return ""
+	}
+	return strings.TrimPrefix(base, "proj-")
+}
+
+// LabelOption returns the tmux session option holding the label, defaulting to
+// "@claude_task", overridable via $MUSTER_LABEL_OPTION.
+func LabelOption() string {
+	if v := os.Getenv("MUSTER_LABEL_OPTION"); v != "" {
+		return v
+	}
+	return "@claude_task"
+}
+
+func query(socket, target, format string) string {
+	if socket == "" || target == "" {
+		return ""
+	}
+	out, err := Run("-S", socket, "display-message", "-p", "-t", target, format)
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+// IsSessionAlive reports whether the tmux session still exists on the socket.
+func IsSessionAlive(socket, sessionID string) bool {
+	if socket == "" || sessionID == "" {
+		return false
+	}
+	_, err := Run("-S", socket, "has-session", "-t", sessionID)
+	return err == nil
+}
+
+// SessionLabel reads the label option and its manual flag for target (a pane or
+// session) on socket. manual is true only when <option>_manual == "1".
+func SessionLabel(socket, target string) (string, bool) {
+	opt := LabelOption()
+	raw := query(socket, target, "#{"+opt+"}\x1f#{"+opt+"_manual}")
+	if raw == "" {
+		return "", false
+	}
+	parts := strings.SplitN(raw, "\x1f", 2)
+	label := parts[0]
+	manual := len(parts) > 1 && parts[1] == "1"
+	return label, manual
+}
+
+// CaptureEnv reads the current process's tmux environment into a Capture.
+func CaptureEnv() Capture {
+	socket := SocketFromEnv()
+	pane := os.Getenv("TMUX_PANE")
+	c := Capture{SocketPath: socket, PaneID: pane, Project: ProjectFromSocket(socket)}
+	if socket == "" || pane == "" {
+		return c
+	}
+	c.SessionID = query(socket, pane, "#{session_id}")
+	c.SessionName = query(socket, pane, "#{session_name}")
+	c.Label, c.LabelManual = SessionLabel(socket, pane)
+	return c
+}

--- a/internal/tmuxenv/tmuxenv_test.go
+++ b/internal/tmuxenv/tmuxenv_test.go
@@ -1,0 +1,82 @@
+package tmuxenv
+
+import (
+	"fmt"
+	"testing"
+)
+
+func withRun(t *testing.T, fn func(args ...string) (string, error)) {
+	t.Helper()
+	prev := Run
+	Run = fn
+	t.Cleanup(func() { Run = prev })
+}
+
+func TestProjectFromSocket(t *testing.T) {
+	cases := map[string]string{
+		"/private/tmp/tmux-501/proj-muster": "muster",
+		"/tmp/tmux-0/proj-foo-bar":          "foo-bar",
+		"/tmp/tmux-0/default":               "",
+		"":                                  "",
+	}
+	for in, want := range cases {
+		if got := ProjectFromSocket(in); got != want {
+			t.Errorf("ProjectFromSocket(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsSessionAlive(t *testing.T) {
+	withRun(t, func(_ ...string) (string, error) { return "", nil })
+	if !IsSessionAlive("/s", "$1") {
+		t.Fatal("want alive when has-session exits 0")
+	}
+	withRun(t, func(_ ...string) (string, error) { return "", fmt.Errorf("no such session") })
+	if IsSessionAlive("/s", "$1") {
+		t.Fatal("want dead when has-session errors")
+	}
+	if IsSessionAlive("", "$1") || IsSessionAlive("/s", "") {
+		t.Fatal("empty socket/session must be dead")
+	}
+}
+
+func TestSessionLabelManualVsAuto(t *testing.T) {
+	withRun(t, func(_ ...string) (string, error) { return "frontend\x1f1", nil })
+	if l, m := SessionLabel("/s", "$1"); l != "frontend" || !m {
+		t.Fatalf("manual: got (%q,%v)", l, m)
+	}
+	withRun(t, func(_ ...string) (string, error) { return "some auto topic\x1f", nil })
+	if l, m := SessionLabel("/s", "$1"); l != "some auto topic" || m {
+		t.Fatalf("auto: got (%q,%v)", l, m)
+	}
+}
+
+func TestCaptureEnvNoTmux(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	c := CaptureEnv()
+	if c.SocketPath != "" || c.Project != "" || c.SessionID != "" {
+		t.Fatalf("no-tmux capture should be empty, got %+v", c)
+	}
+}
+
+func TestCaptureEnvPopulated(t *testing.T) {
+	t.Setenv("TMUX", "/private/tmp/tmux-501/proj-muster,123,0")
+	t.Setenv("TMUX_PANE", "%0")
+	withRun(t, func(args ...string) (string, error) {
+		last := args[len(args)-1]
+		switch last {
+		case "#{session_id}":
+			return "$7", nil
+		case "#{session_name}":
+			return "muster-2", nil
+		default: // label format
+			return "backend\x1f1", nil
+		}
+	})
+	c := CaptureEnv()
+	if c.Project != "muster" || c.SessionID != "$7" || c.SessionName != "muster-2" ||
+		c.Label != "backend" || !c.LabelManual {
+		t.Fatalf("capture=%+v", c)
+	}
+}


### PR DESCRIPTION
Makes muster's agent registry **self-maintaining and human-legible** (roadmap buckets #1+#2). Built subagent-driven from `docs/superpowers/specs/2026-07-14-session-identity-design.md` + plan; every task implementer→reviewed, whole-branch Opus review = READY TO MERGE, `just verify` green.

## What's new
- **`internal/tmuxenv`** — the single canonical tmux touchpoint outside the daemon: pane capture, `ProjectFromSocket`, `IsSessionAlive`, `SessionLabel`. mcpserver now delegates to it (no duplicate capture).
- **Store** — `project`/`label`/`label_manual` columns + idempotent `ALTER` migration (live `bus.db` upgrades in place) + `DeleteAgent` (history-safe: `from_agent` is text, not a FK).
- **Daemon** — `deregister_agent` op; `register_agent` persists the new fields. Core stays tmux-agnostic.
- **CLI** — `muster register [alias] --role --model` / `deregister` / `gc` (tmux-verified liveness reaping). `muster agents` now shows `PROJECT · ALIAS · LABEL · MODEL · LIVE`.
- **Addressable labels** — `send`/`nudge`/`inbox`/`tasks` accept `<alias|label|proj:label>` via one canonical resolver. Bare labels resolve within your **current project** and **never silently cross a project boundary**; labels are addressable only when manually pinned (`@claude_task` via `prefix T`).

## Grounding
Project scope is derived for free from the per-project tmux socket (`proj-<project>`); no new env var. Workspaces intentionally deferred (no machine identity for them in the terminal layer). Hook wiring documented; dotfiles wiring deferred per request.

## Fast-follow (non-blocking, from the Opus review)
Test-coverage only, code correct by construction: dead-agent exact-alias resolution, `uniqueOrErr` ambiguity branch, migration forward-path (column-less legacy DB).

🤖 Generated with [Claude Code](https://claude.ai/code)