### PR TITLE
site: statusbar nav across pages + llms.txt

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,10 +1,10 @@
 name: deploy-site
 
 # Deploys muster.tools from the repo: the landing page (site/index.html), the
-# docs page (site/docs/index.html), their shared style.css/site.js, and the
-# root install.sh (served at https://muster.tools/install.sh). Runs on every
-# merge to main that touches the site or the installer — no manual deploy
-# steps.
+# docs page (site/docs/index.html), their shared style.css/site.js, the
+# llms.txt summary for LLM tooling, and the root install.sh (served at
+# https://muster.tools/install.sh). Runs on every merge to main that touches
+# the site or the installer — no manual deploy steps.
 on:
   push:
     branches: [main]
@@ -35,6 +35,7 @@ jobs:
           cp site/style.css dist/
           cp site/site.js dist/
           cp site/docs/index.html dist/docs/
+          cp site/llms.txt dist/
           cp install.sh dist/
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -15,9 +15,17 @@
 
 <div class="statusbar">
   <div class="wrap">
-    <span><span class="dot">●</span> <a href="/"><b>muster</b></a> &nbsp;·&nbsp; docs</span>
-    <span>local <span class="dot">·</span> MIT
-      &nbsp; <button class="theme-toggle" id="tt" aria-label="Toggle color theme">theme</button></span>
+    <div class="sb-left">
+      <a class="sb-brand" href="/"><span class="dot">●</span> <b>muster</b></a>
+      <nav class="sb-nav" aria-label="Site">
+        <a href="/docs/" class="active" aria-current="page">docs</a>
+        <a href="https://github.com/schuettc/muster">github</a>
+      </nav>
+    </div>
+    <span class="sb-meta">
+      <span class="sb-meta-text">local <span class="dot">·</span> MIT</span>
+      &nbsp; <button class="theme-toggle" id="tt" aria-label="Toggle color theme">theme</button>
+    </span>
   </div>
 </div>
 
@@ -180,7 +188,7 @@ set -ga status-left <span class="c-sig">'#{?@muster_inbox,#[fg=colour0#,bg=colou
 
 <footer>
   <div class="wrap foot">
-    <span><span class="mm">muster</span> · docs — <a href="/">back to the landing page</a></span>
+    <span><span class="mm">muster</span> · docs</span>
     <span>
       <a href="https://github.com/schuettc/muster">GitHub</a> &nbsp;·&nbsp;
       <a href="https://github.com/schuettc/muster/releases">Releases</a> &nbsp;·&nbsp;

--- a/site/index.html
+++ b/site/index.html
@@ -15,9 +15,17 @@
 
 <div class="statusbar">
   <div class="wrap">
-    <span><span class="dot">●</span> <b>muster</b> &nbsp;·&nbsp; local agent bus</span>
-    <span>local <span class="dot">·</span> MIT
-      &nbsp; <button class="theme-toggle" id="tt" aria-label="Toggle color theme">theme</button></span>
+    <div class="sb-left">
+      <a class="sb-brand" href="/"><span class="dot">●</span> <b>muster</b></a>
+      <nav class="sb-nav" aria-label="Site">
+        <a href="/docs/">docs</a>
+        <a href="https://github.com/schuettc/muster">github</a>
+      </nav>
+    </div>
+    <span class="sb-meta">
+      <span class="sb-meta-text">local <span class="dot">·</span> MIT</span>
+      &nbsp; <button class="theme-toggle" id="tt" aria-label="Toggle color theme">theme</button>
+    </span>
   </div>
 </div>
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,55 @@
+# muster
+
+> muster is a local coordination bus for coding agents: independent coding-agent
+> sessions (Claude Code, Codex, and any other MCP client) register on a shared bus
+> and send messages or hand off tasks to each other. It ships as a single static
+> Go binary running in three modes — a daemon over a unix socket, a stdio MCP
+> server, and a human CLI — is tmux-native for agent identity, liveness, and mail
+> notification, and never calls a model itself; it only routes between agent
+> sessions that are already running on their own.
+
+## Docs
+
+- [muster.tools](https://muster.tools/): landing page — the pitch, the message-flow walkthrough, and the MCP tool groups.
+- [muster.tools/docs/](https://muster.tools/docs/): full reference — every CLI command with its flags, the tmux mailbox, session hooks, and the three ways an agent notices mail.
+- [github.com/schuettc/muster](https://github.com/schuettc/muster): source repository.
+- [README.md](https://raw.githubusercontent.com/schuettc/muster/main/README.md): project README, raw Markdown.
+- [install.sh](https://muster.tools/install.sh): shell installer for the prebuilt binary.
+
+## CLI
+
+Talk:
+- `send` — send a message to an agent, role, or everyone.
+- `nudge` — type a check-inbox nudge into an agent's tmux pane.
+
+Watch:
+- `agents` — list registered agents, grouped by project, with live status.
+- `inbox` — show an agent's threads.
+- `tasks` — show an agent's task threads.
+- `events` — print the bus journal, oldest first.
+- `watch` — tail the bus journal live.
+- `station` — full-screen operator TUI for the bus.
+
+Identity:
+- `register` — register the current tmux session as an agent.
+- `deregister` — remove an agent's registration.
+- `label` — name or clear the current tmux session's label.
+- `gc` — reap dead agents and prune old journal events.
+
+Plumbing:
+- `serve` — run the daemon (lazy unix-socket API server).
+- `mcp` — run the MCP stdio server for coding-agent tool use.
+- `hook` — session-lifecycle hook entry point for agent harness configs.
+- `debug` — send a raw op to the daemon (dev tool).
+
+## Setup
+
+Install the binary — either `curl -fsSL https://muster.tools/install.sh | sh` for a
+prebuilt binary, or `go install github.com/schuettc/muster/cmd/muster@latest` from
+source. Then register the MCP server with each agent: `claude mcp add muster -s
+user -- muster mcp` for Claude Code, `codex mcp add muster -- muster mcp` for
+Codex, or point any other MCP client at `muster mcp` over stdio. Finally, in each
+tmux session, get the agent onto the bus — ask it once to register (it calls its
+`register_agent` tool), or install the `SessionStart`/`Stop`/`SessionEnd` hooks
+described in the docs so it registers automatically and handles its own mail at
+turn end.

--- a/site/style.css
+++ b/site/style.css
@@ -66,6 +66,19 @@ a { color: var(--signal); }
 .theme-toggle { font: inherit; color: var(--muted); background: transparent; border: 1px solid var(--line); border-radius: 6px; padding: .25rem .6rem; cursor: pointer; letter-spacing: .1em; }
 .theme-toggle:hover { color: var(--text); border-color: var(--muted); }
 
+/* statusbar cross-page nav — brand + docs/github links, left-adjacent */
+.sb-left { display: flex; align-items: center; gap: 1.15rem; min-width: 0; }
+.sb-brand { display: inline-flex; align-items: center; gap: .35em; flex-shrink: 0; }
+.sb-nav { display: flex; align-items: center; gap: .95rem; }
+.sb-nav a { color: var(--muted); text-decoration: none; }
+.sb-nav a:hover, .sb-nav a:focus-visible { color: var(--text); text-decoration: underline; }
+.sb-nav a.active { color: var(--text); }
+.sb-meta { display: flex; align-items: center; flex-shrink: 0; }
+@media (max-width: 30rem) {
+  .sb-meta-text { display: none; }
+  .sb-nav { gap: .7rem; }
+}
+
 .hero { padding: clamp(3.25rem, 8vw, 5.5rem) 0 2.5rem; }
 .eyebrow { font-family: var(--mono); font-size: .78rem; letter-spacing: .15em; text-transform: uppercase; color: var(--signal); margin: 0 0 1.3rem; }
 .wordmark { font-family: var(--mono); font-weight: 600; font-size: clamp(2.5rem, 8vw, 4.2rem); letter-spacing: -.02em; margin: 0; line-height: 1; }


### PR DESCRIPTION
Operator-previewed:

- **Statusbar nav on both pages** — `● muster` links home, with `docs` and `github` alongside; the current page renders active (`aria-current`). Styling lives once in the shared stylesheet; the right-side meta text hides under 30rem so the bar stays one row on phones. The docs footer back-link text was simplified since the nav now covers it.
- **`/llms.txt`** — llmstxt.org-convention summary: project blockquote, doc/source/install links, the grouped CLI list with one-liners (cross-checked against the docs page), and the three-step setup. Wired into the pages assemble step.