### PR TITLE
feat(nudge): submit for codex via delayed standalone Enter

### DIFF
--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -6,14 +6,25 @@ package nudge
 import (
 	"fmt"
 	"os/exec"
+	"time"
 )
 
 const message = "📬 check your muster inbox (call get_inbox)"
 
+// codexSubmitDelay is the pause between typing the nudge text and sending a
+// standalone Enter for codex. codex's TUI treats an Enter that is bundled with
+// (or immediately follows) pasted send-keys text as part of the paste, not a
+// submit; a lone Enter sent after a short delay submits reliably. Empirically a
+// zero delay fails and a few hundred ms works, so this is a conservative
+// default. claude submits with no delay.
+const codexSubmitDelay = 500 * time.Millisecond
+
 // TmuxNudger types a nudge into a pane and optionally submits it. Run is the
-// command executor (nil → real tmux).
+// command executor (nil → real tmux) and Sleep is the delay function (nil →
+// time.Sleep); both are injectable for testing.
 type TmuxNudger struct {
-	Run func(args ...string) error
+	Run   func(args ...string) error
+	Sleep func(d time.Duration)
 }
 
 func (n TmuxNudger) run(args ...string) error {
@@ -24,10 +35,20 @@ func (n TmuxNudger) run(args ...string) error {
 	return run(args...)
 }
 
+func (n TmuxNudger) sleep(d time.Duration) {
+	if n.Sleep != nil {
+		n.Sleep(d)
+		return
+	}
+	time.Sleep(d)
+}
+
 // Nudge types the check-inbox line into the pane. When submit is requested it
-// presses Enter ONLY for model types known to accept it (claude); codex holds
-// send-keys text in its composer, so it is typed-only and submitted=false is
-// returned so the caller can tell the operator to press Enter.
+// presses Enter to submit the turn: claude accepts the Enter immediately, while
+// codex needs a short delay after the text before a standalone Enter registers
+// as a submit (see codexSubmitDelay). Unknown model types are typed-only
+// (submitted=false) because their send-keys submit behavior is unverified, so
+// the caller can tell the operator to press Enter.
 func (n TmuxNudger) Nudge(socketPath, paneID, modelType string, submit bool) (bool, error) {
 	if socketPath == "" || paneID == "" {
 		return false, fmt.Errorf("agent has no tmux pane (not registered from inside tmux)")
@@ -35,11 +56,19 @@ func (n TmuxNudger) Nudge(socketPath, paneID, modelType string, submit bool) (bo
 	if err := n.run("-S", socketPath, "send-keys", "-t", paneID, "-l", message); err != nil {
 		return false, fmt.Errorf("send-keys failed (pane may be gone): %w", err)
 	}
-	if submit && modelType == "claude" {
-		if err := n.run("-S", socketPath, "send-keys", "-t", paneID, "Enter"); err != nil {
-			return false, fmt.Errorf("submit failed: %w", err)
-		}
-		return true, nil
+	if !submit {
+		return false, nil
 	}
-	return false, nil
+	switch modelType {
+	case "claude":
+		// Immediate Enter submits.
+	case "codex":
+		n.sleep(codexSubmitDelay) // let codex finish processing the paste before Enter
+	default:
+		return false, nil // unknown submit behavior → typed-only
+	}
+	if err := n.run("-S", socketPath, "send-keys", "-t", paneID, "Enter"); err != nil {
+		return false, fmt.Errorf("submit failed: %w", err)
+	}
+	return true, nil
 }

--- a/internal/nudge/nudge_test.go
+++ b/internal/nudge/nudge_test.go
@@ -3,6 +3,7 @@ package nudge
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func recorder() (*[][]string, func(args ...string) error) {
@@ -10,37 +11,96 @@ func recorder() (*[][]string, func(args ...string) error) {
 	return &calls, func(args ...string) error { calls = append(calls, args); return nil }
 }
 
-func TestNudgeClaudeTypesAndSubmits(t *testing.T) {
+// sleepRecorder returns a Sleep func that records the durations it was asked to
+// wait, so tests can assert whether (and how long) a nudge paused before Enter.
+func sleepRecorder() (*[]time.Duration, func(time.Duration)) {
+	var slept []time.Duration
+	return &slept, func(d time.Duration) { slept = append(slept, d) }
+}
+
+func joinCalls(calls [][]string) string {
+	joined := ""
+	for _, c := range calls {
+		joined += strings.Join(c, " ") + "\n"
+	}
+	return joined
+}
+
+func TestNudgeClaudeTypesAndSubmitsWithoutDelay(t *testing.T) {
 	calls, run := recorder()
-	n := TmuxNudger{Run: run}
+	slept, sleep := sleepRecorder()
+	n := TmuxNudger{Run: run, Sleep: sleep}
 	submitted, err := n.Nudge("/s", "%1", "claude", true)
 	if err != nil || !submitted {
 		t.Fatalf("claude submit: submitted=%v err=%v", submitted, err)
 	}
-	joined := ""
-	for _, c := range *calls {
-		joined += strings.Join(c, " ") + "\n"
-	}
+	joined := joinCalls(*calls)
 	if !strings.Contains(joined, "send-keys") || !strings.Contains(joined, "-t %1") || !strings.Contains(joined, "Enter") {
 		t.Fatalf("expected send-keys + Enter for claude:\n%s", joined)
 	}
+	if len(*slept) != 0 {
+		t.Fatalf("claude must submit with no delay, slept=%v", *slept)
+	}
 }
 
-func TestNudgeCodexTypesOnly(t *testing.T) {
+func TestNudgeCodexTypesAndSubmitsAfterDelay(t *testing.T) {
 	calls, run := recorder()
-	n := TmuxNudger{Run: run}
+	slept, sleep := sleepRecorder()
+	n := TmuxNudger{Run: run, Sleep: sleep}
 	submitted, err := n.Nudge("/s", "%2", "codex", true)
 	if err != nil {
 		t.Fatalf("codex: %v", err)
 	}
+	if !submitted {
+		t.Fatalf("codex must now report submitted=true (delayed standalone Enter submits its TUI)")
+	}
+	// Codex must pause once before pressing Enter.
+	if len(*slept) != 1 || (*slept)[0] <= 0 {
+		t.Fatalf("codex must sleep exactly once for a positive delay before Enter, slept=%v", *slept)
+	}
+	// The Enter must be a separate send-keys call issued after the text, not bundled.
+	c := *calls
+	if len(c) != 2 {
+		t.Fatalf("expected 2 tmux calls (text, then Enter), got %d: %v", len(c), c)
+	}
+	if strings.Contains(strings.Join(c[0], " "), "Enter") {
+		t.Fatalf("first call (text) must not contain Enter: %v", c[0])
+	}
+	if !strings.Contains(strings.Join(c[1], " "), "Enter") {
+		t.Fatalf("second call must be the Enter: %v", c[1])
+	}
+}
+
+func TestNudgeCodexNoSubmitTypesOnly(t *testing.T) {
+	calls, run := recorder()
+	slept, sleep := sleepRecorder()
+	n := TmuxNudger{Run: run, Sleep: sleep}
+	submitted, err := n.Nudge("/s", "%2", "codex", false)
+	if err != nil {
+		t.Fatalf("codex no-submit: %v", err)
+	}
 	if submitted {
-		t.Fatalf("codex must report submitted=false (its TUI ignores send-keys Enter)")
+		t.Fatalf("no-submit must report submitted=false")
 	}
-	joined := ""
-	for _, c := range *calls {
-		joined += strings.Join(c, " ") + "\n"
+	if strings.Contains(joinCalls(*calls), "Enter") {
+		t.Fatalf("no-submit must not send Enter:\n%s", joinCalls(*calls))
 	}
-	if strings.Contains(joined, "Enter") {
-		t.Fatalf("codex nudge must not send Enter:\n%s", joined)
+	if len(*slept) != 0 {
+		t.Fatalf("no-submit must not delay, slept=%v", *slept)
+	}
+}
+
+func TestNudgeUnknownModelTypedOnly(t *testing.T) {
+	calls, run := recorder()
+	n := TmuxNudger{Run: run}
+	submitted, err := n.Nudge("/s", "%3", "gemini", true)
+	if err != nil {
+		t.Fatalf("unknown model: %v", err)
+	}
+	if submitted {
+		t.Fatalf("unknown model type must be typed-only (submitted=false)")
+	}
+	if strings.Contains(joinCalls(*calls), "Enter") {
+		t.Fatalf("unknown model must not send Enter (submit behavior unverified):\n%s", joinCalls(*calls))
 	}
 }


### PR DESCRIPTION
## What

Make `muster nudge` actually submit the turn for **codex** agents, not just type into the composer. This closes the Claude-only autonomy gap: previously Claude woke via `send-keys` + `Enter`, but Codex could only be typed to (`submitted=false`), so an idle Codex agent needed a human to press Enter.

## Why the old assumption was wrong

`nudge.go` gated the submit-`Enter` to `claude` on the belief that "codex holds send-keys text in its composer" and ignores `Enter`. Verified live on `codex-cli 0.144.3` that this is **incomplete**:

| Sequence | Result |
|---|---|
| `text + Enter` bundled in one call | ❌ sits in composer |
| `text`, then `Enter` back-to-back (no delay) | ❌ sits in composer |
| `text`, **short delay**, then standalone `Enter` | ✅ **submits** |

Codex's TUI treats an `Enter` bundled with (or immediately following) pasted `send-keys` text as part of the paste (bracketed paste); a lone `Enter` after a short delay submits reliably.

## Change

- Drop the claude-only submit gate. `claude` submits immediately; `codex` sleeps `codexSubmitDelay` (500ms) then sends a standalone `Enter`; unknown model types stay typed-only (`submitted=false`) since their submit behavior is unverified.
- `Sleep` is injectable on `TmuxNudger` (nil → `time.Sleep`) for deterministic tests.

## Test

- TDD: 4 unit tests — claude submits with no delay, codex submits after exactly one positive delay (Enter is a separate call after the text), no-submit stays typed-only, unknown model typed-only.
- `just verify` green (gofmt, golangci-lint 0 issues, `go test -race`, build).
- **Live**: `muster nudge bettor-help-workspace-2` → `delivered + submitted` → the idle Codex session submitted and drained its inbox autonomously.

## Context

Part of proving Codex turn-level autonomy end-to-end (registration via `SessionStart` hook + self-resolving inbox via `Stop` hook `decision:block`). This PR is the idle-wake half. Complements `feat/notify-identity` (mailbox/store); split so the two branches don't collide on nudge/wake/daemon.