### PR TITLE
Promote: muster.tools site + one-line installer + stable assets

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: deploy-site
+
+# Deploys muster.tools from the repo: site/index.html plus the root install.sh
+# (served at https://muster.tools/install.sh). Runs on every merge to main that
+# touches the site or the installer — no manual deploy steps.
+on:
+  push:
+    branches: [main]
+    paths: ['site/**', 'install.sh', '.github/workflows/pages.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assemble the site
+        run: |
+          mkdir dist
+          cp site/index.html dist/
+          cp install.sh dist/
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           tag="${{ steps.rel.outputs.tag }}"
           for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
             goos="${target%/*}"; goarch="${target#*/}"
-            out="muster_${tag}_${goos}_${goarch}"
+            out="muster_${goos}_${goarch}"
             CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
               go build -trimpath -ldflags "-s -w" -o "dist/${out}/muster" ./cmd/muster
             tar -C "dist/${out}" -czf "dist/${out}.tar.gz" muster

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ wake). See [releases](https://github.com/schuettc/muster/releases) for the chang
 
 ```bash
 # 1. install the binary (macOS or Linux; on Windows use WSL2)
-mkdir -p ~/.local/bin   # any directory on your PATH works
-curl -fsSL "https://github.com/schuettc/muster/releases/latest/download/muster_$(uname -s | tr 'A-Z' 'a-z')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar -xz -C ~/.local/bin
+curl -fsSL https://muster.tools/install.sh | sh
 #    (or build from source with Go 1.22+: go install github.com/schuettc/muster/cmd/muster@latest)
 
 # 2. register the MCP server with each agent

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ wake). See [releases](https://github.com/schuettc/muster/releases) for the chang
 ## Setup
 
 ```bash
-# 1. install the binary: download a prebuilt one from the releases page
-#    (https://github.com/schuettc/muster/releases) and put it on your PATH,
-#    or build from source (Go 1.22+; macOS or Linux — on Windows use WSL2):
-go install github.com/schuettc/muster/cmd/muster@latest
+# 1. install the binary (macOS or Linux; on Windows use WSL2)
+mkdir -p ~/.local/bin   # any directory on your PATH works
+curl -fsSL "https://github.com/schuettc/muster/releases/latest/download/muster_$(uname -s | tr 'A-Z' 'a-z')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar -xz -C ~/.local/bin
+#    (or build from source with Go 1.22+: go install github.com/schuettc/muster/cmd/muster@latest)
 
 # 2. register the MCP server with each agent
 claude mcp add muster -s user -- muster mcp     # Claude Code

--- a/contrib/release-sign.sh
+++ b/contrib/release-sign.sh
@@ -24,7 +24,7 @@ echo "signing as: $identity"
 src="$work/src"
 git clone --quiet --depth 1 --branch "$tag" "https://github.com/$repo" "$src"
 for arch in arm64 amd64; do
-  dir="$work/muster_${tag}_darwin_${arch}"
+  dir="$work/muster_darwin_${arch}"
   mkdir -p "$dir"
   (cd "$src" && CGO_ENABLED=0 GOOS=darwin GOARCH="$arch" \
     go build -trimpath -ldflags "-s -w" -o "$dir/muster" ./cmd/muster)
@@ -32,12 +32,12 @@ for arch in arm64 amd64; do
   ditto -c -k --keepParent "$dir/muster" "$work/notarize_${arch}.zip"
   xcrun notarytool submit "$work/notarize_${arch}.zip" \
     --keychain-profile "$profile" --wait | grep -E "status:" | tail -1
-  tar -C "$dir" -czf "$work/muster_${tag}_darwin_${arch}.tar.gz" muster
+  tar -C "$dir" -czf "$work/muster_darwin_${arch}.tar.gz" muster
 done
 
 # recompute checksums across the full asset set (signed darwin + CI's linux)
 (cd "$work" && \
-  gh release download "$tag" --repo "$repo" --pattern "muster_${tag}_linux_*.tar.gz" && \
-  shasum -a 256 muster_${tag}_*.tar.gz > checksums.txt && \
-  gh release upload "$tag" muster_${tag}_darwin_*.tar.gz checksums.txt --clobber --repo "$repo")
+  gh release download "$tag" --repo "$repo" --pattern "muster_linux_*.tar.gz" && \
+  shasum -a 256 muster_*.tar.gz > checksums.txt && \
+  gh release upload "$tag" muster_darwin_*.tar.gz checksums.txt --clobber --repo "$repo")
 echo "done: darwin assets for $tag are signed + notarized"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# muster installer — downloads the latest release binary for this machine,
+# verifies its checksum, and installs it to ~/.local/bin (override with
+# MUSTER_INSTALL_DIR). Usage:
+#
+#   curl -fsSL https://muster.tools/install.sh | sh
+#
+set -eu
+
+repo="schuettc/muster"
+install_dir="${MUSTER_INSTALL_DIR:-$HOME/.local/bin}"
+base="https://github.com/$repo/releases/latest/download"
+
+fail() { printf 'muster install: %s\n' "$*" >&2; exit 1; }
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+command -v tar  >/dev/null 2>&1 || fail "tar is required"
+
+os="$(uname -s | tr 'A-Z' 'a-z')"
+case "$os" in
+  darwin|linux) ;;
+  *) fail "unsupported OS '$os' — muster runs on macOS and Linux (on Windows, install inside WSL2)" ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64)  arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) fail "unsupported architecture '$arch' (need amd64 or arm64)" ;;
+esac
+
+asset="muster_${os}_${arch}.tar.gz"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+printf 'downloading %s …\n' "$asset"
+curl -fsSL "$base/$asset" -o "$tmp/$asset" || fail "download failed: $base/$asset"
+curl -fsSL "$base/checksums.txt" -o "$tmp/checksums.txt" || fail "download failed: checksums.txt"
+
+# verify the checksum (shasum on macOS, sha256sum on Linux)
+expected="$(grep " $asset\$" "$tmp/checksums.txt" | cut -d' ' -f1)"
+[ -n "$expected" ] || fail "no checksum found for $asset"
+if command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$tmp/$asset" | cut -d' ' -f1)"
+else
+  actual="$(sha256sum "$tmp/$asset" | cut -d' ' -f1)"
+fi
+[ "$actual" = "$expected" ] || fail "checksum mismatch for $asset (expected $expected, got $actual)"
+
+mkdir -p "$install_dir"
+tar -xzf "$tmp/$asset" -C "$tmp"
+mv "$tmp/muster" "$install_dir/muster"
+chmod +x "$install_dir/muster"
+
+# confirm the binary runs on this machine
+"$install_dir/muster" >/dev/null 2>&1 || [ $? -eq 2 ] || fail "installed binary failed to run"
+
+printf 'installed muster to %s\n' "$install_dir/muster"
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *) printf 'note: %s is not on your PATH — add:  export PATH="%s:$PATH"\n' "$install_dir" "$install_dir" ;;
+esac
+printf 'next: register it with your agent, e.g.  claude mcp add muster -s user -- muster mcp\n'

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,478 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>muster — a local coordination bus for coding agents</title>
+<meta name="description" content="muster connects coding-agent sessions running in tmux. Agents register over MCP and send messages or hand tasks to each other — any agent that can register an MCP server can join.">
+<meta property="og:title" content="muster — a local coordination bus for coding agents">
+<meta property="og:description" content="Agent sessions that message and hand off tasks across terminals. Local, tmux-native, one static binary.">
+<meta property="og:url" content="https://muster.tools">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📬</text></svg>">
+</head>
+<body>
+<style>
+  :root {
+    --ink:      #14161d;
+    --ink-2:    #1a1d27;
+    --ink-3:    #21252f;
+    --paper:    #f4f5f8;
+    --paper-2:  #ffffff;
+    --line-d:   #2b2f3b;
+    --line-l:   #e3e5ec;
+    --fg-d:     #e8eaf1;
+    --fg-l:     #1a1d27;
+    --muted-d:  #969cae;
+    --muted-l:  #59606f;
+    --signal-d: #eba63f;
+    --signal-l: #b06f14;
+    --wire:     #6cb3c2;
+    --mono: "SF Mono", ui-monospace, "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --maxw: 60rem;
+    --radius: 12px;
+
+    --bg: var(--ink); --surface: var(--ink-2); --surface-2: var(--ink-3);
+    --text: var(--fg-d); --muted: var(--muted-d); --line: var(--line-d);
+    --signal: var(--signal-d); --signal-soft: rgba(235,166,63,.12);
+    --shadow: 0 1px 0 rgba(255,255,255,.03), 0 18px 40px -24px rgba(0,0,0,.7);
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: var(--paper); --surface: var(--paper-2); --surface-2: #eef0f4;
+      --text: var(--fg-l); --muted: var(--muted-l); --line: var(--line-l);
+      --signal: var(--signal-l); --signal-soft: rgba(176,111,20,.10);
+      --shadow: 0 1px 0 rgba(0,0,0,.02), 0 18px 40px -28px rgba(20,22,29,.28);
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: var(--ink); --surface: var(--ink-2); --surface-2: var(--ink-3);
+    --text: var(--fg-d); --muted: var(--muted-d); --line: var(--line-d);
+    --signal: var(--signal-d); --signal-soft: rgba(235,166,63,.12);
+    --shadow: 0 1px 0 rgba(255,255,255,.03), 0 18px 40px -24px rgba(0,0,0,.7);
+  }
+  :root[data-theme="light"] {
+    --bg: var(--paper); --surface: var(--paper-2); --surface-2: #eef0f4;
+    --text: var(--fg-l); --muted: var(--muted-l); --line: var(--line-l);
+    --signal: var(--signal-l); --signal-soft: rgba(176,111,20,.10);
+    --shadow: 0 1px 0 rgba(0,0,0,.02), 0 18px 40px -28px rgba(20,22,29,.28);
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text); font-family: var(--sans); line-height: 1.62; -webkit-font-smoothing: antialiased; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 1.5rem; }
+  a { color: var(--signal); }
+
+  .statusbar { border-bottom: 1px solid var(--line); font-family: var(--mono); font-size: .72rem; letter-spacing: .12em; text-transform: uppercase; color: var(--muted); }
+  .statusbar .wrap { display: flex; justify-content: space-between; align-items: center; gap: 1rem; padding: .85rem 1.5rem; }
+  .statusbar b { color: var(--text); font-weight: 600; }
+  .statusbar .dot { color: var(--signal); }
+  .theme-toggle { font: inherit; color: var(--muted); background: transparent; border: 1px solid var(--line); border-radius: 6px; padding: .25rem .6rem; cursor: pointer; letter-spacing: .1em; }
+  .theme-toggle:hover { color: var(--text); border-color: var(--muted); }
+
+  .hero { padding: clamp(3.25rem, 8vw, 5.5rem) 0 2.5rem; }
+  .eyebrow { font-family: var(--mono); font-size: .78rem; letter-spacing: .15em; text-transform: uppercase; color: var(--signal); margin: 0 0 1.3rem; }
+  .wordmark { font-family: var(--mono); font-weight: 600; font-size: clamp(2.5rem, 8vw, 4.2rem); letter-spacing: -.02em; margin: 0; line-height: 1; }
+  .wordmark .cursor { display: inline-block; width: .56ch; height: .88em; margin-left: .12em; transform: translateY(.06em); background: var(--signal); animation: blink 1.15s steps(1) infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+  h1.lede { font-size: clamp(1.6rem, 4.3vw, 2.5rem); line-height: 1.14; letter-spacing: -.02em; font-weight: 600; text-wrap: balance; margin: 1.4rem 0 1rem; max-width: 24ch; }
+  .sub { font-size: 1.1rem; color: var(--muted); max-width: 62ch; margin: 0 0 2rem; }
+  .sub b { color: var(--text); font-weight: 600; }
+  .cta { display: flex; flex-wrap: wrap; gap: .8rem; align-items: center; }
+  .btn { font-family: var(--mono); font-size: .92rem; text-decoration: none; border-radius: 8px; padding: .7rem 1.15rem; display: inline-flex; align-items: center; gap: .5rem; border: 1px solid transparent; transition: transform .12s ease, background .15s ease, border-color .15s ease; }
+  .btn-primary { background: var(--signal); color: #17140d; font-weight: 600; }
+  .btn-primary:hover { transform: translateY(-1px); }
+  .btn-ghost { border-color: var(--line); color: var(--text); }
+  .btn-ghost:hover { border-color: var(--muted); background: var(--surface); }
+  .btn:focus-visible { outline: 2px solid var(--signal); outline-offset: 2px; }
+
+  .term { background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); overflow: hidden; }
+  .hero .term { margin-top: 3rem; }
+  .term-bar { display: flex; align-items: center; gap: .5rem; padding: .7rem 1rem; border-bottom: 1px solid var(--line); background: var(--surface-2); font-family: var(--mono); font-size: .74rem; color: var(--muted); }
+  .term-bar .lamp { width: .6rem; height: .6rem; border-radius: 50%; background: var(--line); }
+  .term-bar .lamp:nth-child(3) { background: var(--signal); }
+  .term-bar .title { margin-left: auto; letter-spacing: .04em; }
+  .term pre { margin: 0; padding: 1.1rem 1.25rem 1.3rem; overflow-x: auto; font-family: var(--mono); font-size: .84rem; line-height: 1.7; color: var(--text); font-variant-numeric: tabular-nums; }
+  .c-dim { color: var(--muted); } .c-sig { color: var(--signal); font-weight: 600; } .c-you { color: var(--wire); }
+  .live, .mail { color: var(--signal); } .mail { font-weight: 600; }
+  .pulse { display: inline-block; animation: pulse 1.9s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+  section { padding: clamp(2.75rem, 6.5vw, 4.5rem) 0; border-top: 1px solid var(--line); }
+  .kicker { font-family: var(--mono); font-size: .74rem; letter-spacing: .15em; text-transform: uppercase; color: var(--muted); margin: 0 0 1rem; }
+  .kicker::before { content: "$ "; color: var(--signal); }
+  h2 { font-size: clamp(1.4rem, 3.3vw, 1.95rem); letter-spacing: -.015em; line-height: 1.16; margin: 0 0 1rem; text-wrap: balance; }
+  h3.subhead { font-size: 1.05rem; margin: 2rem 0 .75rem; letter-spacing: -.01em; }
+  .lead { font-size: 1.06rem; color: var(--muted); max-width: 64ch; margin: 0 0 1.75rem; }
+  .lead b { color: var(--text); font-weight: 600; }
+  code.i, .lead code, .note code, .row .d code, .adr .d code { font-family: var(--mono); font-size: .86em; background: var(--surface); border: 1px solid var(--line); padding: .05em .38em; border-radius: 5px; color: var(--text); }
+
+  .modes { display: grid; grid-template-columns: 1fr; gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+  @media (min-width: 44rem) { .modes { grid-template-columns: repeat(3,1fr); } }
+  .mode { background: var(--bg); padding: 1.3rem 1.3rem; }
+  .mode .t { font-family: var(--mono); color: var(--signal); font-size: .82rem; letter-spacing: .04em; margin: 0 0 .5rem; }
+  .mode p { margin: 0; color: var(--muted); font-size: .95rem; }
+  .mode p b { color: var(--text); font-weight: 600; }
+
+  .toolgroups { display: grid; grid-template-columns: 1fr; gap: 1px; background: var(--line); border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+  @media (min-width: 44rem) { .toolgroups { grid-template-columns: 1fr 1fr; } }
+  .tg { background: var(--bg); padding: 1.3rem 1.3rem; }
+  .tg h3 { font-family: var(--mono); font-size: .8rem; letter-spacing: .1em; text-transform: uppercase; color: var(--signal); margin: 0 0 .6rem; }
+  .tg code { font-family: var(--mono); font-size: .82rem; color: var(--text); }
+  .tg p { margin: .45rem 0 0; color: var(--muted); font-size: .93rem; }
+  .tg p b { color: var(--text); font-weight: 600; }
+  .lifecycle { font-family: var(--mono); font-size: .78rem; color: var(--muted); display: block; margin-top: .5rem; }
+  .lifecycle b { color: var(--signal); font-weight: 600; }
+
+  /* addressing rows */
+  .adr { border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+  .adr .row2 { display: grid; grid-template-columns: 1fr; gap: .25rem; padding: 1.1rem 1.25rem; }
+  @media (min-width: 44rem) { .adr .row2 { grid-template-columns: 11rem 1fr; gap: 1.3rem; align-items: baseline; } }
+  .adr .row2 + .row2 { border-top: 1px solid var(--line); }
+  .adr .k { font-family: var(--mono); font-size: .82rem; color: var(--signal); }
+  .adr .d { color: var(--text); font-size: .96rem; }
+  .adr .d .m { color: var(--muted); }
+
+  .tabs { display: flex; flex-wrap: wrap; gap: .55rem; margin: 0 0 1.5rem; }
+  .tab { font-family: var(--mono); font-size: .8rem; border: 1px solid var(--line); border-radius: 7px; padding: .42rem .7rem; color: var(--muted); background: var(--surface); }
+  .tab.sig { border-color: var(--signal); color: var(--text); }
+  .tab.sig b { color: var(--signal); }
+
+  .rows { border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+  .row { display: grid; grid-template-columns: 1fr; gap: .3rem; padding: 1.2rem 1.3rem; }
+  @media (min-width: 44rem) { .row { grid-template-columns: 8rem 1fr; gap: 1.4rem; align-items: baseline; } }
+  .row + .row { border-top: 1px solid var(--line); }
+  .row .k { font-family: var(--mono); font-size: .8rem; letter-spacing: .06em; text-transform: uppercase; color: var(--signal); }
+  .row .d { color: var(--text); font-size: .98rem; }
+  .row .d b { font-weight: 600; }
+  .row .d .m { color: var(--muted); }
+  .note { margin: 1.5rem 0 0; font-size: .98rem; color: var(--muted); max-width: 66ch; }
+  .note b { color: var(--text); font-weight: 600; }
+
+  pre.code { background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius); padding: 1.15rem 1.3rem; overflow-x: auto; font-family: var(--mono); font-size: .85rem; line-height: 1.8; margin: 0; color: var(--text); box-shadow: var(--shadow); }
+  pre.code .cm { color: var(--muted); } pre.code .pr { color: var(--signal); } pre.code .k2 { color: var(--wire); }
+  .codegap { margin-top: 1rem; }
+
+  footer { border-top: 1px solid var(--line); padding: 2.5rem 0 3.5rem; }
+  .foot { display: flex; flex-wrap: wrap; gap: 1rem 1.6rem; align-items: center; justify-content: space-between; font-family: var(--mono); font-size: .8rem; color: var(--muted); }
+  .foot a { color: var(--muted); text-decoration: none; border-bottom: 1px solid transparent; }
+  .foot a:hover { color: var(--signal); border-bottom-color: var(--signal); }
+  .foot .mm { color: var(--text); font-weight: 600; }
+
+  /* the product name, when it appears in prose — echoes the wordmark */
+  .mstr { font-family: var(--mono); color: var(--signal); font-weight: 600; font-size: .94em; letter-spacing: -.01em; }
+
+  /* left TOC — shown only when the viewport has room beside the column */
+  html { scroll-behavior: smooth; }
+  section, header.hero { scroll-margin-top: 1.25rem; }
+  .toc { display: none; }
+  @media (min-width: 84rem) {
+    .toc {
+      display: block; position: fixed; top: 50%; transform: translateY(-50%);
+      left: calc((100vw - var(--maxw)) / 2 - 11.5rem); width: 9.5rem;
+      font-family: var(--mono); font-size: .76rem; letter-spacing: .04em;
+    }
+    .toc a {
+      display: block; padding: .28rem 0 .28rem .75rem; color: var(--muted);
+      text-decoration: none; border-left: 2px solid var(--line);
+    }
+    .toc a:hover { color: var(--text); }
+    .toc a.active { color: var(--signal); border-left-color: var(--signal); }
+  }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+
+  @media (prefers-reduced-motion: reduce) { .wordmark .cursor, .pulse { animation: none; } .btn { transition: none; } }
+</style>
+
+<div class="statusbar">
+  <div class="wrap">
+    <span><span class="dot">●</span> <b>muster</b> &nbsp;·&nbsp; local agent bus</span>
+    <span>local <span class="dot">·</span> MIT
+      &nbsp; <button class="theme-toggle" id="tt" aria-label="Toggle color theme">theme</button></span>
+  </div>
+</div>
+
+<nav class="toc" aria-label="Sections">
+  <a href="#top">muster</a>
+  <a href="#what">what it is</a>
+  <a href="#tools">the tools</a>
+  <a href="#mailbox">tmux &amp; mailbox</a>
+  <a href="#hooks">hooks</a>
+  <a href="#wake">wake</a>
+  <a href="#setup">setup</a>
+</nav>
+
+<header class="hero" id="top">
+  <div class="wrap">
+    <p class="eyebrow">Local coordination bus for coding agents</p>
+    <p class="wordmark">muster<span class="cursor" aria-hidden="true"></span></p>
+    <h1 class="lede">A message bus between the agent sessions in your terminals.</h1>
+    <p class="sub">
+      <span class="mstr">muster</span> connects coding-agent sessions running in tmux. Each agent
+      registers over MCP and sends messages or hands tasks to the others — <b>any agent that can
+      register an MCP server can join</b>. <span class="mstr">muster</span> runs on your machine,
+      using a unix socket for transport and a SQLite file for state.
+    </p>
+    <div class="cta">
+      <a class="btn btn-primary" href="https://github.com/schuettc/muster">View on GitHub →</a>
+      <a class="btn btn-ghost" href="https://github.com/schuettc/muster/releases">Releases</a>
+    </div>
+
+    <div class="term" role="img" aria-label="A muster session where one agent sends another a note and the recipient's mailbox lights up.">
+      <div class="term-bar"><span class="lamp"></span><span class="lamp"></span><span class="lamp"></span><span class="title">~ muster</span></div>
+<pre><span class="c-dim">$</span> muster agents
+<span class="c-dim">PROJECT   ALIAS      LABEL      MODEL   LIVE</span>
+web       web        frontend   claude  <span class="live">●</span>
+api       api-2      backend    codex   <span class="live">●</span>
+
+<span class="c-dim"># the frontend agent messages the backend, from its own session</span>
+<span class="c-you">›</span> send api-2 <span class="c-sig">"GET /users is missing createdAt"</span>
+
+api-2   <span class="mail">📬 1</span><span class="pulse"></span>   <span class="c-dim">← a mailbox flag on the backend's tmux tab</span>
+api-2   reply  <span class="c-sig">"fixed — createdAt added"</span>
+</pre>
+    </div>
+  </div>
+</header>
+
+<section id="what">
+  <div class="wrap">
+    <p class="kicker">what it is</p>
+    <h2>One binary, three modes.</h2>
+    <p class="lead"><span class="mstr">muster</span> is a single static Go binary that runs in three modes. The bus routes between your agents without ever calling a model itself.</p>
+    <div class="modes">
+      <div class="mode"><p class="t">daemon</p><p>A background process that holds the agents, messages, and tasks, listening on a <b>unix socket</b>. It starts automatically the first time anything uses the bus.</p></div>
+      <div class="mode"><p class="t">MCP server</p><p><code style="font-family:var(--mono)">muster mcp</code> serves the bus over stdio. Register it in any MCP client and the agent gets the eleven coordination tools below.</p></div>
+      <div class="mode"><p class="t">CLI</p><p>You can use the CLI from any shell to watch and drive the bus — <code style="font-family:var(--mono)">muster agents</code> lists who's connected, <code style="font-family:var(--mono)">muster send</code> and <code style="font-family:var(--mono)">muster nudge</code> reach an agent, and <code style="font-family:var(--mono)">muster label</code> names a session. Session hooks call the CLI as well.</p></div>
+    </div>
+  </div>
+</section>
+
+<section id="tools">
+  <div class="wrap">
+    <p class="kicker">the tools</p>
+    <h2>Messages, tasks, and shared state.</h2>
+    <p class="lead">The bus exposes eleven MCP tools in four groups. The core distinction is between a <b>message</b>, which is a plain thread with no state, and a <b>task</b>, which is a thread with a lifecycle that someone must pick up and finish.</p>
+    <div class="toolgroups">
+      <div class="tg">
+        <h3>identity</h3>
+        <code>register_agent · list_agents</code>
+        <p>Join the bus once per session and see who's connected. Registration captures the session's tmux pane automatically, so muster knows where each agent lives.</p>
+      </div>
+      <div class="tg">
+        <h3>conversation</h3>
+        <code>send_message · reply · get_inbox · get_thread</code>
+        <p>Send a message to a peer, list what's addressed to you, read a thread in full, and answer on it.</p>
+      </div>
+      <div class="tg">
+        <h3>work</h3>
+        <code>task_create · task_claim · task_transition</code>
+        <p>Hand off work that has a state. Claiming is atomic — two agents can't take the same task.</p>
+        <span class="lifecycle">open → <b>claimed</b> → needs_info | blocked → <b>completed</b> | declined | cancelled</span>
+      </div>
+      <div class="tg">
+        <h3>shared state</h3>
+        <code>kv_set · kv_get</code>
+        <p>These two keep a shared key/value scratchpad for facts both sides need — an API contract, a port number, an agreed decision.</p>
+      </div>
+    </div>
+
+    <h3 class="subhead">In practice, you ask in plain language</h3>
+    <p class="lead">Your agent has these tools, so you don't type commands at it — you say what you want and it makes the calls. Phrases like these do the work:</p>
+    <div class="tabs" style="margin-bottom:2rem">
+      <span class="tab">"who's on the muster bus?"</span>
+      <span class="tab">"check your muster inbox"</span>
+      <span class="tab">"send api-2 a message about the response shape"</span>
+      <span class="tab">"hand this review to backend as a muster task"</span>
+      <span class="tab">"reply on that thread when you're done"</span>
+    </div>
+
+    <h3 class="subhead">Addressing — three ways to name a recipient</h3>
+    <div class="adr">
+      <div class="row2">
+        <span class="k">api-2</span>
+        <span class="d">An <b>alias</b> is the agent's tmux session name, unique on the bus. Every agent has one — it's the ALIAS column in <code>muster agents</code>.</span>
+      </div>
+      <div class="row2">
+        <span class="k">backend</span>
+        <span class="d">A <b>label</b> is a name you give a session. Run <code>muster label backend</code> inside it once, and <code>send backend "…"</code> reaches it from then on. <span class="m"><code>muster label --clear</code> removes it.</span></span>
+      </div>
+      <div class="row2">
+        <span class="k">api:backend</span>
+        <span class="d">The <b>project:label</b> form matters only if you run <b>one tmux server per project</b>. A project is the tmux server a session runs on: start your servers with sockets named <code>proj-&lt;name&gt;</code> (for example <code>tmux -L proj-api</code>) and muster scopes agents by that name — a bare label then resolves within your own project only, and <code>api:backend</code> reaches across. On the default tmux server there are no projects; every agent shares one namespace and everything else in <span class="mstr">muster</span> works the same.</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="mailbox">
+  <div class="wrap">
+    <p class="kicker">tmux &amp; the mailbox</p>
+    <h2>Mail shows up on the tab.</h2>
+    <p class="lead">When mail arrives, the daemon sets a tmux option on the recipient's session — <code>@muster_inbox</code>, holding the unread count. tmux doesn't display custom options by default, so add these two lines to your <code>~/.tmux.conf</code> and reload (<code>tmux source ~/.tmux.conf</code>):</p>
+<pre class="code"><span class="cm"># render the muster mailbox in the tab title and status bar</span>
+set -g set-titles on
+set -g set-titles-string <span class="c-sig">'#{?@muster_inbox,📬#{@muster_inbox} ,}#S'</span>
+set -ga status-left <span class="c-sig">'#{?@muster_inbox,#[fg=colour0#,bg=colour6#,bold] 📬#{@muster_inbox} #[default] ,}'</span>
+</pre>
+    <p class="note codegap">If you already customize <code>set-titles-string</code> or <code>status-left</code>, merge the <code>#{?@muster_inbox,…}</code> conditional into your own strings — it renders nothing when there is no mail.</p>
+    <div class="tabs">
+      <span class="tab">web · frontend</span>
+      <span class="tab sig"><b>📬 2</b> · api-2 · backend</span>
+      <span class="tab">db · migrations</span>
+    </div>
+    <p class="note">The flag <b>persists until the agent reads its inbox</b> (a <code>get_inbox</code> call clears it), and switching to the tab does not clear it. <span class="mstr">muster</span> only sets a tmux option here; it never types into a pane.</p>
+  </div>
+</section>
+
+<section id="hooks">
+  <div class="wrap">
+    <p class="kicker">hooks</p>
+    <h2>Register on start, handle mail on turn end.</h2>
+    <p class="lead">The <span class="mstr">muster</span> binary is its own session hook: <code>muster hook &lt;event&gt; &lt;model&gt;</code>. Wired into your agent's lifecycle hooks, it does two things — <b>SessionStart</b> registers the session on the bus, and <b>Stop</b> (the end of each turn) checks for unread muster mail and, if there is any, instructs the agent to read its inbox and reply. There is nothing to copy or chmod, the hook is a no-op for sessions that aren't registered agents, and it never blocks a session from starting.</p>
+
+    <h3 class="subhead">Claude Code — add to <code class="i">~/.claude/settings.json</code></h3>
+<pre class="code">"hooks": {
+  "SessionStart": [
+    { "matcher": "startup|resume",
+      "hooks": [ { "type": "command", "command": <span class="c-sig">"muster hook SessionStart claude"</span> } ] }
+  ],
+  "Stop": [
+    { "hooks": [ { "type": "command", "command": <span class="c-sig">"muster hook Stop claude"</span> } ] }
+  ],
+  "SessionEnd": [
+    { "hooks": [ { "type": "command", "command": <span class="c-sig">"muster hook SessionEnd claude"</span> } ] }
+  ]
+}
+</pre>
+
+    <h3 class="subhead">Codex — save as <code class="i">~/.codex/hooks.json</code></h3>
+<pre class="code">{
+  "hooks": {
+    "SessionStart": [ { "hooks": [ { "type": "command", "command": <span class="c-sig">"muster hook SessionStart codex"</span> } ] } ],
+    "Stop":         [ { "hooks": [ { "type": "command", "command": <span class="c-sig">"muster hook Stop codex"</span> } ] } ]
+  }
+}
+</pre>
+    <p class="note codegap">Three Codex specifics: on the next <code>codex</code> launch it shows a one-time <b>"Hooks need review"</b> prompt — choose Trust (trust is recorded against the file's hash; editing it re-prompts). Codex fires <b>SessionStart on the session's first turn</b>, not at launch — the agent appears on the bus after its first exchange. And Codex has <b>no SessionEnd event</b> — <code>muster gc</code> reaps agents whose tmux session is gone, so the roster stays honest either way.</p>
+    <p class="note">If <code>muster</code> isn't on the PATH your harness gives hook commands (e.g. it's in <code>~/go/bin</code>), use the absolute binary path in the <code>command</code> strings — Codex in particular does not expand <code>~</code>.</p>
+  </div>
+</section>
+
+<section id="wake">
+  <div class="wrap">
+    <p class="kicker">wake</p>
+    <h2>Three ways an agent notices mail.</h2>
+    <div class="rows">
+      <div class="row">
+        <span class="k">mailbox</span>
+        <span class="d">The <span class="mail">📬</span> count on the tab (previous section) is the passive signal: you see it, and the agent acts on it the next time it checks its inbox — or when you ask it to.</span>
+      </div>
+      <div class="row">
+        <span class="k">nudge</span>
+        <span class="d"><code>muster nudge api-2</code> is the manual poke for waking an idle agent right now: it types "check your inbox" into that agent's pane and submits it — immediately for Claude Code, with a short delayed Enter for Codex. <span class="m">This is the only muster mechanism that types into a pane.</span></span>
+      </div>
+      <div class="row">
+        <span class="k">stop hook</span>
+        <span class="d">The Stop hook is the automatic path: with the <code>muster hook Stop</code> entry from the previous section installed, an agent that finishes a turn with unread mail reads its inbox and replies on its own. <span class="m">Mail that arrives while an agent is working gets handled when the turn ends.</span></span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="setup">
+  <div class="wrap">
+    <p class="kicker">setup</p>
+    <h2>Requirements and setup.</h2>
+    <h3 class="subhead">What you need</h3>
+    <div class="rows">
+      <div class="row">
+        <span class="k">tmux</span>
+        <span class="d">Agents run inside tmux sessions — <span class="mstr">muster</span> uses tmux for agent identity, liveness, the mailbox, and nudging. <span class="m">Any tmux setup works; no particular configuration is required.</span></span>
+      </div>
+      <div class="row">
+        <span class="k">the binary</span>
+        <span class="d">Download a prebuilt binary from the <a href="https://github.com/schuettc/muster/releases">releases page</a> — one static file with no dependencies, signed and notarized on macOS. <span class="m">Building from source with Go 1.22+ works too.</span></span>
+      </div>
+      <div class="row">
+        <span class="k">os</span>
+        <span class="d">macOS or Linux. <span class="m">On Windows, install inside WSL2, where tmux and unix sockets are standard.</span></span>
+      </div>
+      <div class="row">
+        <span class="k">an agent</span>
+        <span class="d">At least one coding agent that can register an MCP server — Claude Code, Codex, or any other MCP client.</span>
+      </div>
+    </div>
+
+    <h3 class="subhead">The three required steps</h3>
+<pre class="code"><span class="cm"># 1. install the binary</span>
+<span class="pr">$</span> curl -fsSL https://muster.tools/install.sh | sh
+<span class="cm">#    or build from source: go install github.com/schuettc/muster/cmd/muster@latest</span>
+
+<span class="cm"># 2. register the MCP server with each agent</span>
+<span class="pr">$</span> claude mcp add muster -s user -- muster mcp
+<span class="pr">$</span> codex mcp add muster -- muster mcp
+<span class="cm">#    any other MCP client: point it at `muster mcp` over stdio</span>
+
+<span class="cm"># 3. in each tmux session, have the agent register — either ask it once:</span>
+<span class="k2">›</span> <span class="c-sig">"register on the muster bus"</span>   <span class="cm">(it calls its register_agent tool)</span>
+<span class="cm">#    or install the SessionStart hook above and skip the ask</span>
+</pre>
+    <p class="note codegap">With that, agents can message, hand off tasks, and share state.</p>
+
+    <h3 class="subhead">The two optional layers</h3>
+    <div class="rows">
+      <div class="row">
+        <span class="k">mailbox</span>
+        <span class="d">Add the two render lines from the <b>tmux section above</b> to your <code>~/.tmux.conf</code>, so unread mail shows as <span class="mail">📬</span> on the tab. <span class="m">Without them the daemon still sets the option; nothing displays it.</span></span>
+      </div>
+      <div class="row">
+        <span class="k">hooks</span>
+        <span class="d">Add the hook blocks from the <b>hooks section above</b> to your agent configs, so sessions register on start and handle their own mail at turn end. <span class="m">Without them you register by asking (step 3) and wake agents with <code>muster nudge</code>.</span></span>
+      </div>
+    </div>
+    <p class="note codegap">Both layers are copy-paste from this page, and both also live in <a href="https://github.com/schuettc/muster/tree/main/contrib">contrib/</a>.</p>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap foot">
+    <span><span class="mm">muster</span> · a local coordination bus for coding agents</span>
+    <span>
+      <a href="https://github.com/schuettc/muster">GitHub</a> &nbsp;·&nbsp;
+      <a href="https://github.com/schuettc/muster/releases">Releases</a> &nbsp;·&nbsp;
+      <a href="https://github.com/schuettc/muster/blob/main/LICENSE">MIT</a>
+    </span>
+  </div>
+</footer>
+
+<script>
+  (function () {
+    var links = document.querySelectorAll('.toc a');
+    var map = {};
+    links.forEach(function (a) { map[a.getAttribute('href').slice(1)] = a; });
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) {
+          links.forEach(function (a) { a.classList.remove('active'); });
+          var a = map[e.target.id];
+          if (a) { a.classList.add('active'); }
+        }
+      });
+    }, { rootMargin: '-40% 0px -55% 0px' });
+    ['top', 'what', 'tools', 'mailbox', 'hooks', 'wake', 'setup'].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) { obs.observe(el); }
+    });
+  })();
+  (function () {
+    var tt = document.getElementById('tt');
+    tt.addEventListener('click', function () {
+      var cur = document.documentElement.getAttribute('data-theme');
+      if (!cur) { cur = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'; }
+      document.documentElement.setAttribute('data-theme', cur === 'dark' ? 'light' : 'dark');
+    });
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Lands on main: the muster.tools landing page with CI Pages deployment (site/ + pages.yml — every future merge touching them republishes automatically), install.sh (one-line checksum-verified installer, served at muster.tools/install.sh), versionless release-asset names behind the stable latest/download URL, and the README rewritten around them. No VERSION bump — the release workflow should see v0.3.1 exists and skip (validating the gate).