### PR TITLE
promote: pane-ownership docs trim + station race-flake test fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,14 +247,11 @@ The muster binary is its own hook — point your harness at `muster hook <event>
 <model>` (e.g. `muster hook Stop claude`). Copy-paste config for both Claude
 Code and Codex is in [`contrib/`](contrib/README.md).
 
-**Pane ownership.** Harnesses often spawn subagents as sibling panes in the
-same tmux session, running the same hooks. Hook events therefore act only when
-the calling pane owns the session's registered identity — first live claimant
-wins (normally your main conversation); later panes no-op instead of stealing
-the registration, draining the primary's mail, or deregistering it on exit. A
-dead owner's pane is taken over on the next SessionStart (a normal restart),
-and the explicit `muster register` / `muster deregister` commands are never
-gated — typing a command overrides.
+**Pane ownership.** Only the session's primary agent pane acts on these
+hooks — a second Claude in the same tmux session (e.g. a spawned subagent)
+won't register, drain mail, or deregister. To move the identity deliberately,
+run `muster register` from the pane that should own it — the explicit
+commands always override.
 
 ## License
 

--- a/internal/station/station_test.go
+++ b/internal/station/station_test.go
@@ -60,6 +60,16 @@ func stubTmuxAlive(t *testing.T, aliveSocket, aliveSessionID string) {
 	t.Cleanup(func() { tmuxenv.Run = prev })
 }
 
+// stubTmuxAllAlive makes every has-session probe answer "alive", for tests
+// where any observed collision must be treated as live (defer to it) rather
+// than dead (take it over).
+func stubTmuxAllAlive(t *testing.T) {
+	t.Helper()
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(...string) (string, error) { return "", nil }
+	t.Cleanup(func() { tmuxenv.Run = prev })
+}
+
 var errNoSuchSession = &stationTestError{"can't find session"}
 
 type stationTestError struct{ msg string }
@@ -435,11 +445,15 @@ func TestDepartedAgentSurvivesUnderTheBar(t *testing.T) {
 // TestRegisterStationIfAbsentRaceFailsOverToNextSuffix covers the T7-deferred
 // CAS race directly: two registerStation calls racing onto the SAME fresh
 // alias concurrently must never both believe they won — the loser must fail
-// over to "station-2" via the if_absent conflict path rather than either
-// silently overwriting the other or erroring out.
+// over to "station-2", either via the if_absent conflict path (both probed
+// before either registered) or via the live-collision probe path (one probed
+// after the other registered). Both racers' tuples must read as ALIVE here:
+// with a dead-everything stub, a racer observing the other's fresh
+// registration takes the dead-takeover path and clobbers it by design —
+// that's the flake #54 chased, not a CAS hole.
 func TestRegisterStationIfAbsentRaceFailsOverToNextSuffix(t *testing.T) {
 	startStationTestDaemon(t)
-	stubTmuxAlive(t, "", "") // nothing is alive; irrelevant (both starts see "not found")
+	stubTmuxAllAlive(t) // every tuple alive: collisions defer, never take over
 	caller := daemonCaller{}
 
 	c1 := tmuxenv.Capture{SocketPath: "/s1", SessionID: "$1", SessionName: "sess1", PaneID: "%1"}


### PR DESCRIPTION
Promotes dev to main: PR #56 (README pane-ownership trim) and PR #57
(fix #54 — station race test stubs racer tuples as alive so observed
collisions defer instead of dead-taking-over). VERSION unchanged (0.7.1);
no release fires.

https://claude.ai/code/session_012bn53mhidGCz7smvJBE5fp