### PR TITLE
fix(release): stamp version/commit into signed darwin binaries

### DIFF
--- a/contrib/release-sign.sh
+++ b/contrib/release-sign.sh
@@ -23,11 +23,16 @@ echo "signing as: $identity"
 # rebuild the darwin binaries from the tag so we sign exactly the released code
 src="$work/src"
 git clone --quiet --depth 1 --branch "$tag" "https://github.com/$repo" "$src"
+# stamp version/commit exactly as release.yml does, so signed binaries don't
+# regress `muster version` to "dev (none)"
+version="${tag#v}"
+commit="$(cd "$src" && git rev-parse --short HEAD)"
+ldflags="-s -w -X github.com/schuettc/muster/internal/version.version=${version} -X github.com/schuettc/muster/internal/version.commit=${commit}"
 for arch in arm64 amd64; do
   dir="$work/muster_darwin_${arch}"
   mkdir -p "$dir"
   (cd "$src" && CGO_ENABLED=0 GOOS=darwin GOARCH="$arch" \
-    go build -trimpath -ldflags "-s -w" -o "$dir/muster" ./cmd/muster)
+    go build -trimpath -ldflags "$ldflags" -o "$dir/muster" ./cmd/muster)
   codesign --sign "$identity" --options runtime --timestamp --force "$dir/muster"
   ditto -c -k --keepParent "$dir/muster" "$work/notarize_${arch}.zip"
   xcrun notarytool submit "$work/notarize_${arch}.zip" \


### PR DESCRIPTION
contrib/release-sign.sh rebuilds the darwin binaries from the tag so it signs
exactly the released code — but it built with plain `-s -w` ldflags, missing
the `-X internal/version.{version,commit}` stamping release.yml applies. Result:
the signed darwin assets for v0.7.0 reported `muster dev (none)` while CI's
linux assets reported `0.7.0`. First release bitten, since the version registry
work only just shipped.

Fix mirrors release.yml exactly: version from the tag name, commit from the
tag clone's HEAD. Verified by re-running the fixed script against v0.7.0 —
the re-signed arm64 binary now reports `muster 0.7.0 (<commit>)`.

https://claude.ai/code/session_012bn53mhidGCz7smvJBE5fp