### PR TITLE
Promote: Codex first-turn registration docs

### DIFF
--- a/.claude/skills/muster-coordination/SKILL.md
+++ b/.claude/skills/muster-coordination/SKILL.md
@@ -16,6 +16,11 @@ begins. The bus captures your tmux pane automatically; your **alias** is how pee
 address you (default: your tmux session name). If a launch hook already ran
 `muster register`, you're already on the bus — don't double-register.
 
+Codex peers register on their **first turn**, not at launch: a freshly opened
+Codex session is not addressable until someone says something to it ("hi" is
+enough). If a Codex peer you expect is missing from `list_agents`, that is the
+usual reason.
+
 ## The core loop
 
 - **`list_agents`** — who's on the bus (project, label, liveness).

--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ Other model types are typed without submitting.
 Registration and inbox-draining can be driven by session lifecycle hooks instead
 of typed by hand:
 
-- **SessionStart** → `muster register` — every session joins the bus on start.
+- **SessionStart** → `muster register` — the session joins the bus on start.
+  Claude Code fires this at launch; Codex fires it on the session's first turn,
+  so say anything to a fresh Codex session ("hi" is enough) before addressing
+  mail to it.
 - **Stop** (turn end) → if the session has unread muster mail, the hook tells the
   agent to drain its inbox and reply, autonomously.
 - **SessionEnd** (Claude Code) → `muster deregister`; `muster gc` covers the rest.

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -28,7 +28,9 @@ Setup:
   into `~/.claude/settings.json`.
 - **Codex:** copy [`codex-hooks.json`](codex-hooks.json) to `~/.codex/hooks.json`.
   On the next `codex` launch you'll get a one-time "Hooks need review" prompt —
-  choose Trust. Codex fires `SessionStart` lazily, on the session's first turn.
+  choose Trust. Codex fires `SessionStart` lazily, on the session's first turn —
+  a freshly opened Codex session is not on the bus until you say something to
+  it, so give it any first message ("hi" is enough) before addressing mail to it.
 
 If `muster` isn't on the PATH your harness gives hook commands (e.g. it lives in
 `~/go/bin`), use the absolute binary path in the `command` strings — Codex in

--- a/site/index.html
+++ b/site/index.html
@@ -537,7 +537,7 @@ set -ga status-left <span class="c-sig">'#{?@muster_inbox,#[fg=colour0#,bg=colou
   }
 }
 </pre>
-    <p class="note codegap">Three Codex specifics: on the next <code>codex</code> launch it shows a one-time <b>"Hooks need review"</b> prompt — choose Trust (trust is recorded against the file's hash; editing it re-prompts). Codex fires <b>SessionStart on the session's first turn</b>, not at launch — the agent appears on the bus after its first exchange. And Codex has <b>no SessionEnd event</b> — <code>muster gc</code> reaps agents whose tmux session is gone, so the roster stays honest either way.</p>
+    <p class="note codegap">Three Codex specifics: on the next <code>codex</code> launch it shows a one-time <b>"Hooks need review"</b> prompt — choose Trust (trust is recorded against the file's hash; editing it re-prompts). Codex fires <b>SessionStart on the session's first turn</b>, not at launch — a freshly opened Codex session is not on the bus until you say something to it, so give it any first message ("hi" is enough) before addressing mail to it. And Codex has <b>no SessionEnd event</b> — <code>muster gc</code> reaps agents whose tmux session is gone, so the roster stays honest either way.</p>
     <p class="note">If <code>muster</code> isn't on the PATH your harness gives hook commands (e.g. it's in <code>~/go/bin</code>), use the absolute binary path in the <code>command</code> strings — Codex in particular does not expand <code>~</code>.</p>
   </div>
 </section>


### PR DESCRIPTION
Docs-only promotion: the say-hi-to-Codex habit on the landing page, README, contrib/README, and the coordination skill (PR #31). No VERSION bump — no release expected; deploy-site republishes the page.

https://claude.ai/code/session_01KDkyFVPBYQBT18855Txw3x