### PR TITLE
promote: site station+CLI reference, CLI help surface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,11 @@ name: release
 # Merge to main = release. The VERSION file is the knob: when a merge lands on
 # main and no tag v<VERSION> exists yet, this workflow tags it, creates the
 # GitHub release (auto-generated notes), and attaches cross-compiled binaries
-# (cgo-free: darwin/linux × arm64/amd64) with sha256 checksums. A merge that
-# doesn't bump VERSION releases nothing. macOS binaries are re-signed and
-# notarized locally afterwards via contrib/release-sign.sh <tag>.
+# (cgo-free: darwin/linux × arm64/amd64) with sha256 checksums. Every binary
+# is stamped with this release's version/commit via -ldflags -X into
+# internal/version. A merge that doesn't bump VERSION releases nothing.
+# macOS binaries are re-signed and notarized locally afterwards via
+# contrib/release-sign.sh <tag>.
 #
 # workflow_dispatch rebuilds assets for an existing release (backfill/repair).
 on:
@@ -59,11 +61,14 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ steps.rel.outputs.tag }}"
+          version="${tag#v}"
+          commit="$(git rev-parse --short HEAD)"
+          ldflags="-s -w -X github.com/schuettc/muster/internal/version.version=${version} -X github.com/schuettc/muster/internal/version.commit=${commit}"
           for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
             goos="${target%/*}"; goarch="${target#*/}"
             out="muster_${goos}_${goarch}"
             CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
-              go build -trimpath -ldflags "-s -w" -o "dist/${out}/muster" ./cmd/muster
+              go build -trimpath -ldflags "$ldflags" -o "dist/${out}/muster" ./cmd/muster
             tar -C "dist/${out}" -czf "dist/${out}.tar.gz" muster
           done
           (cd dist && shasum -a 256 *.tar.gz > checksums.txt)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /bin/
 
+# generated man page (just man / release.yml render it fresh — never committed)
+/contrib/muster.1
+
 # runtime state (the local daemon's SQLite DB + WAL)
 bus.db
 bus.db-shm

--- a/cmd/muster/main.go
+++ b/cmd/muster/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -22,44 +23,70 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: muster <serve|debug|mcp|agents|inbox|send|tasks|events|watch|station|nudge|register|deregister|gc|hook|label> [args]")
+		humancli.Usage(os.Stdout)
 		os.Exit(2)
 	}
 	switch os.Args[1] {
 	case "serve":
+		if wantsHelp(os.Args[2:]) {
+			_ = humancli.HelpFor("serve", os.Stdout)
+			return
+		}
 		os.Exit(runServe())
 	case "debug":
+		if wantsHelp(os.Args[2:]) {
+			_ = humancli.HelpFor("debug", os.Stdout)
+			return
+		}
 		runDebug(os.Args[2:])
 	case "mcp":
+		if wantsHelp(os.Args[2:]) {
+			_ = humancli.HelpFor("mcp", os.Stdout)
+			return
+		}
 		runMCP()
 	default:
-		// humancli.Dispatch owns the CLI subcommand list and errors on an
-		// unknown one — routing everything here keeps that list canonical
-		// (a second list in this switch once shipped a release whose usage
-		// advertised a subcommand main() refused to route).
+		// humancli.Dispatch owns the CLI subcommand list (including
+		// help/version) and errors on an unknown one — routing everything
+		// here keeps that list canonical (a second list in this switch once
+		// shipped a release whose usage advertised a subcommand main()
+		// refused to route).
 		if err := humancli.Dispatch(os.Args[1:], os.Stdout); err != nil {
 			fmt.Fprintln(os.Stderr, "muster:", err)
-			os.Exit(1)
+			code := 1
+			var usageErr *humancli.UsageError
+			if errors.As(err, &usageErr) {
+				code = 2
+			}
+			os.Exit(code)
 		}
 	}
+}
+
+// wantsHelp reports whether the first token after a subcommand name is a
+// help flag. serve/mcp/debug are owned by main() (not humancli.Dispatch),
+// so their -h/--help handling lives here rather than behind flag.ErrHelp
+// interception the way the humancli-dispatched commands do it.
+func wantsHelp(args []string) bool {
+	return len(args) > 0 && humancli.IsHelpArg(args[0])
 }
 
 // runServe runs the daemon until it receives SIGINT/SIGTERM, returning the
 // process exit code (0 on a clean shutdown, non-zero on setup failure).
 func runServe() int {
 	if err := os.MkdirAll(paths.Home(), 0o755); err != nil {
-		fmt.Fprintln(os.Stderr, "mkdir:", err)
+		fmt.Fprintln(os.Stderr, "muster: mkdir:", err)
 		return 1
 	}
 	s, err := store.Open(paths.DBPath())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "open store:", err)
+		fmt.Fprintln(os.Stderr, "muster: open store:", err)
 		return 1
 	}
 	defer func() { _ = s.Close() }()
 	d, err := daemon.Serve(paths.SocketPath(), s, wake.NewTmuxNotifier("@muster_inbox", 500*time.Millisecond))
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "serve:", err)
+		fmt.Fprintln(os.Stderr, "muster: serve:", err)
 		return 1
 	}
 	defer func() { _ = d.Close() }()
@@ -77,7 +104,7 @@ func runServe() int {
 //	muster debug list_agents
 func runDebug(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: muster debug <op> [key=value ...]")
+		fmt.Fprintln(os.Stderr, "muster: usage: muster debug <op> [key=value ...]")
 		os.Exit(2)
 	}
 	req := proto.Request{Op: args[0], Args: map[string]any{}}
@@ -91,7 +118,7 @@ func runDebug(args []string) {
 	}
 	resp, err := client.Call(paths.SocketPath(), req)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "call:", err)
+		fmt.Fprintln(os.Stderr, "muster: call:", err)
 		os.Exit(1)
 	}
 	out, _ := json.MarshalIndent(resp, "", "  ")
@@ -105,7 +132,7 @@ func runDebug(args []string) {
 // all diagnostics go to stderr.
 func runMCP() {
 	if err := mcpserver.Run(context.Background()); err != nil {
-		fmt.Fprintln(os.Stderr, "mcp:", err)
+		fmt.Fprintln(os.Stderr, "muster: mcp:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/muster/main_test.go
+++ b/cmd/muster/main_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestMain builds the shared binary lazily (see builtBinary) and removes its
+// temp directory once every test in this package has run.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if binPath != "" {
+		_ = os.RemoveAll(filepath.Dir(binPath))
+	}
+	os.Exit(code)
+}
+
+// builtBinary lazily builds the real muster binary once per test process
+// (not per test) and returns its path, so exit-code/output behavior is
+// verified end-to-end through main() itself — the layer unit tests inside
+// internal/humancli can't reach, since the exit-code split (UsageError → 2,
+// everything else → 1) and the bare-invocation/serve-mcp-debug help
+// interception all live here.
+var (
+	buildOnce sync.Once
+	binPath   string
+	buildErr  error
+)
+
+func builtBinary(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "muster-cli-test-")
+		if err != nil {
+			buildErr = err
+			return
+		}
+		binPath = filepath.Join(dir, "muster")
+		cmd := exec.Command("go", "build", "-o", binPath, ".")
+		cmd.Dir = "."
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			buildErr = err
+			t.Logf("go build output:\n%s", out)
+		}
+	})
+	if buildErr != nil {
+		t.Fatalf("building muster binary: %v", buildErr)
+	}
+	return binPath
+}
+
+// run execs the built binary with args and returns stdout, stderr, and the
+// process exit code.
+func run(t *testing.T, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	bin := builtBinary(t)
+	cmd := exec.Command(bin, args...)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	code = 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			code = exitErr.ExitCode()
+		} else {
+			t.Fatalf("running %v: %v", args, err)
+		}
+	}
+	return outBuf.String(), errBuf.String(), code
+}
+
+func TestBareInvocationExitsTwoOnStdout(t *testing.T) {
+	out, _, code := run(t)
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(out, "muster — local multi-agent coordination bus") {
+		t.Errorf("stdout missing grouped usage banner:\n%s", out)
+	}
+}
+
+func TestHelpExitsZero(t *testing.T) {
+	out, _, code := run(t, "help")
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out, "Talk:") {
+		t.Errorf("stdout missing grouped usage:\n%s", out)
+	}
+}
+
+func TestUnknownCommandExitsTwo(t *testing.T) {
+	_, errOut, code := run(t, "bogus")
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+	if !strings.HasPrefix(errOut, "muster: unknown command") {
+		t.Errorf("stderr = %q, want a \"muster: unknown command\" prefix", errOut)
+	}
+}
+
+func TestUnknownHelpCommandExitsTwo(t *testing.T) {
+	_, errOut, code := run(t, "help", "bogus")
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(errOut, "valid commands:") {
+		t.Errorf("stderr missing valid-commands listing: %q", errOut)
+	}
+}
+
+func TestVersionExitsZero(t *testing.T) {
+	for _, args := range [][]string{{"version"}, {"--version"}} {
+		out, _, code := run(t, args...)
+		if code != 0 {
+			t.Errorf("%v: exit code = %d, want 0", args, code)
+		}
+		if !strings.HasPrefix(out, "muster ") {
+			t.Errorf("%v: stdout = %q, want it to start with \"muster \"", args, out)
+		}
+	}
+}
+
+func TestServeMcpDebugHelpExitZero(t *testing.T) {
+	for _, name := range []string{"serve", "mcp", "debug"} {
+		for _, flag := range []string{"-h", "--help"} {
+			out, _, code := run(t, name, flag)
+			if code != 0 {
+				t.Errorf("%s %s: exit code = %d, want 0", name, flag, code)
+			}
+			if !strings.Contains(out, "muster "+name+" — ") {
+				t.Errorf("%s %s: stdout missing command help banner:\n%s", name, flag, out)
+			}
+		}
+	}
+}
+
+func TestDebugMissingOpStillExitsNonzero(t *testing.T) {
+	// Sanity check that fixing debug's -h handling didn't disturb its
+	// existing "no args" error path.
+	_, errOut, code := run(t, "debug")
+	if code == 0 {
+		t.Error("expected non-zero exit for `muster debug` with no op")
+	}
+	if !strings.Contains(errOut, "usage: muster debug") {
+		t.Errorf("stderr = %q, want the debug usage message", errOut)
+	}
+}

--- a/internal/humancli/events.go
+++ b/internal/humancli/events.go
@@ -2,6 +2,7 @@ package humancli
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -41,23 +42,51 @@ func loadLabels() map[string]string {
 	return render.LoadLabels(callDataCaller{})
 }
 
+// eventsFlagVals holds cmdEvents' parsed flag pointers.
+type eventsFlagVals struct {
+	agent, kind       *string
+	thread            *int64
+	limit, width      *int
+	aliases, fullTime *bool
+}
+
+// newEventsFlagsWithVals declares events' flags and returns typed access to
+// their values — shared by cmdEvents (real parsing) and newEventsFlags
+// (registry help/man rendering).
+func newEventsFlagsWithVals() (*flag.FlagSet, eventsFlagVals) {
+	fs := flag.NewFlagSet("events", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var v eventsFlagVals
+	v.agent = fs.String("agent", "", "only events for this agent alias")
+	v.kind = fs.String("kind", "", "only events of this kind")
+	v.thread = fs.Int64("thread", 0, "only events for this thread id")
+	v.limit = fs.Int("limit", 50, "max events to show")
+	v.aliases = fs.Bool("aliases", false, "show raw aliases instead of current labels")
+	v.fullTime = fs.Bool("full-time", false, "show dates, not just times")
+	v.width = fs.Int("width", 0, "line budget in columns (default $COLUMNS or 120)")
+	return fs, v
+}
+
+// newEventsFlags builds events' flag.FlagSet for registry-driven help/man
+// rendering.
+func newEventsFlags() *flag.FlagSet {
+	fs, _ := newEventsFlagsWithVals()
+	return fs
+}
+
 // cmdEvents prints the daemon's observability event log — every mailbox
 // notify outcome (lit / cleared / skipped / error), inbox read, send, task,
 // and nudge event, oldest first. This is the "when was whose mailbox
 // actually lit" answer.
 func cmdEvents(args []string, out io.Writer) error {
-	fs := flag.NewFlagSet("events", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	agent := fs.String("agent", "", "only events for this agent alias")
-	kind := fs.String("kind", "", "only events of this kind")
-	thread := fs.Int64("thread", 0, "only events for this thread id")
-	limit := fs.Int("limit", 50, "max events to show (default 50)")
-	aliases := fs.Bool("aliases", false, "show raw aliases instead of current labels")
-	fullTime := fs.Bool("full-time", false, "show dates, not just times")
-	width := fs.Int("width", 0, "line budget in columns (default $COLUMNS or 120)")
+	fs, v := newEventsFlagsWithVals()
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("events", out)
+		}
 		return fmt.Errorf("usage: muster events [--agent <alias>] [--kind <kind>] [--thread <id>] [--limit <n>] [--aliases] [--full-time] [--width <cols>]")
 	}
+	agent, kind, thread, limit, aliases, fullTime, width := v.agent, v.kind, v.thread, v.limit, v.aliases, v.fullTime, v.width
 	page, err := fetchEvents(*agent, *kind, *thread, -1, *limit)
 	if err != nil {
 		return err

--- a/internal/humancli/help.go
+++ b/internal/humancli/help.go
@@ -1,0 +1,108 @@
+package humancli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// UsageError marks a Dispatch error as an operator mistake (unknown command,
+// missing required argument) rather than a runtime failure (a daemon call
+// that failed, a bad flag value). cmd/muster's main() checks for it to
+// decide between exit code 2 (usage) and 1 (everything else) — the
+// conventional split, and the same code bare-invocation-with-no-args already
+// used.
+type UsageError struct{ msg string }
+
+// Error implements the error interface.
+func (e *UsageError) Error() string { return e.msg }
+
+// usageErrorf builds a UsageError with a formatted message.
+func usageErrorf(format string, a ...any) error {
+	return &UsageError{msg: fmt.Sprintf(format, a...)}
+}
+
+// IsHelpArg reports whether s is a help flag/word muster recognizes at the
+// front of a command's arguments.
+func IsHelpArg(s string) bool { return s == "-h" || s == "--help" }
+
+// helpRequested reports whether any argument is a help flag — used by the
+// handful of commands (agents, inbox, tasks, deregister) that take no real
+// flags and so have no flag.FlagSet of their own to catch -h/--help via
+// flag.ErrHelp.
+func helpRequested(args []string) bool {
+	for _, a := range args {
+		if IsHelpArg(a) {
+			return true
+		}
+	}
+	return false
+}
+
+// Usage writes muster's grouped command listing (bare `muster`, `muster
+// help`) to out: one padded line per command, grouped under the four
+// headers in groupOrder, plumbing last.
+func Usage(out io.Writer) {
+	_, _ = fmt.Fprintln(out, "muster — local multi-agent coordination bus")
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, "Usage:")
+	_, _ = fmt.Fprintln(out, "  muster <command> [args]")
+	_, _ = fmt.Fprintln(out)
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	for _, g := range groupOrder {
+		_, _ = fmt.Fprintf(tw, "%s:\n", groupHeading[g])
+		for _, c := range Registry {
+			if c.Group != g {
+				continue
+			}
+			_, _ = fmt.Fprintf(tw, "  %s\t%s\n", c.Name, c.Summary)
+		}
+		_, _ = fmt.Fprintln(tw)
+	}
+	_ = tw.Flush()
+	_, _ = fmt.Fprintln(out, "Run 'muster help <command>' for details on a command.")
+	_, _ = fmt.Fprintln(out, "Docs: https://muster.tools")
+}
+
+// HelpFor writes one command's full usage (synopsis, description, flags with
+// defaults) to out. An unknown name is a UsageError listing valid commands.
+func HelpFor(name string, out io.Writer) error {
+	cmd, ok := lookup(name)
+	if !ok {
+		return usageErrorf("unknown command %q\n\nvalid commands: %s", name, strings.Join(commandNames(), ", "))
+	}
+	_, _ = fmt.Fprintf(out, "muster %s — %s\n\n", cmd.Name, cmd.Summary)
+	_, _ = fmt.Fprintf(out, "Usage:\n  muster %s\n", cmd.Synopsis)
+	if cmd.Help != "" {
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintln(out, cmd.Help)
+	}
+	if cmd.NewFlags != nil {
+		fs := cmd.NewFlags()
+		hasFlags := false
+		fs.VisitAll(func(*flag.Flag) { hasFlags = true })
+		if hasFlags {
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprintln(out, "Flags:")
+			fs.SetOutput(out)
+			fs.PrintDefaults()
+		}
+	}
+	return nil
+}
+
+// dispatchHelp implements `muster help`, `muster help --man`, and `muster
+// help <cmd>`.
+func dispatchHelp(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		Usage(out)
+		return nil
+	}
+	if args[0] == "--man" {
+		_, err := io.WriteString(out, ManPage())
+		return err
+	}
+	return HelpFor(args[0], out)
+}

--- a/internal/humancli/help_test.go
+++ b/internal/humancli/help_test.go
@@ -1,0 +1,131 @@
+package humancli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestUsageGroupedSnapshot is the grouped-usage snapshot: every group header
+// appears in order, and every command's name + one-line summary is listed
+// under it (a padded-columns row, not just present anywhere in the output).
+func TestUsageGroupedSnapshot(t *testing.T) {
+	var buf bytes.Buffer
+	Usage(&buf)
+	out := buf.String()
+
+	headings := []string{"Talk:", "Watch:", "Identity:", "Plumbing:"}
+	lastIdx := -1
+	for _, h := range headings {
+		idx := strings.Index(out, h)
+		if idx < 0 {
+			t.Fatalf("Usage output missing heading %q:\n%s", h, out)
+		}
+		if idx < lastIdx {
+			t.Fatalf("heading %q out of order in Usage output:\n%s", h, out)
+		}
+		lastIdx = idx
+	}
+
+	for _, c := range Registry {
+		if !strings.Contains(out, c.Name) {
+			t.Errorf("Usage output missing command name %q", c.Name)
+		}
+		if !strings.Contains(out, c.Summary) {
+			t.Errorf("Usage output missing summary for %q: %q", c.Name, c.Summary)
+		}
+	}
+
+	if !strings.Contains(out, "muster help <command>") {
+		t.Error("Usage output missing the 'muster help <command>' pointer")
+	}
+	if !strings.Contains(out, "muster.tools") {
+		t.Error("Usage output missing the muster.tools footer")
+	}
+}
+
+// TestBareInvocationVsHelp mirrors main.go's split: Dispatch itself doesn't
+// decide exit codes for the truly-bare (zero args) case — main.go special-
+// cases that before ever calling Dispatch — but `muster help` (args =
+// ["help"]) must report success.
+func TestBareInvocationVsHelp(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"help"}, &buf); err != nil {
+		t.Fatalf("help: unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "muster — local multi-agent coordination bus") {
+		t.Fatalf("help output missing banner:\n%s", buf.String())
+	}
+}
+
+// TestTopLevelHelpFlags checks `muster -h` and `muster --help` both render
+// the same grouped usage as `muster help`.
+func TestTopLevelHelpFlags(t *testing.T) {
+	var wantBuf bytes.Buffer
+	Usage(&wantBuf)
+
+	for _, arg := range []string{"-h", "--help"} {
+		var buf bytes.Buffer
+		if err := Dispatch([]string{arg}, &buf); err != nil {
+			t.Fatalf("%s: unexpected error: %v", arg, err)
+		}
+		if buf.String() != wantBuf.String() {
+			t.Fatalf("%s output does not match Usage():\ngot:\n%s\nwant:\n%s", arg, buf.String(), wantBuf.String())
+		}
+	}
+}
+
+// TestHelpForUnknownCommand checks the "unknown command in muster help <x>"
+// contract: a UsageError listing valid commands.
+func TestHelpForUnknownCommand(t *testing.T) {
+	var buf bytes.Buffer
+	err := HelpFor("bogus", &buf)
+	if err == nil {
+		t.Fatal("expected error for unknown command")
+	}
+	var ue *UsageError
+	if !errors.As(err, &ue) {
+		t.Fatalf("expected *UsageError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "valid commands:") {
+		t.Fatalf("error missing valid-commands listing: %v", err)
+	}
+	for _, c := range Registry {
+		if !strings.Contains(err.Error(), c.Name) {
+			t.Errorf("valid-commands listing missing %q: %v", c.Name, err)
+		}
+	}
+}
+
+// TestDispatchHelpMan checks `muster help --man` emits roff, not the
+// grouped usage — and that it's NOT itself listed as a command (hidden).
+func TestDispatchHelpMan(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"help", "--man"}, &buf); err != nil {
+		t.Fatalf("help --man: unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(buf.String(), ".TH MUSTER 1") {
+		t.Fatalf("help --man output doesn't start with a .TH roff header:\n%.100s", buf.String())
+	}
+
+	var usageBuf bytes.Buffer
+	Usage(&usageBuf)
+	if strings.Contains(usageBuf.String(), "--man") {
+		t.Error("--man should be hidden from grouped usage output")
+	}
+}
+
+// TestDispatchVersion checks `version` and `--version` both print
+// version.Line()'s output and exit clean.
+func TestDispatchVersion(t *testing.T) {
+	for _, arg := range []string{"version", "--version"} {
+		var buf bytes.Buffer
+		if err := Dispatch([]string{arg}, &buf); err != nil {
+			t.Fatalf("%s: unexpected error: %v", arg, err)
+		}
+		if !strings.HasPrefix(buf.String(), "muster ") {
+			t.Fatalf("%s output = %q, want a line starting with \"muster \"", arg, buf.String())
+		}
+	}
+}

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -20,6 +20,9 @@ import (
 // internal error is swallowed, and on any input other than a recognized
 // event it is simply a no-op.
 func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
+	if helpRequested(args) {
+		return HelpFor("hook", out)
+	}
 	if len(args) < 1 {
 		return fmt.Errorf("usage: muster hook <SessionStart|SessionEnd|Stop> [model]")
 	}

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -4,10 +4,10 @@ package humancli
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -16,8 +16,8 @@ import (
 	"github.com/schuettc/muster/internal/nudge"
 	"github.com/schuettc/muster/internal/paths"
 	"github.com/schuettc/muster/internal/proto"
-	"github.com/schuettc/muster/internal/station"
 	"github.com/schuettc/muster/internal/tmuxenv"
+	"github.com/schuettc/muster/internal/version"
 )
 
 // nudgeRun lets tests intercept the tmux command executor for nudges.
@@ -84,40 +84,30 @@ func callData(op string, args map[string]any) (json.RawMessage, error) {
 }
 
 // Dispatch routes an operator subcommand. args[0] is the subcommand name.
+// It also owns muster's help/version surface (`help`, `-h`, `--help`,
+// `version`, `--version`) — cmd/muster's main() routes anything that isn't
+// serve/mcp/debug here, and those three special-case help themselves before
+// ever reaching Dispatch (see cmd/muster/main.go), so this is the one place
+// that needs to recognize them.
 func Dispatch(args []string, out io.Writer) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: muster <agents|inbox|send|tasks|events|watch|station|nudge|register|deregister|gc|hook|label> [args]")
+		return fmt.Errorf("usage: muster <command> [args] (see 'muster help')")
 	}
 	switch args[0] {
-	case "agents":
-		return cmdAgents(out)
-	case "station":
-		return station.Run(args[1:])
-	case "send":
-		return cmdSend(args[1:], out)
-	case "inbox":
-		return cmdInbox(args[1:], out)
-	case "tasks":
-		return cmdTasks(args[1:], out)
-	case "events":
-		return cmdEvents(args[1:], out)
-	case "watch":
-		return cmdWatch(args[1:], out, watchOpts{})
-	case "nudge":
-		return cmdNudge(args[1:], out)
-	case "register":
-		return cmdRegister(args[1:], out)
-	case "deregister":
-		return cmdDeregister(args[1:], out)
-	case "gc":
-		return cmdGC(args[1:], out)
-	case "hook":
-		return cmdHook(args[1:], os.Stdin, out)
-	case "label":
-		return cmdLabel(args[1:], out)
-	default:
-		return fmt.Errorf("unknown command %q", args[0])
+	case "help":
+		return dispatchHelp(args[1:], out)
+	case "-h", "--help":
+		Usage(out)
+		return nil
+	case "version", "--version":
+		_, err := fmt.Fprintln(out, version.Line())
+		return err
 	}
+	cmd, ok := lookup(args[0])
+	if !ok || cmd.Run == nil {
+		return usageErrorf("unknown command %q (see 'muster help')", args[0])
+	}
+	return cmd.Run(args[1:], out)
 }
 
 // cmdAgents lists registered agents grouped by project, showing each
@@ -183,33 +173,60 @@ func validateIntent(intent string) error {
 	return nil
 }
 
+// sendFlagVals holds cmdSend's parsed flag pointers.
+type sendFlagVals struct {
+	from, subject, ref, intent *string
+	role, broadcast            *bool
+}
+
+// newSendFlagsWithVals declares send's flags and returns both the FlagSet
+// and typed access to its values — the one declaration cmdSend (real
+// parsing) and newSendFlags (registry help/man rendering) both build on, so
+// the two can't drift apart.
+func newSendFlagsWithVals() (*flag.FlagSet, sendFlagVals) {
+	fs := flag.NewFlagSet("send", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var v sendFlagVals
+	v.from = fs.String("from", "human", "sending agent alias")
+	v.subject = fs.String("subject", "", "message subject")
+	v.ref = fs.String("ref", "", "pointer to the work")
+	v.role = fs.Bool("role", false, "treat target as a role")
+	v.broadcast = fs.Bool("broadcast", false, "send to everyone")
+	v.intent = fs.String("intent", "", "message intent: fyi, reply-requested, or action-requested")
+	return fs, v
+}
+
+// newSendFlags builds send's flag.FlagSet for registry-driven help/man
+// rendering (Command.NewFlags); its values are unused, only the declared
+// flags (names, defaults, usage strings) matter here.
+func newSendFlags() *flag.FlagSet {
+	fs, _ := newSendFlagsWithVals()
+	return fs
+}
+
 // cmdSend sends a message to an agent, role, or broadcast target and prints
 // the resulting thread ID.
 func cmdSend(args []string, out io.Writer) error {
-	fs := flag.NewFlagSet("send", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	from := fs.String("from", "human", "sending agent alias")
-	subject := fs.String("subject", "", "message subject")
-	ref := fs.String("ref", "", "pointer to the work")
-	role := fs.Bool("role", false, "treat target as a role")
-	broadcast := fs.Bool("broadcast", false, "send to everyone")
-	intent := fs.String("intent", "", "message intent: fyi, reply-requested, or action-requested")
+	fs, v := newSendFlagsWithVals()
 	flagArgs, rest := splitFlagsAndPositional(args)
 	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("send", out)
+		}
 		return err
 	}
-	if err := validateIntent(*intent); err != nil {
+	if err := validateIntent(*v.intent); err != nil {
 		return err
 	}
 	toKind, toTarget := "agent", ""
 	switch {
-	case *broadcast:
+	case *v.broadcast:
 		toKind = "broadcast"
-	case *role:
+	case *v.role:
 		toKind = "role"
 	}
 	var body string
-	if *broadcast {
+	if *v.broadcast {
 		if len(rest) < 1 {
 			return fmt.Errorf("usage: muster send --broadcast <body> [--intent fyi|reply-requested|action-requested]")
 		}
@@ -229,8 +246,8 @@ func cmdSend(args []string, out io.Writer) error {
 		body = strings.Join(rest[1:], " ")
 	}
 	raw, err := callData("send_message", map[string]any{
-		"from": *from, "to_kind": toKind, "to_target": toTarget,
-		"subject": *subject, "ref": *ref, "body": body, "intent": *intent,
+		"from": *v.from, "to_kind": toKind, "to_target": toTarget,
+		"subject": *v.subject, "ref": *v.ref, "body": body, "intent": *v.intent,
 	})
 	if err != nil {
 		return err
@@ -306,7 +323,13 @@ func splitFlagsAndPositional(args []string, boolFlags ...map[string]bool) (flagA
 		if hasValue {
 			name = name[:idx]
 		}
-		if hasValue || bf[name] {
+		// "h"/"help" are always boolean, regardless of the caller's bf map:
+		// the flag package itself never consumes a value for them (an
+		// unrecognized -h/-help short-circuits to flag.ErrHelp before value
+		// consumption is even considered), so treating them as a value flag
+		// here would wrongly swallow the next token — e.g. `send -h alice
+		// hello` must NOT bind "alice" to -h as its value.
+		if hasValue || bf[name] || name == "h" || name == "help" {
 			flagArgs = append(flagArgs, a)
 			continue
 		}
@@ -331,6 +354,9 @@ func splitFlagsAndPositional(args []string, boolFlags ...map[string]bool) (flagA
 
 // cmdInbox prints the given alias's threads.
 func cmdInbox(args []string, out io.Writer) error {
+	if helpRequested(args) {
+		return HelpFor("inbox", out)
+	}
 	if len(args) < 1 {
 		return fmt.Errorf("usage: muster inbox <alias|label|proj:label>")
 	}
@@ -343,6 +369,9 @@ func cmdInbox(args []string, out io.Writer) error {
 
 // cmdTasks prints the given alias's inbox filtered to kind=task threads.
 func cmdTasks(args []string, out io.Writer) error {
+	if helpRequested(args) {
+		return HelpFor("tasks", out)
+	}
 	if len(args) < 1 {
 		return fmt.Errorf("usage: muster tasks <alias|label|proj:label>")
 	}
@@ -383,13 +412,30 @@ func printThreads(out io.Writer, alias string, tasksOnly bool) error {
 	return tw.Flush()
 }
 
+// newNudgeFlagsWithVals declares nudge's flags and returns typed access to
+// their values, mirroring newSendFlagsWithVals.
+func newNudgeFlagsWithVals() (fs *flag.FlagSet, noSubmit *bool) {
+	fs = flag.NewFlagSet("nudge", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	noSubmit = fs.Bool("no-submit", false, "type the nudge but do not press Enter")
+	return fs, noSubmit
+}
+
+// newNudgeFlags builds nudge's flag.FlagSet for registry-driven help/man
+// rendering.
+func newNudgeFlags() *flag.FlagSet {
+	fs, _ := newNudgeFlagsWithVals()
+	return fs
+}
+
 // cmdNudge resolves alias to its registered tmux pane and types the
 // check-inbox line into it, auto-submitting when the model type accepts it.
 func cmdNudge(args []string, out io.Writer) error {
-	fs := flag.NewFlagSet("nudge", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	noSubmit := fs.Bool("no-submit", false, "type the nudge but do not press Enter")
+	fs, noSubmit := newNudgeFlagsWithVals()
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("nudge", out)
+		}
 		return err
 	}
 	rest := fs.Args()

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -2,6 +2,7 @@ package humancli
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -13,18 +14,36 @@ import (
 	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
+// newRegisterFlagsWithVals declares register's flags and returns typed
+// access to their values — shared by cmdRegister (real parsing) and
+// newRegisterFlags (registry help/man rendering).
+func newRegisterFlagsWithVals() (fs *flag.FlagSet, role, model *string) {
+	fs = flag.NewFlagSet("register", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	role = fs.String("role", "", "this agent's role")
+	model = fs.String("model", "claude", "model backing this agent: claude or codex")
+	return fs, role, model
+}
+
+// newRegisterFlags builds register's flag.FlagSet for registry-driven
+// help/man rendering.
+func newRegisterFlags() *flag.FlagSet {
+	fs, _, _ := newRegisterFlagsWithVals()
+	return fs
+}
+
 // cmdRegister registers the current tmux session as an agent. Alias precedence:
 // explicit positional arg → $MUSTER_ALIAS → tmux session name.
 func cmdRegister(args []string, out io.Writer) error {
-	fs := flag.NewFlagSet("register", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	role := fs.String("role", "", "this agent's role")
-	model := fs.String("model", "claude", "model backing this agent: claude or codex")
+	fs, role, model := newRegisterFlagsWithVals()
 	// register has no boolean flags: --role and --model both take values, so
 	// pass an empty bool-flags set (an implicit default would wrongly reuse
 	// send's --role, which IS boolean there).
 	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{})
 	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("register", out)
+		}
 		return err
 	}
 	c := tmuxenv.CaptureEnv()
@@ -55,6 +74,9 @@ func cmdRegister(args []string, out io.Writer) error {
 // cmdDeregister removes an agent's registration. Alias precedence mirrors
 // register: explicit arg → $MUSTER_ALIAS → tmux session name.
 func cmdDeregister(args []string, out io.Writer) error {
+	if helpRequested(args) {
+		return HelpFor("deregister", out)
+	}
 	alias := ""
 	switch {
 	case len(args) > 0:
@@ -74,6 +96,24 @@ func cmdDeregister(args []string, out io.Writer) error {
 	return err
 }
 
+// newGCFlagsWithVals declares gc's flags and returns typed access to their
+// values — shared by cmdGC (real parsing) and newGCFlags (registry help/man
+// rendering).
+func newGCFlagsWithVals() (fs *flag.FlagSet, eventsKeep *time.Duration, purgeAgents *bool) {
+	fs = flag.NewFlagSet("gc", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	eventsKeep = fs.Duration("events-keep", 720*time.Hour, "prune journal events older than this")
+	purgeAgents = fs.Bool("purge-agents", false, "hard-delete departed and tmux-dead agent rows instead of tombstoning them (irreversible: identity, project, label, and read-state are all gone)")
+	return fs, eventsKeep, purgeAgents
+}
+
+// newGCFlags builds gc's flag.FlagSet for registry-driven help/man
+// rendering.
+func newGCFlags() *flag.FlagSet {
+	fs, _, _ := newGCFlagsWithVals()
+	return fs
+}
+
 // cmdGC tombstones every agent whose tmux session is no longer alive (spec:
 // deregistration is a soft delete now — departed=1, row and read-state kept
 // as history), then prunes journal events older than --events-keep (default
@@ -83,11 +123,11 @@ func cmdDeregister(args []string, out io.Writer) error {
 // prune error is reported on the same writer but never masks the agent-phase
 // summary already printed.
 func cmdGC(args []string, out io.Writer) error {
-	fs := flag.NewFlagSet("gc", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	eventsKeep := fs.Duration("events-keep", 720*time.Hour, "prune journal events older than this")
-	purgeAgents := fs.Bool("purge-agents", false, "hard-delete departed and tmux-dead agent rows instead of tombstoning them (irreversible: identity, project, label, and read-state are all gone)")
+	fs, eventsKeep, purgeAgents := newGCFlagsWithVals()
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("gc", out)
+		}
 		return err
 	}
 	if *eventsKeep <= 0 {

--- a/internal/humancli/label.go
+++ b/internal/humancli/label.go
@@ -1,6 +1,7 @@
 package humancli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -9,15 +10,33 @@ import (
 	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
+// newLabelFlagsWithVals declares label's flags and returns typed access to
+// their values — shared by cmdLabel (real parsing) and newLabelFlags
+// (registry help/man rendering).
+func newLabelFlagsWithVals() (fs *flag.FlagSet, clearFlag *bool) {
+	fs = flag.NewFlagSet("label", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	clearFlag = fs.Bool("clear", false, "clear this session's label")
+	return fs, clearFlag
+}
+
+// newLabelFlags builds label's flag.FlagSet for registry-driven help/man
+// rendering.
+func newLabelFlags() *flag.FlagSet {
+	fs, _ := newLabelFlagsWithVals()
+	return fs
+}
+
 // cmdLabel implements "muster label <name>" / "muster label --clear": naming
 // (or clearing) the current tmux session's label in one command, in place of
 // the two tmux set-option incantations an operator would otherwise type by
 // hand. It requires $TMUX (there is no "current session" outside tmux).
 func cmdLabel(args []string, out io.Writer) error {
-	fs := flag.NewFlagSet("label", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	clearFlag := fs.Bool("clear", false, "clear this session's label")
+	fs, clearFlag := newLabelFlagsWithVals()
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("label", out)
+		}
 		return err
 	}
 	rest := fs.Args()

--- a/internal/humancli/man.go
+++ b/internal/humancli/man.go
@@ -1,0 +1,100 @@
+package humancli
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/schuettc/muster/internal/paths"
+	"github.com/schuettc/muster/internal/version"
+)
+
+// roffEscape neutralizes roff's leading-dot, backslash, and double-quote
+// special meaning in free text pulled from the registry (synopses/help
+// paragraphs). A literal "-h" or "--foo" can't be misread as a macro
+// request by man(1); a literal "body" (send's synopsis quotes its body
+// argument) can't have its quotes silently eaten by .B/.TP's
+// whitespace-and-quote argument splitting — groff treats a bare `"word"`
+// argument as a QUOTED argument and strips the quotes, which is exactly
+// wrong for text we want printed verbatim.
+func roffEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\(dq`)
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(line, ".") || strings.HasPrefix(line, "'") {
+			b.WriteString(`\&`)
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+// ManPage renders muster's man(1) page as roff, generated from the same
+// Registry that drives `muster help` — the man page is never hand-maintained
+// and never committed (see justfile's `man` recipe and
+// .github/workflows/release.yml), so it cannot drift from the CLI's actual
+// commands.
+func ManPage() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, `.TH MUSTER 1 "%s" "muster" "User Commands"
+`, version.Version())
+	b.WriteString(`.SH NAME
+muster \- local multi-agent coordination bus
+.SH SYNOPSIS
+.B muster
+.I command
+.RI [ args ...]
+.SH DESCRIPTION
+muster is a local multi-agent coordination bus: independent coding-agent
+sessions (each in its own tmux tab) hand tasks and messages to each other
+without copy/paste. It never calls a model itself \- it only routes between
+agents already running on their own plans.
+.PP
+The binary has three modes:
+.TP
+.B serve
+runs the daemon, a lazy unix-socket API server every other mode talks to.
+.TP
+.B mcp
+runs an MCP stdio server exposing the daemon's operations as tools for a
+coding agent to call directly.
+.TP
+.I (default)
+every other subcommand is the human operator CLI: a plain client of the
+daemon, exactly as capable as the MCP tools.
+`)
+
+	b.WriteString(".SH COMMANDS\n")
+	for _, g := range groupOrder {
+		fmt.Fprintf(&b, ".SS %s\n", roffEscape(groupHeading[g]))
+		for _, c := range Registry {
+			if c.Group != g {
+				continue
+			}
+			fmt.Fprintf(&b, ".TP\n.B muster %s\n%s\n", roffEscape(c.Synopsis), roffEscape(c.Summary))
+		}
+	}
+
+	fmt.Fprintf(&b, `.SH FILES
+.TP
+.I ~/%s
+Default data directory (override with $MUSTER_HOME).
+.TP
+.I ~/%s/%s
+SQLite journal/store database.
+.TP
+.I ~/%s/%s
+The daemon's unix socket.
+`,
+		paths.HomeSuffix(),
+		paths.HomeSuffix(), filepath.Base(paths.DBPath()),
+		paths.HomeSuffix(), filepath.Base(paths.SocketPath()))
+
+	b.WriteString(`.SH SEE ALSO
+https://muster.tools
+`)
+	return b.String()
+}

--- a/internal/humancli/man_test.go
+++ b/internal/humancli/man_test.go
@@ -1,0 +1,75 @@
+package humancli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestManPageHeaders checks the generated roff has the headers man(1)
+// expects (.TH, .SH NAME/SYNOPSIS/DESCRIPTION/COMMANDS/FILES/SEE ALSO).
+func TestManPageHeaders(t *testing.T) {
+	page := ManPage()
+	for _, want := range []string{
+		".TH MUSTER 1",
+		".SH NAME",
+		".SH SYNOPSIS",
+		".SH DESCRIPTION",
+		".SH COMMANDS",
+		".SH FILES",
+		".SH SEE ALSO",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("man page missing %q", want)
+		}
+	}
+}
+
+// TestManPageOneEntryPerCommand checks every Registry command gets its own
+// .TP entry (with its synopsis, roff-escaped) and every group its own .SS
+// heading — the man page can't silently drop a command or a group.
+func TestManPageOneEntryPerCommand(t *testing.T) {
+	page := ManPage()
+	for _, g := range groupOrder {
+		if !strings.Contains(page, ".SS "+groupHeading[g]) {
+			t.Errorf("man page missing .SS heading for group %q", groupHeading[g])
+		}
+	}
+	tpCount := strings.Count(page, ".TP\n.B muster ")
+	if tpCount != len(Registry) {
+		t.Errorf("man page has %d command .TP entries, want %d (len(Registry))", tpCount, len(Registry))
+	}
+	for _, c := range Registry {
+		if !strings.Contains(page, roffEscape(c.Summary)) {
+			t.Errorf("man page missing summary for %q", c.Name)
+		}
+	}
+}
+
+// TestManPageFilesSectionUsesPaths checks the FILES section names the
+// actual db/socket leaf filenames internal/paths constructs, not a
+// hardcoded second copy.
+func TestManPageFilesSectionUsesPaths(t *testing.T) {
+	page := ManPage()
+	for _, want := range []string{"bus.db", "sock", "MUSTER_HOME"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("man page FILES section missing %q", want)
+		}
+	}
+}
+
+// TestRoffEscapeNeutralizesLeadingDotAndQuotes checks the escaper the man
+// renderer relies on: a leading "." would otherwise be read as a macro
+// request, and a bare "quoted word" would have its quotes silently eaten by
+// .B/.TP's argument parser.
+func TestRoffEscapeNeutralizesLeadingDotAndQuotes(t *testing.T) {
+	got := roffEscape(`.dangerous line with "a quote" and a \backslash`)
+	if strings.HasPrefix(got, ".") {
+		t.Errorf("roffEscape left a leading '.': %q", got)
+	}
+	if strings.Contains(got, `"`) {
+		t.Errorf("roffEscape left a literal double quote: %q", got)
+	}
+	if !strings.Contains(got, `\\backslash`) {
+		t.Errorf("roffEscape did not double the backslash: %q", got)
+	}
+}

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -1,0 +1,294 @@
+package humancli
+
+import (
+	"errors"
+	"flag"
+	"io"
+	"os"
+
+	"github.com/schuettc/muster/internal/station"
+)
+
+// Group buckets a Command for the grouped bare/`help` listing and the man
+// page's SECTION headings. Order matters: groupOrder below is the only place
+// display order is decided, so adding a group means updating both here and
+// groupOrder.
+type Group int
+
+// The four command groups, in the order the operator sees them everywhere
+// (bare usage, `muster help`, the man page): talk first (the thing you do
+// most), watch second, identity third, plumbing last (daemon/dev internals,
+// rarely typed by hand).
+const (
+	GroupTalk Group = iota
+	GroupWatch
+	GroupIdentity
+	GroupPlumbing
+)
+
+// groupOrder is display order for the four groups.
+var groupOrder = []Group{GroupTalk, GroupWatch, GroupIdentity, GroupPlumbing}
+
+// groupHeading names each group's listing header.
+var groupHeading = map[Group]string{
+	GroupTalk:     "Talk",
+	GroupWatch:    "Watch",
+	GroupIdentity: "Identity",
+	GroupPlumbing: "Plumbing",
+}
+
+// Command is one row of muster's command registry — the single table that
+// drives bare `muster` / `muster help` (grouped usage), `muster help <cmd>`
+// and `muster <cmd> -h/--help` (per-command usage), and the generated man
+// page. There is deliberately no second list anywhere: cmd/muster's main()
+// routes serve/mcp/debug itself (they need process-level setup this package
+// has no business doing — daemon startup, stdio protocol framing) but still
+// declares a Registry row so help/man rendering covers them; Run is nil for
+// exactly those three, everything else is dispatched through Dispatch.
+type Command struct {
+	// Name is the subcommand word, e.g. "send".
+	Name string
+	// Synopsis is the argument shape shown after the name in usage output,
+	// e.g. `send <target> "body" [--from <alias>] ...`. It does NOT repeat
+	// "muster " or the command name.
+	Synopsis string
+	// Summary is the one-line description shown in grouped usage listings.
+	Summary string
+	// Help is one or more longer paragraphs shown by `muster help <cmd>` /
+	// `muster <cmd> -h`, below the synopsis. May be empty.
+	Help string
+	// Group buckets this command for display.
+	Group Group
+	// NewFlags builds a fresh *flag.FlagSet declaring this command's flags,
+	// for `PrintDefaults`-driven help/man rendering. It is the SAME
+	// constructor the command's real Run function calls to parse its own
+	// args (see e.g. newSendFlags) — one declaration, not a help-text copy
+	// that can drift from the real flags. nil means the command takes no
+	// flags.
+	NewFlags func() *flag.FlagSet
+	// Run executes the command. nil for serve/mcp/debug, which cmd/muster's
+	// main() owns directly (see the Command doc comment above).
+	Run func(args []string, out io.Writer) error
+}
+
+// Registry is every muster subcommand, operator-facing and plumbing alike.
+// Do not add a command anywhere else: Dispatch, Usage, HelpFor, and the man
+// renderer all walk this slice, so an entry here is the only thing required
+// for a command to show up consistently everywhere.
+//
+// Built in init() rather than as a var literal on purpose: several Run
+// closures below call HelpFor, which (via lookup) reads Registry itself.
+// Go's package-initialization-cycle check is a static, conservative
+// approximation that follows every function a var initializer references,
+// transitively — it can't tell that HelpFor is only ever called long after
+// init(), so a `var Registry = []Command{...Run: closureThatCallsHelpFor...}`
+// literal trips a false-positive "initialization cycle for Registry" at
+// compile time. Assigning inside init() sidesteps that check entirely: it's
+// ordinary sequential code, not a variable initializer expression.
+var Registry []Command
+
+func init() {
+	Registry = []Command{
+		{
+			Name:     "send",
+			Synopsis: `send <target> "body" [--from <alias>] [--subject <s>] [--ref <r>] [--role] [--broadcast] [--intent fyi|reply-requested|action-requested]`,
+			Summary:  "Send a message to an agent, role, or everyone.",
+			Help: `target is an alias, a label, or a "project:label" pair, resolved the same
+way for every muster surface (send, nudge, inbox, tasks). --role treats
+target as a role name instead of an agent; --broadcast ignores target and
+sends to every registered agent (target is then omitted: 'muster send
+--broadcast "body"'). --intent tags the message for the recipient's
+inbox/hook rendering: fyi (default, no action implied), reply-requested, or
+action-requested.`,
+			Group:    GroupTalk,
+			NewFlags: newSendFlags,
+			Run:      cmdSend,
+		},
+		{
+			Name:     "nudge",
+			Synopsis: `nudge <alias|label|proj:label> [--no-submit]`,
+			Summary:  "Type a check-inbox nudge into an agent's tmux pane.",
+			Help: `Resolves the target to its registered tmux pane and types the check-inbox
+line into it, auto-submitting (pressing Enter) when the agent's model type
+accepts an unattended submit. --no-submit types the line but leaves it for
+the operator (or the agent) to submit by hand.`,
+			Group:    GroupTalk,
+			NewFlags: newNudgeFlags,
+			Run:      cmdNudge,
+		},
+		{
+			Name:     "agents",
+			Synopsis: "agents",
+			Summary:  "List registered agents, grouped by project, with live status.",
+			Help:     `Shows every registered agent's project, alias, label, model, and whether its tmux session is still alive.`,
+			Group:    GroupWatch,
+			Run: func(args []string, out io.Writer) error {
+				if helpRequested(args) {
+					return HelpFor("agents", out)
+				}
+				return cmdAgents(out)
+			},
+		},
+		{
+			Name:     "inbox",
+			Synopsis: "inbox <alias|label|proj:label>",
+			Summary:  "Show an agent's threads.",
+			Help:     `Prints every thread in the target agent's inbox: id, kind, from, to, status, who spoke last, unread count, and subject.`,
+			Group:    GroupWatch,
+			Run:      cmdInbox,
+		},
+		{
+			Name:     "tasks",
+			Synopsis: "tasks <alias|label|proj:label>",
+			Summary:  "Show an agent's task threads.",
+			Help:     `Same as 'muster inbox' but filtered to kind=task threads only.`,
+			Group:    GroupWatch,
+			Run:      cmdTasks,
+		},
+		{
+			Name:     "events",
+			Synopsis: "events [--agent <alias>] [--kind <kind>] [--thread <id>] [--limit <n>] [--aliases] [--full-time] [--width <cols>]",
+			Summary:  "Print the bus journal (event log), oldest first.",
+			Help: `The observability log behind every mailbox notify outcome (lit / cleared /
+skipped / error), inbox read, send, task, and nudge event — "when was whose
+mailbox actually lit." --aliases shows raw aliases instead of resolving
+current labels; --full-time prints dates, not just times.`,
+			Group:    GroupWatch,
+			NewFlags: newEventsFlags,
+			Run:      cmdEvents,
+		},
+		{
+			Name:     "watch",
+			Synopsis: "watch [--agent <alias>] [--kind <k>] [--thread <id>] [--interval <dur>] [--backlog <n>] [--aliases] [--full-time] [--width <cols>]",
+			Summary:  "Tail the bus journal live.",
+			Help: `Prints the last --backlog matching events, then polls for new ones every
+--interval until interrupted (Ctrl-C). Side-effect-free: watching never
+marks anything read.`,
+			Group:    GroupWatch,
+			NewFlags: newWatchFlags,
+			Run:      func(args []string, out io.Writer) error { return cmdWatch(args, out, watchOpts{}) },
+		},
+		{
+			Name:     "station",
+			Synopsis: "station [--interval <dur>] [--aliases] [--width <cols>] [--alias <name>]",
+			Summary:  "Full-screen operator TUI for the bus.",
+			Help:     `A live, navigable projects → agents → threads view of the bus, built on the same event journal 'muster watch' tails.`,
+			Group:    GroupWatch,
+			NewFlags: station.FlagSet,
+			Run: func(args []string, out io.Writer) error {
+				// station.Run launches a full-screen bubbletea program and its
+				// own flag.FlagSet doesn't discard -h output, so -h/--help is
+				// intercepted here first, via a throwaway parse against the same
+				// flag declarations (station.FlagSet) — see that function's doc
+				// comment for why it's a second declaration rather than a shared
+				// call.
+				if err := station.FlagSet().Parse(args); errors.Is(err, flag.ErrHelp) {
+					return HelpFor("station", out)
+				}
+				return station.Run(args)
+			},
+		},
+		{
+			Name:     "register",
+			Synopsis: "register [<alias>] [--role <role>] [--model claude|codex]",
+			Summary:  "Register the current tmux session as an agent.",
+			Help: `Alias precedence: the explicit argument, then $MUSTER_ALIAS, then the tmux
+session name. Captures the calling session's project/pane/socket identity
+from tmux (internal/tmuxenv) so other commands can address it.`,
+			Group:    GroupIdentity,
+			NewFlags: newRegisterFlags,
+			Run:      cmdRegister,
+		},
+		{
+			Name:     "deregister",
+			Synopsis: "deregister [<alias>]",
+			Summary:  "Remove an agent's registration.",
+			Help:     `Alias precedence mirrors register: the explicit argument, then $MUSTER_ALIAS, then the tmux session name. A soft delete (tombstone) — see 'muster gc'.`,
+			Group:    GroupIdentity,
+			Run:      cmdDeregister,
+		},
+		{
+			Name:     "label",
+			Synopsis: "label [<name>] [--clear]",
+			Summary:  "Name or clear the current tmux session's label.",
+			Help:     `Requires a tmux session ($TMUX set). Sets (or, with --clear or a bare 'muster label', clears) this session's addressable label in one command.`,
+			Group:    GroupIdentity,
+			NewFlags: newLabelFlags,
+			Run:      cmdLabel,
+		},
+		{
+			Name:     "gc",
+			Synopsis: "gc [--events-keep <dur>] [--purge-agents]",
+			Summary:  "Reap dead agents and prune old journal events.",
+			Help: `Tombstones every agent whose tmux session is no longer alive (a soft
+delete: identity and read-state survive as history), then prunes journal
+events older than --events-keep (default 720h = 30 days). --purge-agents
+instead hard-deletes every departed or currently-dead agent row —
+irreversible, off by default.`,
+			Group:    GroupIdentity,
+			NewFlags: newGCFlags,
+			Run:      cmdGC,
+		},
+		{
+			Name:     "serve",
+			Synopsis: "serve",
+			Summary:  "Run the daemon (lazy unix-socket API server).",
+			Help: `The daemon speaks newline-delimited JSON over a unix socket
+(internal/proto) and is the one process every other muster command and the
+MCP server talk to. Logs one line to stderr on startup, then blocks until
+SIGINT/SIGTERM.`,
+			Group: GroupPlumbing,
+		},
+		{
+			Name:     "mcp",
+			Synopsis: "mcp",
+			Summary:  "Run the MCP stdio server for coding-agent tool use.",
+			Help: `Exposes the daemon's operations as MCP tools over stdio, for a coding
+agent (Claude Code, Codex, ...) to call directly. stdout is the MCP
+protocol channel — all diagnostics go to stderr.`,
+			Group: GroupPlumbing,
+		},
+		{
+			Name:     "hook",
+			Synopsis: "hook <SessionStart|SessionEnd|Stop> [model]",
+			Summary:  "Session-lifecycle hook entry point for agent harness configs.",
+			Help: `The single entry point an agent harness's hook config (Claude Code,
+Codex, ...) points at directly — not normally typed by hand. SessionStart
+registers, SessionEnd deregisters, Stop checks the calling tmux session's
+inbox and, if there's unread mail, prints decision:block JSON telling the
+agent to drain it. model defaults to "claude" when omitted. Never blocks a
+session: every internal error is swallowed.`,
+			Group: GroupPlumbing,
+			Run:   func(args []string, out io.Writer) error { return cmdHook(args, os.Stdin, out) },
+		},
+		{
+			Name:     "debug",
+			Synopsis: "debug <op> [key=value ...]",
+			Summary:  "Send a raw op to the daemon (dev tool).",
+			Help: `Bypasses muster's own subcommands and calls the daemon directly with an
+arbitrary op and string key=value args, printing the raw JSON response. For
+exploring or debugging the wire protocol — not part of the stable operator
+surface.`,
+			Group: GroupPlumbing,
+		},
+	}
+}
+
+// lookup finds a Registry command by name.
+func lookup(name string) (Command, bool) {
+	for _, c := range Registry {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return Command{}, false
+}
+
+// commandNames returns every registered command name, in Registry order.
+func commandNames() []string {
+	names := make([]string, 0, len(Registry))
+	for _, c := range Registry {
+		names = append(names, c.Name)
+	}
+	return names
+}

--- a/internal/humancli/registry_test.go
+++ b/internal/humancli/registry_test.go
@@ -1,0 +1,124 @@
+package humancli
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// wantCommandNames is muster's full subcommand vocabulary, independent of
+// Registry — a second, hand-maintained list so a future edit that silently
+// drops (or typos) a Registry entry fails a test instead of shipping quietly.
+// Keep this in sync with CLAUDE.md's package-map/usage line and
+// cmd/muster/main.go's routing comment.
+var wantCommandNames = []string{
+	"send", "nudge",
+	"agents", "inbox", "tasks", "events", "watch", "station",
+	"register", "deregister", "label", "gc",
+	"serve", "mcp", "hook", "debug",
+}
+
+// mainOwnedCommands are the Registry names cmd/muster's main() dispatches
+// directly (never through humancli.Dispatch) — they need process-level setup
+// (daemon startup, MCP stdio framing, a one-off raw daemon call) this
+// package deliberately doesn't do. Every other Registry command must have a
+// non-nil Run.
+var mainOwnedCommands = map[string]bool{"serve": true, "mcp": true, "debug": true}
+
+func TestRegistryCompleteness(t *testing.T) {
+	got := append([]string(nil), commandNames()...)
+	want := append([]string(nil), wantCommandNames...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("Registry has %d commands, want %d\ngot:  %v\nwant: %v", len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("Registry command set mismatch:\ngot:  %v\nwant: %v", got, want)
+		}
+	}
+}
+
+// TestRegistryRunNilOnlyForMainOwned enforces the Command.Run contract
+// documented on the type: nil exactly for the three commands main() owns,
+// non-nil (and dispatchable) for every other Registry entry. This is the
+// "switch vs registry" cross-check the CLI-help spec asks for — Dispatch has
+// no separate switch anymore (it walks Registry directly via lookup), so the
+// only place drift could reappear is a Run left nil (or wrongly non-nil).
+func TestRegistryRunNilOnlyForMainOwned(t *testing.T) {
+	for _, c := range Registry {
+		wantNil := mainOwnedCommands[c.Name]
+		gotNil := c.Run == nil
+		if gotNil != wantNil {
+			t.Errorf("%s: Run nil = %v, want %v (mainOwnedCommands = %v)", c.Name, gotNil, wantNil, mainOwnedCommands[c.Name])
+		}
+	}
+}
+
+// TestDispatchUnknownCommandIsUsageError checks the exit-code-2 contract:
+// cmd/muster's main() type-asserts *UsageError to decide 2 vs 1.
+func TestDispatchUnknownCommandIsUsageError(t *testing.T) {
+	err := Dispatch([]string{"bogus"}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error for unknown command")
+	}
+	var ue *UsageError
+	if !errors.As(err, &ue) {
+		t.Fatalf("expected *UsageError, got %T: %v", err, err)
+	}
+}
+
+// TestEveryCommandHelpExitsCleanAndDocumentsSynopsis is table-driven over
+// Registry: `muster <cmd> -h` must succeed (nil error, i.e. exit 0) and its
+// output must contain the command's synopsis — the same guarantee
+// `muster help <cmd>` gives, exercised through the real dispatch path
+// (Command.Run) instead of calling HelpFor directly, so it also proves each
+// command's own flag.ErrHelp/helpRequested interception actually fires.
+func TestEveryCommandHelpExitsCleanAndDocumentsSynopsis(t *testing.T) {
+	for _, c := range Registry {
+		if c.Run == nil {
+			continue // serve/mcp/debug: help-tested at the main package level
+		}
+		t.Run(c.Name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := Dispatch([]string{c.Name, "-h"}, &buf); err != nil {
+				t.Fatalf("%s -h: unexpected error: %v", c.Name, err)
+			}
+			if !strings.Contains(buf.String(), c.Synopsis) {
+				t.Fatalf("%s -h output missing synopsis %q:\n%s", c.Name, c.Synopsis, buf.String())
+			}
+
+			buf.Reset()
+			if err := Dispatch([]string{c.Name, "--help"}, &buf); err != nil {
+				t.Fatalf("%s --help: unexpected error: %v", c.Name, err)
+			}
+			if !strings.Contains(buf.String(), c.Synopsis) {
+				t.Fatalf("%s --help output missing synopsis %q:\n%s", c.Name, c.Synopsis, buf.String())
+			}
+		})
+	}
+}
+
+// TestHelpCommandMatchesDirectFlag checks `muster help <cmd>` renders
+// identically to `muster <cmd> -h`, for every Registry command (main-owned
+// ones included, since `help <cmd>` always routes through HelpFor
+// regardless of who owns Run).
+func TestHelpCommandMatchesDirectFlag(t *testing.T) {
+	for _, c := range Registry {
+		t.Run(c.Name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := Dispatch([]string{"help", c.Name}, &buf); err != nil {
+				t.Fatalf("help %s: unexpected error: %v", c.Name, err)
+			}
+			if !strings.Contains(buf.String(), c.Synopsis) {
+				t.Fatalf("help %s output missing synopsis %q:\n%s", c.Name, c.Synopsis, buf.String())
+			}
+			if !strings.Contains(buf.String(), c.Summary) {
+				t.Fatalf("help %s output missing summary %q:\n%s", c.Name, c.Summary, buf.String())
+			}
+		})
+	}
+}

--- a/internal/humancli/watch.go
+++ b/internal/humancli/watch.go
@@ -1,6 +1,7 @@
 package humancli
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -18,23 +19,52 @@ type watchOpts struct {
 	errw     io.Writer // stderr for retry/reset notes; nil = os.Stderr
 }
 
+// watchFlagVals holds cmdWatch's parsed flag pointers.
+type watchFlagVals struct {
+	agent, kind       *string
+	thread            *int64
+	interval          *time.Duration
+	backlog, width    *int
+	aliases, fullTime *bool
+}
+
+// newWatchFlagsWithVals declares watch's flags and returns typed access to
+// their values — shared by cmdWatch (real parsing) and newWatchFlags
+// (registry help/man rendering).
+func newWatchFlagsWithVals() (*flag.FlagSet, watchFlagVals) {
+	fs := flag.NewFlagSet("watch", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var v watchFlagVals
+	v.agent = fs.String("agent", "", "only events concerning this alias")
+	v.kind = fs.String("kind", "", "only this event kind")
+	v.thread = fs.Int64("thread", 0, "only this thread")
+	v.interval = fs.Duration("interval", time.Second, "poll interval")
+	v.backlog = fs.Int("backlog", 10, "history lines to print before following (0 = none)")
+	v.aliases = fs.Bool("aliases", false, "show raw aliases instead of current labels")
+	v.fullTime = fs.Bool("full-time", false, "show dates, not just times")
+	v.width = fs.Int("width", 0, "line budget in columns (default $COLUMNS or 120)")
+	return fs, v
+}
+
+// newWatchFlags builds watch's flag.FlagSet for registry-driven help/man
+// rendering.
+func newWatchFlags() *flag.FlagSet {
+	fs, _ := newWatchFlagsWithVals()
+	return fs
+}
+
 // cmdWatch tails the bus journal: prints the last --backlog matching events,
 // then polls list_events with the max_id cursor every --interval until
 // interrupted. Side-effect-free: never marks anything read.
 func cmdWatch(args []string, out io.Writer, o watchOpts) error {
-	fs := flag.NewFlagSet("watch", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	agent := fs.String("agent", "", "only events concerning this alias")
-	kind := fs.String("kind", "", "only this event kind")
-	thread := fs.Int64("thread", 0, "only this thread")
-	interval := fs.Duration("interval", time.Second, "poll interval")
-	backlog := fs.Int("backlog", 10, "history lines to print before following (0 = none)")
-	aliases := fs.Bool("aliases", false, "show raw aliases instead of current labels")
-	fullTime := fs.Bool("full-time", false, "show dates, not just times")
-	width := fs.Int("width", 0, "line budget in columns (default $COLUMNS or 120)")
+	fs, v := newWatchFlagsWithVals()
 	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("watch", out)
+		}
 		return fmt.Errorf("usage: muster watch [--agent <alias>] [--thread <id>] [--kind <k>] [--interval <dur>] [--backlog <n>] [--aliases] [--full-time] [--width <cols>]")
 	}
+	agent, kind, thread, interval, backlog, aliases, fullTime, width := v.agent, v.kind, v.thread, v.interval, v.backlog, v.aliases, v.fullTime, v.width
 	if o.errw == nil {
 		o.errw = os.Stderr
 	}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -6,6 +6,11 @@ import (
 	"path/filepath"
 )
 
+// HomeSuffix is Home's path relative to the user's home directory — exported
+// so documentation (the man page's FILES section) can describe the default
+// location without duplicating the literal path segments Home() joins.
+func HomeSuffix() string { return filepath.Join(".local", "share", "muster") }
+
 // Home is the muster data directory (~/.local/share/muster, or $MUSTER_HOME).
 func Home() string {
 	if h := os.Getenv("MUSTER_HOME"); h != "" {
@@ -15,7 +20,7 @@ func Home() string {
 	if err != nil {
 		base = "."
 	}
-	return filepath.Join(base, ".local", "share", "muster")
+	return filepath.Join(base, HomeSuffix())
 }
 
 // DBPath is the SQLite database path.

--- a/internal/station/station.go
+++ b/internal/station/station.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strings"
@@ -40,6 +41,23 @@ func (daemonCaller) Call(op string, args map[string]any) (json.RawMessage, error
 		return nil, fmt.Errorf("marshal %s result: %w", op, err)
 	}
 	return b, nil
+}
+
+// FlagSet declares station's flags, exported so muster's CLI command
+// registry (internal/humancli) can render `muster help station` /
+// `muster station -h` and detect flag.ErrHelp before ever spinning up the
+// full-screen TUI, without keeping a second, driftable copy of the flag
+// list. Run below builds its OWN identical FlagSet rather than calling this
+// one directly, because it needs typed *string/*bool/*int pointers back —
+// keep the two declarations in sync if you touch either.
+func FlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("station", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Duration("interval", time.Second, "poll interval")
+	fs.Bool("aliases", false, "show raw aliases instead of current labels")
+	fs.Int("width", 0, "line budget in columns (default $COLUMNS or 120)")
+	fs.String("alias", "station", "this station's registration alias (so two stations on one machine don't collide)")
+	return fs
 }
 
 // Run parses station's flags, registers its tmux identity on the bus

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,33 @@
+// Package version holds muster's build-time version stamp. It exists so
+// exactly one pair of variables gets the -ldflags -X treatment — cmd/muster,
+// the justfile, and .github/workflows/release.yml all target
+// github.com/schuettc/muster/internal/version.{version,commit} rather than
+// three copies scattered across main packages.
+package version
+
+// version and commit are overwritten at build time via:
+//
+//	-ldflags "-X github.com/schuettc/muster/internal/version.version=$(cat VERSION) \
+//	          -X github.com/schuettc/muster/internal/version.commit=$(git rev-parse --short HEAD)"
+//
+// A plain `go build` / `go run` (no ldflags — local dev, `go test`, an
+// unstamped checkout) leaves them at these defaults, so `muster version`
+// still prints something sane: "muster dev (none)".
+var (
+	version = "dev"
+	commit  = "none"
+)
+
+// Version returns the stamped version ("dev" if the binary wasn't built with
+// the ldflags above).
+func Version() string { return version }
+
+// Commit returns the stamped short commit hash ("none" if unstamped).
+func Commit() string { return commit }
+
+// Line formats muster's canonical one-line version banner, e.g.
+// "muster 0.6.0 (a1b2c3d)". This is the single formatting function so both
+// `muster version` and `muster --version` render identically.
+func Line() string {
+	return "muster " + version + " (" + commit + ")"
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,34 @@
+package version
+
+import "testing"
+
+// TestLine exercises the formatting function directly by swapping the
+// package-level vars — this is what a real ldflags-stamped build looks like
+// without needing a build-tag'd or ldflags'd test binary (which would be
+// overkill for a one-line format function).
+func TestLine(t *testing.T) {
+	origVersion, origCommit := version, commit
+	t.Cleanup(func() { version, commit = origVersion, origCommit })
+
+	version, commit = "1.2.3", "abc1234"
+	if got, want := Line(), "muster 1.2.3 (abc1234)"; got != want {
+		t.Fatalf("Line() = %q, want %q", got, want)
+	}
+	if Version() != "1.2.3" {
+		t.Fatalf("Version() = %q, want 1.2.3", Version())
+	}
+	if Commit() != "abc1234" {
+		t.Fatalf("Commit() = %q, want abc1234", Commit())
+	}
+}
+
+// TestLineDefaults checks the unstamped-build fallback wording.
+func TestLineDefaults(t *testing.T) {
+	origVersion, origCommit := version, commit
+	t.Cleanup(func() { version, commit = origVersion, origCommit })
+
+	version, commit = "dev", "none"
+	if got, want := Line(), "muster dev (none)"; got != want {
+		t.Fatalf("Line() = %q, want %q", got, want)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -1,6 +1,13 @@
 # muster developer tasks — the SAME targets CI runs, so local and CI can't drift.
 set shell := ["bash", "-uc"]
 
+# Version stamp: cmd/muster, justfile, and .github/workflows/release.yml all
+# target the SAME internal/version vars via -ldflags -X, so a local `just
+# build`, `just verify`, and a release build report the same thing.
+version := `cat VERSION`
+commit := `git rev-parse --short HEAD 2>/dev/null || echo none`
+ldflags := "-X github.com/schuettc/muster/internal/version.version=" + version + " -X github.com/schuettc/muster/internal/version.commit=" + commit
+
 # Format code.
 fmt:
     gofmt -w .
@@ -19,14 +26,14 @@ test:
 
 # Build the binary.
 build:
-    CGO_ENABLED=0 go build -o bin/muster ./cmd/muster
+    CGO_ENABLED=0 go build -ldflags "{{ ldflags }}" -o bin/muster ./cmd/muster
 
 # Cross-compile all release targets (no output, fail fast).
 cross:
     set -e; \
     for goos in darwin linux; do \
       for goarch in arm64 amd64; do \
-        CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build -o /dev/null ./cmd/muster; \
+        CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build -ldflags "{{ ldflags }}" -o /dev/null ./cmd/muster; \
       done; \
     done
 

--- a/site/index.html
+++ b/site/index.html
@@ -33,10 +33,13 @@
     --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     --maxw: 60rem;
     --radius: 12px;
+    --danger-d: #e5484d;
+    --danger-l: #c22a2a;
 
     --bg: var(--ink); --surface: var(--ink-2); --surface-2: var(--ink-3);
     --text: var(--fg-d); --muted: var(--muted-d); --line: var(--line-d);
     --signal: var(--signal-d); --signal-soft: rgba(235,166,63,.12); --sock: var(--sock-d);
+    --danger: var(--danger-d);
     --shadow: 0 1px 0 rgba(255,255,255,.03), 0 18px 40px -24px rgba(0,0,0,.7);
   }
   @media (prefers-color-scheme: light) {
@@ -44,6 +47,7 @@
       --bg: var(--paper); --surface: var(--paper-2); --surface-2: #eef0f4;
       --text: var(--fg-l); --muted: var(--muted-l); --line: var(--line-l);
       --signal: var(--signal-l); --signal-soft: rgba(176,111,20,.10); --sock: var(--sock-l);
+      --danger: var(--danger-l);
       --shadow: 0 1px 0 rgba(0,0,0,.02), 0 18px 40px -28px rgba(20,22,29,.28);
     }
   }
@@ -51,12 +55,14 @@
     --bg: var(--ink); --surface: var(--ink-2); --surface-2: var(--ink-3);
     --text: var(--fg-d); --muted: var(--muted-d); --line: var(--line-d);
     --signal: var(--signal-d); --signal-soft: rgba(235,166,63,.12); --sock: var(--sock-d);
+    --danger: var(--danger-d);
     --shadow: 0 1px 0 rgba(255,255,255,.03), 0 18px 40px -24px rgba(0,0,0,.7);
   }
   :root[data-theme="light"] {
     --bg: var(--paper); --surface: var(--paper-2); --surface-2: #eef0f4;
     --text: var(--fg-l); --muted: var(--muted-l); --line: var(--line-l);
     --signal: var(--signal-l); --signal-soft: rgba(176,111,20,.10); --sock: var(--sock-l);
+    --danger: var(--danger-l);
     --shadow: 0 1px 0 rgba(0,0,0,.02), 0 18px 40px -28px rgba(20,22,29,.28);
   }
 
@@ -96,6 +102,7 @@
   .term-bar .title { margin-left: auto; letter-spacing: .04em; }
   .term pre { margin: 0; padding: 1.1rem 1.25rem 1.3rem; overflow-x: auto; font-family: var(--mono); font-size: .84rem; line-height: 1.7; color: var(--text); font-variant-numeric: tabular-nums; }
   .c-dim { color: var(--muted); } .c-sig { color: var(--signal); font-weight: 600; } .c-you { color: var(--wire); }
+  .c-bad { color: var(--danger); font-weight: 600; }
   .live, .mail { color: var(--signal); } .mail { font-weight: 600; }
   .pulse { display: inline-block; animation: pulse 1.9s ease-in-out infinite; }
   @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
@@ -134,6 +141,12 @@
   .adr .k { font-family: var(--mono); font-size: .82rem; color: var(--signal); }
   .adr .d { color: var(--text); font-size: .96rem; }
   .adr .d .m { color: var(--muted); }
+
+  /* CLI reference — same row2 layout as addressing rows, wider key column
+     for full command signatures */
+  .cliref .row2 { grid-template-columns: 1fr; }
+  @media (min-width: 44rem) { .cliref .row2 { grid-template-columns: 15rem 1fr; } }
+  .cliref .k { font-size: .8rem; }
 
   .tabs { display: flex; flex-wrap: wrap; gap: .55rem; margin: 0 0 1.5rem; }
   .tab { font-family: var(--mono); font-size: .8rem; border: 1px solid var(--line); border-radius: 7px; padding: .42rem .7rem; color: var(--muted); background: var(--surface); }
@@ -244,6 +257,8 @@
   <a href="#flow">the flow</a>
   <a href="#what">what it is</a>
   <a href="#tools">the tools</a>
+  <a href="#station">station</a>
+  <a href="#cli">the cli</a>
   <a href="#mailbox">tmux &amp; mailbox</a>
   <a href="#hooks">hooks</a>
   <a href="#wake">wake</a>
@@ -488,6 +503,96 @@ api-2   reply  <span class="c-sig">"fixed — createdAt added"</span>
   </div>
 </section>
 
+<section id="station">
+  <div class="wrap">
+    <p class="kicker">station</p>
+    <h2>The operator gets a station.</h2>
+    <p class="lead"><code style="font-family:var(--mono)">muster station</code> is the full-screen operator TUI for the whole bus. You drill down — projects, then a project's agents, then an agent's threads, then the conversation itself — and act from wherever you're standing: send, reply, or nudge without leaving the screen. Station also has its own mailbox page (<code style="font-family:var(--mono)">m</code>), listing mail addressed to the operator, unread and read history both.</p>
+
+    <div class="term">
+      <div class="term-bar"><span class="lamp"></span><span class="lamp"></span><span class="lamp"></span><span class="title">~ muster station</span></div>
+<pre><span class="c-dim">muster</span> <span class="c-dim">›</span> bettor-help <span class="c-dim">›</span> datalake
+
+<span class="c-dim">  ID  INTENT        WHO                   AGE   SUBJECT</span>
+  41  <span class="c-bad">needs action</span>  operator→datalake     2m    migration script is stuck on a lock
+  38  <span class="c-sig">wants reply</span>   datalake→operator     51m   does this schema diff look right to you?
+  22  <span class="c-dim">fyi</span>           ci→datalake           3h    nightly backfill finished clean
+
+<span class="c-dim">── thread #41 ──────────────────────────────────────────</span>
+operator   <span class="c-dim">2m ago</span>    migration script has been running 40 minutes — stuck, or just slow?
+datalake   <span class="c-dim">just now</span>  looks like a lock wait on the migrations table, checking now.
+</pre>
+    </div>
+    <p class="lifecycle"><b>Enter</b> opens · <b>Esc</b> back · <b>g</b> home · <b>m</b> mailbox · <b>s</b> send · <b>r</b> reply · <b>n</b> nudge · <b>/</b> filter · <b>q</b> quit</p>
+  </div>
+</section>
+
+<section id="cli">
+  <div class="wrap">
+    <p class="kicker">the cli</p>
+    <h2>Every command, from any shell.</h2>
+    <p class="lead">Agents coordinate over the MCP tools above. The CLI is the same bus, for humans and for hooks — every operation the daemon supports is reachable from a plain subcommand, not just the eleven MCP tools.</p>
+    <div class="adr cliref">
+      <div class="row2">
+        <span class="k">muster serve</span>
+        <span class="d">Runs the daemon in the foreground. You don't normally start it yourself — the CLI and the MCP server both spawn it automatically the first time anything touches the bus — so run this by hand only when you want to watch its log.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster mcp</span>
+        <span class="d">Serves the bus over stdio as an MCP server. This is the command each agent registers with its MCP client, and the source of the eleven coordination tools.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster station</span>
+        <span class="d">Opens the full-screen operator TUI described in the <a href="#station">station section above</a> — projects, agents, threads, and the conversation, with send, reply, and nudge built in.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster agents</span>
+        <span class="d">Prints the roster: every registered agent's project, alias, label, model, and whether its tmux session is currently live.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster inbox &lt;target&gt;</span>
+        <span class="d">Prints one agent's threads — everything addressed to it or started by it, with kind, status, and unread count. <span class="m"><code>muster tasks &lt;target&gt;</code> prints the same inbox filtered down to threads that are tasks.</span></span>
+      </div>
+      <div class="row2">
+        <span class="k">muster send &lt;target&gt; "…" --from &lt;alias&gt;</span>
+        <span class="d">Sends a message. <code>--intent fyi|reply-requested|action-requested</code> tags what kind of response it expects, <code>--subject</code> and <code>--ref</code> attach a subject line and a pointer to the work, <code>--role</code> treats the target as a role rather than an alias, and <code>--broadcast</code> sends to everyone instead of one target.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster nudge &lt;target&gt; [--no-submit]</span>
+        <span class="d">Wakes an idle agent right now by typing "check your inbox" into its tmux pane and pressing Enter — this is the only muster command that ever types into a pane. <code>--no-submit</code> types the line without pressing Enter, so you can edit it first.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster label &lt;name&gt;</span>
+        <span class="d">Pins an addressable name on the current tmux session, so <code>send &lt;name&gt; "…"</code> reaches it from then on. <span class="m"><code>muster label --clear</code> removes it. Both require running inside tmux.</span></span>
+      </div>
+      <div class="row2">
+        <span class="k">muster register [alias] / muster deregister [alias]</span>
+        <span class="d">Join or leave the bus by hand — the alias defaults to the current tmux session's name if you don't pass one. <code>register</code> also takes <code>--role &lt;role&gt;</code> and <code>--model &lt;claude|codex&gt;</code>. Session hooks call both of these for you; see below.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster gc [--purge-agents] [--events-keep &lt;dur&gt;]</span>
+        <span class="d">Tombstones every agent whose tmux session is gone — soft-deleted, kept as history — and prunes journal rows older than <code>--events-keep</code> (default 720h). <code>--purge-agents</code> hard-deletes departed or dead agent rows instead of tombstoning them; that step is irreversible.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster events [--agent] [--kind] [--thread] [--limit]</span>
+        <span class="d">Prints the bus journal after the fact — every send, reply, task change, nudge, and mailbox notify, newest activity last. Any of the filters can narrow it to one agent, one event kind, or one thread.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster watch</span>
+        <span class="d">The same journal as <code>muster events</code>, but live: prints recent backlog, then follows the bus and prints each new event as it happens until you interrupt it. <span class="m">Takes the same <code>--agent</code>/<code>--kind</code>/<code>--thread</code> filters plus <code>--interval</code> for the poll rate.</span></span>
+      </div>
+      <div class="row2">
+        <span class="k">muster hook &lt;event&gt; &lt;model&gt;</span>
+        <span class="d">The binary acting as its own session hook, wired into your agent harness's lifecycle config. <b>SessionStart</b> registers the session, <b>Stop</b> checks for unread mail at the end of a turn and tells the agent to go read it, and <b>SessionEnd</b> deregisters. See the <a href="#hooks">hooks section</a> for the exact config.</span>
+      </div>
+      <div class="row2">
+        <span class="k">muster debug &lt;op&gt; [key=value …]</span>
+        <span class="d">Sends one raw daemon operation with string key=value arguments and prints the raw JSON response — the escape hatch behind the claim above: every daemon operation is reachable from the CLI, including ones with no dedicated subcommand.</span>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section id="mailbox">
   <div class="wrap">
     <p class="kicker">tmux &amp; the mailbox</p>
@@ -691,7 +796,7 @@ set -ga status-left <span class="c-sig">'#{?@muster_inbox,#[fg=colour0#,bg=colou
         }
       });
     }, { rootMargin: '-40% 0px -55% 0px' });
-    ['top', 'what', 'flow', 'tools', 'mailbox', 'hooks', 'wake', 'setup'].forEach(function (id) {
+    ['top', 'what', 'flow', 'tools', 'station', 'cli', 'mailbox', 'hooks', 'wake', 'setup'].forEach(function (id) {
       var el = document.getElementById(id);
       if (el) { obs.observe(el); }
     });


### PR DESCRIPTION
Promotes dev to main: the muster.tools station section + full CLI reference (#43) and the CLI command registry driving help/usage/version/man (#44).

No VERSION change — no release fires; the site redeploys on merge. The man page and stamped `muster version` ship with the next VERSION bump.