### PR TITLE
chore: MIT license + public-release hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /bin/
+
+# runtime state (the local daemon's SQLite DB + WAL)
+bus.db
+bus.db-shm
+bus.db-wal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Court Schuett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ dotfiles wiring for a given machine is maintained separately from this repo.
 
 ## License
 
-TBD
+[MIT](LICENSE) © Court Schuett

--- a/docs/design.md
+++ b/docs/design.md
@@ -18,8 +18,8 @@ scenarios define "done":
    a standing Codex session claims it, reviews, and posts the verdict back;
    Claude sees it and acts. All async, no copy/paste.
 2. **Consumer → producer feedback** — a session working in the *consumer*
-   (`~/bettor-help`) files a request/bug to the *producer*
-   (`bettor-help-workspace`); the producer session picks it up, ships it, and
+   (`~/app`) files a request/bug to the *producer*
+   (`app-workspace`); the producer session picks it up, ships it, and
    replies. The consumer gets used the way it's meant to be, and its feedback
    reaches the producer automatically.
 
@@ -33,7 +33,7 @@ scenarios define "done":
   pane can participate. Claude and Codex are the v1 clients.
 - **Per-project tmux servers.** Verified: this machine runs **one tmux server
   per project**, each on its own socket (`__proj_srv() → proj-<project>`), e.g.
-  `proj-bettor-help` and `proj-bettor-help-workspace` are *different servers*. A
+  `proj-app` and `proj-app-workspace` are *different servers*. A
   naive `tmux send-keys -t <session>` on the default socket silently misses
   them. The wake mechanism must be socket-aware.
 
@@ -143,7 +143,7 @@ agent {
   alias,                      # you choose, e.g. "backend" / "reviewer" (addressable)
   role,                       # producer | consumer | reviewer | ... (addressable)
   model_type,                 # claude | codex
-  socket_path,                # from $TMUX field 1  → e.g. /private/tmp/tmux-501/proj-bettor-help
+  socket_path,                # from $TMUX field 1  → e.g. /private/tmp/tmux-501/proj-app
   pane_id,                    # from $TMUX_PANE     → e.g. %6
   session_name,               # #S, display + secondary lookup
   registered_at, last_seen
@@ -205,7 +205,7 @@ tmux -S <socket_path> send-keys -t <pane_id> -l "<message>" ; send Enter
 
 - **v2 — Contracts:** producer publishes its API surface; consumers subscribe
   and get diffs on change (`register_contract` / `subscribe_contract` /
-  `diff_contracts`). The bettor-help killer feature.
+  `diff_contracts`). The app killer feature.
 - **v3 — Control plane:** `muster tui` dashboard (agents, live activity from
   pane titles, inbox depths, task board) + richer human CLI.
 - **Later:** advisory file leases, append-only event/timeline log, cross-machine
@@ -217,8 +217,8 @@ tmux -S <socket_path> send-keys -t <pane_id> -l "<message>" ; send Enter
 2. **Wake:** integration test that spawns two tmux sessions on *different*
    sockets, registers both, sends a task, asserts the knock lands in the right
    pane (assert via `capture-pane`).
-3. **Cross-server:** explicitly exercise `proj-bettor-help` ↔
-   `proj-bettor-help-workspace` addressing.
+3. **Cross-server:** explicitly exercise `proj-app` ↔
+   `proj-app-workspace` addressing.
 4. **Multi-model:** register a Claude `mcp` client and a Codex `mcp` client
    against the same daemon; round-trip a task both directions.
 5. **End-to-end (scenario 1):** Claude `task_create` → Codex `task_claim` →

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,6 @@ another daemon client" that also overlays tmux liveness.
 ## Further out (from the v1 design)
 
 - **v2 Contracts** — a producer publishes its API surface; consumers subscribe and
-  get diffs on change (the bettor-help producer/consumer use case).
+  get diffs on change (the app producer/consumer use case).
 - **v3 Dashboard TUI** — `muster tui`: live agents/activity/tasks.
 - Advisory file leases; append-only event log; cross-machine.

--- a/docs/superpowers/plans/2026-07-13-muster-milestone-b-mcp.md
+++ b/docs/superpowers/plans/2026-07-13-muster-milestone-b-mcp.md
@@ -325,7 +325,7 @@ import (
 
 func TestRegisterAgentCapturesTmuxEnv(t *testing.T) {
 	startTestDaemon(t)
-	t.Setenv("TMUX", "/private/tmp/tmux-501/proj-bettor-help,123,4")
+	t.Setenv("TMUX", "/private/tmp/tmux-501/proj-app,123,4")
 	t.Setenv("TMUX_PANE", "%6")
 
 	_, out, err := registerAgentHandler(context.Background(), nil, RegisterAgentIn{


### PR DESCRIPTION
Make the (now public) repo properly released.

- **Add `LICENSE`** — MIT © Court Schuett; README license section `TBD` → `[MIT](LICENSE)`. A public repo with no license is legally all-rights-reserved; this makes it actually usable/forkable.
- **`.gitignore` the runtime DB** — `bus.db` + WAL sidecars (a stray one sat at the repo root; footgun for an accidental commit).
- **Genericize private-project references** — the producer/consumer example in `docs/design.md`/`roadmap.md`/one plan named a private project (`bettor-help`); replaced with a neutral `app`/`app-workspace` so no private project name is exposed in the public docs.

No code changes; docs + license + gitignore only.

🤖 Generated with [Claude Code](https://claude.ai/code)