### PR TITLE
feat(cli): muster hook + muster label — zero-friction setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ That's a working bus. Two optional layers, both in [`contrib/`](contrib/):
 
 - **See the mailbox** — two lines of tmux config render `📬<count>` on tabs with
   unread mail ([`contrib/tmux-mailbox.conf`](contrib/tmux-mailbox.conf)).
-- **Automate the lifecycle** — session hooks auto-register agents on start and
-  have them drain their own inbox at turn end
-  ([`contrib/muster-session-hook.sh`](contrib/muster-session-hook.sh)).
+- **Automate the lifecycle** — session hooks (`muster hook <event> <model>`)
+  auto-register agents on start and have them drain their own inbox at turn
+  end ([config for both harnesses in `contrib/`](contrib/README.md)).
 
 ## MCP mode
 
@@ -109,10 +109,11 @@ values are typed without submitting).
   `proj-<name>` convention (one tmux server per project). On the default tmux
   server there's no project — everything shares one namespace, and the rest of
   muster works the same.
-- **label** is read from a tmux session option (default `@claude_task`,
-  override with `$MUSTER_LABEL_OPTION`). A label is addressable only when its
-  `<option>_manual` companion is set — i.e. you named the session deliberately;
-  auto-generated values are shown parenthesized and are not addressable.
+- **label** is a name you give a session: run `muster label backend` inside it
+  (or `muster label --clear` to remove it). Only deliberately-set labels are
+  addressable; auto-generated values are shown parenthesized and are not.
+  (Stored in a tmux session option — default `@claude_task`, override with
+  `$MUSTER_LABEL_OPTION`.)
 
 ### Addressing
 
@@ -156,8 +157,9 @@ of typed by hand:
   agent to drain its inbox and reply, autonomously.
 - **SessionEnd** (Claude Code) → `muster deregister`; `muster gc` covers the rest.
 
-The hook script and copy-paste config for both Claude Code and Codex are in
-[`contrib/`](contrib/README.md).
+The muster binary is its own hook — point your harness at `muster hook <event>
+<model>` (e.g. `muster hook Stop claude`). Copy-paste config for both Claude
+Code and Codex is in [`contrib/`](contrib/README.md).
 
 ## License
 

--- a/cmd/muster/main.go
+++ b/cmd/muster/main.go
@@ -22,7 +22,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: muster <serve|debug|mcp|agents|inbox|send|tasks|nudge|register|deregister|gc> [args]")
+		fmt.Fprintln(os.Stderr, "usage: muster <serve|debug|mcp|agents|inbox|send|tasks|nudge|register|deregister|gc|hook|label> [args]")
 		os.Exit(2)
 	}
 	switch os.Args[1] {
@@ -32,7 +32,7 @@ func main() {
 		runDebug(os.Args[2:])
 	case "mcp":
 		runMCP()
-	case "agents", "inbox", "send", "tasks", "nudge", "register", "deregister", "gc":
+	case "agents", "inbox", "send", "tasks", "nudge", "register", "deregister", "gc", "hook", "label":
 		if err := humancli.Dispatch(os.Args[1:], os.Stdout); err != nil {
 			fmt.Fprintln(os.Stderr, "muster:", err)
 			os.Exit(1)

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -12,29 +12,34 @@ two lines in [`tmux-mailbox.conf`](tmux-mailbox.conf) to your `~/.tmux.conf`
 those), reload tmux, and sessions with unread muster mail show `📬<count>` in
 the tab title and status bar until the agent reads its inbox.
 
-## 2. Hooks: auto-register + self-resolving inbox (`muster-session-hook.sh`)
+## 2. Hooks: auto-register + self-resolving inbox
 
-Without hooks, you ask an agent to call `register_agent` once per session (or
-put that instruction in your project's `CLAUDE.md`/`AGENTS.md`). With hooks,
-sessions handle themselves:
+The muster binary is its own hook — no script to copy. Point your agent's
+session hooks at `muster hook <event> <model>`:
 
-- **SessionStart** → runs `muster register`, so every session joins the bus
-  automatically.
-- **Stop** (turn end) → if the session has unread muster mail, the hook tells
-  the agent to drain its inbox and reply — autonomously, no human relay.
+- **SessionStart** → registers the session on the bus.
+- **Stop** (turn end) → if the session has unread muster mail, tells the agent
+  to drain its inbox and reply — autonomously.
+- **SessionEnd** (Claude Code only; Codex has no such event) → deregisters.
 
 Setup:
 
-1. Copy [`muster-session-hook.sh`](muster-session-hook.sh) somewhere stable and
-   `chmod +x` it.
-2. **Claude Code:** merge [`claude-settings-hooks.json`](claude-settings-hooks.json)
-   into `~/.claude/settings.json`, fixing the script path. Claude expands `~` in
-   hook commands.
-3. **Codex:** copy [`codex-hooks.json`](codex-hooks.json) to `~/.codex/hooks.json`,
-   fixing the script path — **use an absolute path** (Codex does not expand `~`).
-   On the next `codex` launch you'll get a one-time "Hooks need review" prompt;
-   choose Trust. Note Codex fires `SessionStart` lazily, on the session's first
-   turn.
+- **Claude Code:** merge [`claude-settings-hooks.json`](claude-settings-hooks.json)
+  into `~/.claude/settings.json`.
+- **Codex:** copy [`codex-hooks.json`](codex-hooks.json) to `~/.codex/hooks.json`.
+  On the next `codex` launch you'll get a one-time "Hooks need review" prompt —
+  choose Trust. Codex fires `SessionStart` lazily, on the session's first turn.
+
+If `muster` isn't on the PATH your harness gives hook commands (e.g. it lives in
+`~/go/bin`), use the absolute binary path in the `command` strings — Codex in
+particular does not expand `~`.
 
 The hook is safe to install globally: for any session that isn't a registered
 agent it does nothing, and it never blocks a session from starting.
+
+### `muster-session-hook.sh`
+
+The same behavior as a standalone POSIX shell script, for anyone who wants to
+customize the hook (change the drain instruction, add logging, gate it per
+project). Functionally identical to `muster hook`; point your hook config at
+the script instead if you use it.

--- a/contrib/claude-settings-hooks.json
+++ b/contrib/claude-settings-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/path/to/muster/contrib/muster-session-hook.sh SessionStart claude"
+            "command": "muster hook SessionStart claude"
           }
         ]
       }
@@ -16,7 +16,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/path/to/muster/contrib/muster-session-hook.sh Stop claude"
+            "command": "muster hook Stop claude"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "muster hook SessionEnd claude"
           }
         ]
       }

--- a/contrib/codex-hooks.json
+++ b/contrib/codex-hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/ABSOLUTE/PATH/TO/muster/contrib/muster-session-hook.sh SessionStart codex"
+            "command": "muster hook SessionStart codex"
           }
         ]
       }
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/ABSOLUTE/PATH/TO/muster/contrib/muster-session-hook.sh Stop codex"
+            "command": "muster hook Stop codex"
           }
         ]
       }

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -1,0 +1,89 @@
+package humancli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// cmdHook implements "muster hook <SessionStart|SessionEnd|Stop> [model]" —
+// the single entry point an agent harness's hook config points at directly
+// (in place of a copied contrib/muster-session-hook.sh). model defaults to
+// "claude" when omitted.
+//
+// A hook must never block a session, so cmdHook always returns nil: every
+// internal error is swallowed, and on any input other than a recognized
+// event it is simply a no-op.
+func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
+	if len(args) < 1 {
+		return fmt.Errorf("usage: muster hook <SessionStart|SessionEnd|Stop> [model]")
+	}
+	model := "claude"
+	if len(args) > 1 && args[1] != "" {
+		model = args[1]
+	}
+	switch args[0] {
+	case "SessionStart":
+		_ = cmdRegister([]string{"--model", model}, io.Discard)
+	case "SessionEnd":
+		_ = cmdDeregister(nil, io.Discard)
+	case "Stop":
+		hookStop(stdin, out)
+	}
+	return nil
+}
+
+// stopInput decodes the Stop-hook stdin payload. Invalid or empty JSON leaves
+// it at its zero value (StopHookActive=false), matching the contrib script's
+// tolerant `jq -r '.stop_hook_active // false'`.
+type stopInput struct {
+	StopHookActive bool `json:"stop_hook_active"`
+}
+
+// stopReason is the JSON payload muster prints on stdout for a Stop hook
+// finding unread mail: {"decision":"block","reason":"..."}. Claude Code and
+// Codex both treat decision:block as "run reason as the next prompt".
+type stopReason struct {
+	Decision string `json:"decision"`
+	Reason   string `json:"reason"`
+}
+
+// hookStop ports contrib/muster-session-hook.sh's Stop branch to Go, with
+// identical semantics: a self-resolving inbox check. If this tmux session has
+// unread muster mail (the @muster_inbox option the daemon sets), it prints one
+// line of decision:block JSON telling the agent to drain its inbox
+// autonomously; otherwise it prints nothing. Best-effort throughout — stdin
+// read/decode failures, a missing tmux, or a missing/non-numeric/zero count
+// all fall through to "print nothing".
+func hookStop(stdin io.Reader, out io.Writer) {
+	var in stopInput
+	if b, err := io.ReadAll(stdin); err == nil {
+		_ = json.Unmarshal(b, &in) // invalid/empty JSON -> zero value (false)
+	}
+	if in.StopHookActive {
+		return // loop guard: we already triggered a continuation this cycle
+	}
+	if os.Getenv("TMUX") == "" {
+		return
+	}
+	count, err := strconv.Atoi(tmuxenv.CurrentSessionOption("@muster_inbox"))
+	if err != nil || count <= 0 {
+		return
+	}
+	alias := tmuxenv.CurrentSessionName()
+	reason := fmt.Sprintf(
+		"You have %d unread muster message(s). Your muster alias is '%s' (this tmux session). "+
+			"Call your muster get_inbox tool now with alias '%s', read each new thread with get_thread, "+
+			"handle the request, and reply with the muster reply tool. Act autonomously — do not ask the user.",
+		count, alias, alias,
+	)
+	b, err := json.Marshal(stopReason{Decision: "block", Reason: reason})
+	if err != nil {
+		return
+	}
+	_, _ = fmt.Fprintln(out, string(b)) // best-effort: a hook's stdout write failing has nowhere to report to
+}

--- a/internal/humancli/hook_test.go
+++ b/internal/humancli/hook_test.go
@@ -1,0 +1,144 @@
+package humancli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+func TestHookStopLoopGuard(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{"stop_hook_active":true}`), &buf); err != nil {
+		t.Fatalf("hook Stop: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output on loop guard, got %q", buf.String())
+	}
+}
+
+func TestHookStopNoTmux(t *testing.T) {
+	t.Setenv("TMUX", "")
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output outside tmux, got %q", buf.String())
+	}
+}
+
+func TestHookStopNoUnread(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	prev := tmuxenv.Run
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	for _, c := range []string{"", "abc", "0", "-1"} {
+		count := c
+		tmuxenv.Run = func(_ ...string) (string, error) { return count, nil }
+		var buf bytes.Buffer
+		if err := cmdHook([]string{"Stop"}, strings.NewReader(`{}`), &buf); err != nil {
+			t.Fatal(err)
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("count=%q: expected no output, got %q", c, buf.String())
+		}
+	}
+}
+
+func TestHookStopUnreadEmitsBlockDecision(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "@muster_inbox":
+			return "3", nil
+		case "#{session_name}":
+			return "backend", nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	// Invalid stdin JSON must be tolerated (treated as stop_hook_active=false),
+	// still proceeding to the count-based decision below.
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`not json`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	var res struct {
+		Decision string `json:"decision"`
+		Reason   string `json:"reason"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &res); err != nil {
+		t.Fatalf("output not valid JSON: %v (%q)", err, buf.String())
+	}
+	if res.Decision != "block" {
+		t.Fatalf("decision = %q, want block", res.Decision)
+	}
+	if !strings.Contains(res.Reason, "alias 'backend'") || !strings.Contains(res.Reason, "3 unread") {
+		t.Fatalf("reason missing expected fields: %q", res.Reason)
+	}
+}
+
+func TestHookSessionStartAndEnd(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/tmux-0/proj-muster,1,0")
+	t.Setenv("TMUX_PANE", "%0")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_id}":
+			return "$1", nil
+		case "#{session_name}":
+			return "muster-hook", nil
+		default:
+			return "", nil
+		}
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart", "codex"}, strings.NewReader(""), &buf); err != nil {
+		t.Fatalf("SessionStart: %v", err)
+	}
+	agents := listAgentsForTest(t, "")
+	found := false
+	for _, a := range agents {
+		if a.Alias == "muster-hook" && a.ModelType == "codex" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected muster-hook registered via SessionStart hook: %+v", agents)
+	}
+
+	buf.Reset()
+	if err := cmdHook([]string{"SessionEnd"}, strings.NewReader(""), &buf); err != nil {
+		t.Fatalf("SessionEnd: %v", err)
+	}
+	agents = listAgentsForTest(t, "")
+	for _, a := range agents {
+		if a.Alias == "muster-hook" {
+			t.Fatalf("expected muster-hook deregistered via SessionEnd hook: %+v", agents)
+		}
+	}
+}
+
+func TestHookSessionStartBestEffortWhenDaemonUnreachable(t *testing.T) {
+	// No test daemon started, and no tmux identity to fall back on: cmdRegister
+	// will fail (can't determine alias / can't reach daemon), but the hook must
+	// swallow that and still return nil — a hook must never block a session.
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("MUSTER_ALIAS", "")
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(""), &buf); err != nil {
+		t.Fatalf("hook must never return an error, got %v", err)
+	}
+	if err := cmdHook([]string{"SessionEnd"}, strings.NewReader(""), &buf); err != nil {
+		t.Fatalf("hook must never return an error, got %v", err)
+	}
+}

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -73,7 +74,7 @@ func callData(op string, args map[string]any) (json.RawMessage, error) {
 // Dispatch routes an operator subcommand. args[0] is the subcommand name.
 func Dispatch(args []string, out io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: muster <agents|inbox|send|tasks|nudge|register|deregister|gc> [args]")
+		return fmt.Errorf("usage: muster <agents|inbox|send|tasks|nudge|register|deregister|gc|hook|label> [args]")
 	}
 	switch args[0] {
 	case "agents":
@@ -92,6 +93,10 @@ func Dispatch(args []string, out io.Writer) error {
 		return cmdDeregister(args[1:], out)
 	case "gc":
 		return cmdGC(out)
+	case "hook":
+		return cmdHook(args[1:], os.Stdin, out)
+	case "label":
+		return cmdLabel(args[1:], out)
 	default:
 		return fmt.Errorf("unknown command %q", args[0])
 	}

--- a/internal/humancli/label.go
+++ b/internal/humancli/label.go
@@ -1,0 +1,53 @@
+package humancli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// cmdLabel implements "muster label <name>" / "muster label --clear": naming
+// (or clearing) the current tmux session's label in one command, in place of
+// the two tmux set-option incantations an operator would otherwise type by
+// hand. It requires $TMUX (there is no "current session" outside tmux).
+func cmdLabel(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("label", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	clearFlag := fs.Bool("clear", false, "clear this session's label")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	rest := fs.Args()
+	name := ""
+	if len(rest) > 0 {
+		name = rest[0]
+	}
+	if os.Getenv("TMUX") == "" {
+		return fmt.Errorf("muster label requires a tmux session ($TMUX is unset)")
+	}
+	opt := tmuxenv.LabelOption()
+	manualOpt := opt + "_manual"
+	if *clearFlag || name == "" {
+		if err := tmuxenv.UnsetSessionOption(opt); err != nil {
+			return err
+		}
+		if err := tmuxenv.UnsetSessionOption(manualOpt); err != nil {
+			return err
+		}
+		_ = tmuxenv.RefreshClient() // best-effort: repaint title bars
+		_, err := fmt.Fprintln(out, "label cleared")
+		return err
+	}
+	if err := tmuxenv.SetSessionOption(opt, name); err != nil {
+		return err
+	}
+	if err := tmuxenv.SetSessionOption(manualOpt, "1"); err != nil {
+		return err
+	}
+	_ = tmuxenv.RefreshClient() // best-effort: repaint title bars
+	_, err := fmt.Fprintf(out, "labeled this session %q (%s)\n", name, opt)
+	return err
+}

--- a/internal/humancli/label_test.go
+++ b/internal/humancli/label_test.go
@@ -1,0 +1,96 @@
+package humancli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+func TestLabelSetsOptionsAndRefreshes(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	var calls [][]string
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdLabel([]string{"backend"}, &buf); err != nil {
+		t.Fatalf("label: %v", err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 tmux calls (set label, set manual, refresh), got %v", calls)
+	}
+	if calls[0][0] != "set-option" || calls[0][1] != "@claude_task" || calls[0][2] != "backend" {
+		t.Fatalf("unexpected label set call: %v", calls[0])
+	}
+	if calls[1][0] != "set-option" || calls[1][1] != "@claude_task_manual" || calls[1][2] != "1" {
+		t.Fatalf("unexpected manual set call: %v", calls[1])
+	}
+	if calls[2][0] != "refresh-client" || calls[2][1] != "-S" {
+		t.Fatalf("unexpected refresh call: %v", calls[2])
+	}
+	if !strings.Contains(buf.String(), `"backend"`) || !strings.Contains(buf.String(), "@claude_task") {
+		t.Fatalf("unexpected confirmation output: %q", buf.String())
+	}
+}
+
+func TestLabelClearUnsetsBothOptions(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	var calls [][]string
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdLabel([]string{"--clear"}, &buf); err != nil {
+		t.Fatalf("label --clear: %v", err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 tmux calls (unset label, unset manual, refresh), got %v", calls)
+	}
+	if calls[0][0] != "set-option" || calls[0][1] != "-u" || calls[0][2] != "@claude_task" {
+		t.Fatalf("unexpected label unset call: %v", calls[0])
+	}
+	if calls[1][0] != "set-option" || calls[1][1] != "-u" || calls[1][2] != "@claude_task_manual" {
+		t.Fatalf("unexpected manual unset call: %v", calls[1])
+	}
+	if !strings.Contains(buf.String(), "cleared") {
+		t.Fatalf("unexpected confirmation output: %q", buf.String())
+	}
+}
+
+func TestLabelEmptyNameActsLikeClear(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	var calls [][]string
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdLabel(nil, &buf); err != nil {
+		t.Fatalf("label with no args: %v", err)
+	}
+	if len(calls) != 3 || calls[0][1] != "-u" {
+		t.Fatalf("expected an unset sequence for empty name, got %v", calls)
+	}
+}
+
+func TestLabelRequiresTmux(t *testing.T) {
+	t.Setenv("TMUX", "")
+	var buf bytes.Buffer
+	err := cmdLabel([]string{"backend"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "tmux") {
+		t.Fatalf("expected a tmux-mentioning error, got %v", err)
+	}
+}

--- a/internal/tmuxenv/tmuxenv.go
+++ b/internal/tmuxenv/tmuxenv.go
@@ -97,6 +97,48 @@ func SessionLabel(socket, target string) (string, bool) {
 	return label, manual
 }
 
+// CurrentSessionOption reads a tmux user option's raw value for the ambient
+// session — no -S/-t, relying on $TMUX in the process environment, as when
+// running inside a hook or shell spawned from a tmux pane. Returns "" if
+// tmux isn't reachable or the option is unset.
+func CurrentSessionOption(name string) string {
+	out, err := Run("show-options", "-qv", name)
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+// CurrentSessionName returns the ambient session's name (no -S/-t), or "" if
+// tmux isn't reachable (e.g. not running inside tmux).
+func CurrentSessionName() string {
+	out, err := Run("display-message", "-p", "#{session_name}")
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+// SetSessionOption sets a tmux user option on the ambient session.
+func SetSessionOption(name, value string) error {
+	_, err := Run("set-option", name, value)
+	return err
+}
+
+// UnsetSessionOption unsets a tmux user option on the ambient session.
+func UnsetSessionOption(name string) error {
+	_, err := Run("set-option", "-u", name)
+	return err
+}
+
+// RefreshClient repaints the ambient session's attached clients (e.g. so a
+// title bar reflects a just-changed label). Best-effort: callers should treat
+// a returned error as non-fatal.
+func RefreshClient() error {
+	_, err := Run("refresh-client", "-S")
+	return err
+}
+
 // CaptureEnv reads the current process's tmux environment into a Capture.
 func CaptureEnv() Capture {
 	socket := SocketFromEnv()


### PR DESCRIPTION
Two new CLI subcommands that remove the last setup friction, plus docs updated to lead with them.

- **`muster hook <SessionStart|SessionEnd|Stop> [model]`** — the binary IS the hook: harness configs point at `muster hook Stop claude` directly (no script copying, no chmod, no absolute-path surgery). SessionStart/SessionEnd reuse the existing register/deregister path (one canonical capture); Stop ports the contrib script's semantics exactly (loop-guard → tmux check → `@muster_inbox` count → `decision:block` JSON with the session's alias, built via json.Marshal). Never returns an error, stdout carries only the decision JSON or nothing — verified path-by-path in review.
- **`muster label <name>` / `--clear`** — names the current session on the bus in one command (sets the label option + its `_manual` companion, refreshes titles), replacing two tmux incantations. All tmux via the `tmuxenv` seam.
- contrib JSON examples now point at `muster hook …`; the shell script stays as the customizable alternative. README documents `muster label`.

Reviewed (spec ✅ / quality approved, zero findings); `just verify` green (tests -race, golangci-lint 0).

🤖 Generated with [Claude Code](https://claude.ai/code)