### PR TITLE
ci,docs: stable asset names; prebuilt install as default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           tag="${{ steps.rel.outputs.tag }}"
           for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
             goos="${target%/*}"; goarch="${target#*/}"
-            out="muster_${tag}_${goos}_${goarch}"
+            out="muster_${goos}_${goarch}"
             CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
               go build -trimpath -ldflags "-s -w" -o "dist/${out}/muster" ./cmd/muster
             tar -C "dist/${out}" -czf "dist/${out}.tar.gz" muster

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ wake). See [releases](https://github.com/schuettc/muster/releases) for the chang
 ## Setup
 
 ```bash
-# 1. install the binary: download a prebuilt one from the releases page
-#    (https://github.com/schuettc/muster/releases) and put it on your PATH,
-#    or build from source (Go 1.22+; macOS or Linux — on Windows use WSL2):
-go install github.com/schuettc/muster/cmd/muster@latest
+# 1. install the binary (macOS or Linux; on Windows use WSL2)
+mkdir -p ~/.local/bin   # any directory on your PATH works
+curl -fsSL "https://github.com/schuettc/muster/releases/latest/download/muster_$(uname -s | tr 'A-Z' 'a-z')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar -xz -C ~/.local/bin
+#    (or build from source with Go 1.22+: go install github.com/schuettc/muster/cmd/muster@latest)
 
 # 2. register the MCP server with each agent
 claude mcp add muster -s user -- muster mcp     # Claude Code

--- a/contrib/release-sign.sh
+++ b/contrib/release-sign.sh
@@ -24,7 +24,7 @@ echo "signing as: $identity"
 src="$work/src"
 git clone --quiet --depth 1 --branch "$tag" "https://github.com/$repo" "$src"
 for arch in arm64 amd64; do
-  dir="$work/muster_${tag}_darwin_${arch}"
+  dir="$work/muster_darwin_${arch}"
   mkdir -p "$dir"
   (cd "$src" && CGO_ENABLED=0 GOOS=darwin GOARCH="$arch" \
     go build -trimpath -ldflags "-s -w" -o "$dir/muster" ./cmd/muster)
@@ -32,12 +32,12 @@ for arch in arm64 amd64; do
   ditto -c -k --keepParent "$dir/muster" "$work/notarize_${arch}.zip"
   xcrun notarytool submit "$work/notarize_${arch}.zip" \
     --keychain-profile "$profile" --wait | grep -E "status:" | tail -1
-  tar -C "$dir" -czf "$work/muster_${tag}_darwin_${arch}.tar.gz" muster
+  tar -C "$dir" -czf "$work/muster_darwin_${arch}.tar.gz" muster
 done
 
 # recompute checksums across the full asset set (signed darwin + CI's linux)
 (cd "$work" && \
-  gh release download "$tag" --repo "$repo" --pattern "muster_${tag}_linux_*.tar.gz" && \
-  shasum -a 256 muster_${tag}_*.tar.gz > checksums.txt && \
-  gh release upload "$tag" muster_${tag}_darwin_*.tar.gz checksums.txt --clobber --repo "$repo")
+  gh release download "$tag" --repo "$repo" --pattern "muster_linux_*.tar.gz" && \
+  shasum -a 256 muster_*.tar.gz > checksums.txt && \
+  gh release upload "$tag" muster_darwin_*.tar.gz checksums.txt --clobber --repo "$repo")
 echo "done: darwin assets for $tag are signed + notarized"


### PR DESCRIPTION
Drops the version from release asset names (muster_darwin_arm64.tar.gz) so GitHub's releases/latest/download URL is a permanent install one-liner; the release page provides the version context. release-sign.sh updated to match. README step 1 now defaults to the curl download, with go install as the source-build alternative.