### PR TITLE
chore: gitignore .superpowers/ scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 bus.db
 bus.db-shm
 bus.db-wal
+
+# SDD / superpowers scratch (transient build artifacts)
+.superpowers/


### PR DESCRIPTION
Upstreams the local-only ignore that has been blocking the primary clone's fast-forward (every SDD session writes .superpowers/ scratch). Once merged, the machine's uncommitted .gitignore edit becomes redundant and the clone can sync — which also fixes installs building stale binaries from it.