### PR TITLE
ci: prebuilt release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: release-assets
+
+# Attach prebuilt binaries to every GitHub release, so users can install
+# without a Go toolchain. muster is cgo-free, so plain cross-compilation
+# covers all targets from one runner.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)build assets for"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: echo "tag=${{ github.event.release.tag_name || inputs.tag }}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build and package all targets
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
+            goos="${target%/*}"; goarch="${target#*/}"
+            out="muster_${tag}_${goos}_${goarch}"
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+              go build -trimpath -ldflags "-s -w" -o "dist/${out}/muster" ./cmd/muster
+            tar -C "dist/${out}" -czf "dist/${out}.tar.gz" muster
+          done
+          (cd dist && shasum -a 256 *.tar.gz > checksums.txt)
+      - name: Upload to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.tag.outputs.tag }}" dist/*.tar.gz dist/checksums.txt --clobber --repo "$GITHUB_REPOSITORY"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ wake). See [releases](https://github.com/schuettc/muster/releases) for the chang
 ## Setup
 
 ```bash
-# 1. build the binary (Go 1.22+; macOS or Linux — on Windows use WSL2)
+# 1. install the binary: download a prebuilt one from the releases page
+#    (https://github.com/schuettc/muster/releases) and put it on your PATH,
+#    or build from source (Go 1.22+; macOS or Linux — on Windows use WSL2):
 go install github.com/schuettc/muster/cmd/muster@latest
 
 # 2. register the MCP server with each agent


### PR DESCRIPTION
Adds a release-assets workflow: on every published release (or workflow_dispatch for backfill), cross-compile cgo-free binaries for darwin/linux × arm64/amd64, tar them with sha256 checksums, and attach them to the release. README's setup step 1 now offers the prebuilt download as the no-Go path.