### PR TITLE
fix(label): sync muster label to the store so CLI and MCP resolve identically

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -32,6 +32,7 @@ type storeAPI interface {
 	GetAgent(alias string) (store.Agent, bool, error)
 	DepartAgent(alias string) error
 	DepartStaleSiblings(socketPath, sessionID string, created int64, keepAlias string) ([]string, error)
+	SetSessionLabel(socketPath, sessionID, label string, manual bool) (int64, error)
 	DeleteAgent(alias string) error
 	CreateThread(t store.Thread, firstBody string) (int64, error)
 	AppendEntry(threadID int64, fromAgent, body, statusChange string) (int64, error)
@@ -661,6 +662,17 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			d.reconcileBadge(old.SocketPath, old.SessionID)
 		}
 		return ok(nil)
+	case "set_label":
+		// The bus-side half of `muster label` (see store.SetSessionLabel):
+		// the CLI has already written the live tmux option; this lands the
+		// same value in the store so the daemon's resolver (which never
+		// re-reads tmux) agrees with the CLI's live-label resolution
+		// immediately, not at the next register_agent upsert.
+		n, err := d.s.SetSessionLabel(str(a, "socket_path"), str(a, "session_id"), str(a, "label"), boolArg(a, "label_manual"))
+		if err != nil {
+			return fail(err)
+		}
+		return ok(map[string]any{"updated": n})
 	case "purge_agent":
 		// The explicit, irreversible hard-delete: `muster gc --purge-agents`'s
 		// own op, distinct from deregister_agent's tombstone. Identity,

--- a/internal/daemon/resolve.go
+++ b/internal/daemon/resolve.go
@@ -16,9 +16,13 @@ import "github.com/schuettc/muster/internal/resolve"
 //
 // The daemon builds resolve.Candidate from store.Agent's STORED
 // label/label_manual, never a live tmux re-read — internal/daemon is
-// tmux-agnostic by rule (CLAUDE.md), so a label change only takes effect
-// here once the owning agent's next register_agent upsert lands it in the
-// store, exactly as every other daemon-side view of label already works.
+// tmux-agnostic by rule (CLAUDE.md). The stored copy is kept current by the
+// writers: `muster label` pushes its change here via the set_label op in the
+// same command that sets the tmux option (see humancli.syncLabelToBus), and
+// register_agent's upsert re-captures it — so this resolver and the CLI's
+// live-tmux resolver see the same manual labels, not eventually-consistent
+// ones. (A label written by raw tmux set-option, bypassing muster, still
+// only lands at the next register.)
 func (d *Daemon) resolveAgentTarget(from, given string) (string, error) {
 	agents, err := d.s.ListAgents()
 	if err != nil {

--- a/internal/daemon/set_label_test.go
+++ b/internal/daemon/set_label_test.go
@@ -1,0 +1,88 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSetLabelMakesLabelResolvableImmediately pins the CLI/MCP consistency
+// contract (see resolveAgentTarget's doc comment): after `muster label`
+// pushes a set_label op, an MCP-path sender resolving the label against the
+// STORE must land on the same alias a CLI sender resolving against live tmux
+// would — immediately, not at the session's next re-register.
+func TestSetLabelMakesLabelResolvableImmediately(t *testing.T) {
+	sock := startWithNotifier(t, &fakeNotifier{})
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "workspace-2", "socket_path": "/s", "session_id": "$0",
+		"project": "bettor-help-workspace",
+	})
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/s", "session_id": "$7",
+		"project": "bettor-help-workspace",
+	})
+
+	// Before the sync: the stored label is blank, so the label must NOT
+	// resolve for a daemon-path sender.
+	pre := call(t, sock, "send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "datalake", "body": "hi",
+	})
+	if pre.OK {
+		t.Fatalf("label must not resolve before set_label lands it in the store: %+v", pre)
+	}
+
+	resp := call(t, sock, "set_label", map[string]any{
+		"socket_path": "/s", "session_id": "$0",
+		"label": "datalake", "label_manual": true,
+	})
+	if !resp.OK {
+		t.Fatalf("set_label: %+v", resp)
+	}
+	data, _ := json.Marshal(resp.Data)
+	var out struct {
+		Updated int64 `json:"updated"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil || out.Updated != 1 {
+		t.Fatalf("set_label updated = %s (err %v), want 1", data, err)
+	}
+
+	post := call(t, sock, "send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "datalake", "body": "hi",
+	})
+	if !post.OK {
+		t.Fatalf("label must resolve immediately after set_label: %+v", post)
+	}
+	th := getThreadForTest(t, sock, threadIDOf(t, post))
+	if th.ToTarget != "workspace-2" {
+		t.Fatalf("resolved target = %q, want workspace-2", th.ToTarget)
+	}
+
+	// Clearing withdraws addressability again.
+	call(t, sock, "set_label", map[string]any{
+		"socket_path": "/s", "session_id": "$0", "label": "", "label_manual": false,
+	})
+	cleared := call(t, sock, "send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "datalake", "body": "hi",
+	})
+	if cleared.OK {
+		t.Fatalf("a cleared label must stop resolving: %+v", cleared)
+	}
+}
+
+// getThreadForTest fetches one thread's header via the get_thread op.
+func getThreadForTest(t *testing.T, sock string, id int64) (th struct {
+	ToTarget string `json:"to_target"`
+}) {
+	t.Helper()
+	resp := call(t, sock, "get_thread", map[string]any{"thread_id": id})
+	data, _ := json.Marshal(resp.Data)
+	var out struct {
+		Thread struct {
+			ToTarget string `json:"to_target"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("get_thread %d: %v (%s)", id, err, data)
+	}
+	th.ToTarget = out.Thread.ToTarget
+	return th
+}

--- a/internal/humancli/label.go
+++ b/internal/humancli/label.go
@@ -31,6 +31,12 @@ func newLabelFlags() *flag.FlagSet {
 // (or clearing) the current tmux session's label in one command, in place of
 // the two tmux set-option incantations an operator would otherwise type by
 // hand. It requires $TMUX (there is no "current session" outside tmux).
+//
+// The tmux option is only half the write: the daemon's resolver reads the
+// STORED label (it is tmux-agnostic by rule), so cmdLabel also pushes the
+// change to the bus via the set_label op (see syncLabelToBus). Without that
+// push, a CLI sender resolving against live tmux and an MCP sender resolving
+// against the store would disagree until the session's next re-register.
 func cmdLabel(args []string, out io.Writer) error {
 	fs, clearFlag := newLabelFlagsWithVals()
 	if err := fs.Parse(args); err != nil {
@@ -57,6 +63,7 @@ func cmdLabel(args []string, out io.Writer) error {
 			return err
 		}
 		_ = tmuxenv.RefreshClient() // best-effort: repaint title bars
+		syncLabelToBus(out, "", false)
 		_, err := fmt.Fprintln(out, "label cleared")
 		return err
 	}
@@ -67,6 +74,30 @@ func cmdLabel(args []string, out io.Writer) error {
 		return err
 	}
 	_ = tmuxenv.RefreshClient() // best-effort: repaint title bars
+	syncLabelToBus(out, name, true)
 	_, err := fmt.Fprintf(out, "labeled this session %q (%s)\n", name, opt)
 	return err
+}
+
+// syncLabelToBus lands the just-written tmux label in the store via the
+// set_label op, for every alias registered to the ambient session, so the
+// daemon's tmux-agnostic resolver agrees with live tmux immediately. The
+// tmux option is already set when this runs, and that option is the source
+// of truth the store mirrors — so a failed push degrades to the OLD
+// behavior (stored copy refreshes at the next register_agent), never a
+// wrong label. It therefore warns rather than fails, and stays silent for
+// a session with no registered agents (updated=0): labeling before
+// registering is routine, and register captures the option anyway.
+func syncLabelToBus(out io.Writer, label string, manual bool) {
+	socket := tmuxenv.SocketFromEnv()
+	sessionID := tmuxenv.CurrentSessionID()
+	if socket == "" || sessionID == "" {
+		return
+	}
+	if _, err := callData("set_label", map[string]any{
+		"socket_path": socket, "session_id": sessionID,
+		"label": label, "label_manual": manual,
+	}); err != nil {
+		_, _ = fmt.Fprintf(out, "warning: bus label sync failed (%v); the stored label refreshes on this session's next register\n", err)
+	}
 }

--- a/internal/humancli/label_test.go
+++ b/internal/humancli/label_test.go
@@ -22,8 +22,10 @@ func TestLabelSetsOptionsAndRefreshes(t *testing.T) {
 	if err := cmdLabel([]string{"backend"}, &buf); err != nil {
 		t.Fatalf("label: %v", err)
 	}
-	if len(calls) != 3 {
-		t.Fatalf("expected 3 tmux calls (set label, set manual, refresh), got %v", calls)
+	// 3 writes + the bus-sync session-id probe (which the stub answers "",
+	// so no daemon call follows — see syncLabelToBus).
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 tmux calls (set label, set manual, refresh, session-id probe), got %v", calls)
 	}
 	if calls[0][0] != "set-option" || calls[0][1] != "@claude_task" || calls[0][2] != "backend" {
 		t.Fatalf("unexpected label set call: %v", calls[0])
@@ -53,8 +55,8 @@ func TestLabelClearUnsetsBothOptions(t *testing.T) {
 	if err := cmdLabel([]string{"--clear"}, &buf); err != nil {
 		t.Fatalf("label --clear: %v", err)
 	}
-	if len(calls) != 3 {
-		t.Fatalf("expected 3 tmux calls (unset label, unset manual, refresh), got %v", calls)
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 tmux calls (unset label, unset manual, refresh, session-id probe), got %v", calls)
 	}
 	if calls[0][0] != "set-option" || calls[0][1] != "-u" || calls[0][2] != "@claude_task" {
 		t.Fatalf("unexpected label unset call: %v", calls[0])
@@ -81,8 +83,54 @@ func TestLabelEmptyNameActsLikeClear(t *testing.T) {
 	if err := cmdLabel(nil, &buf); err != nil {
 		t.Fatalf("label with no args: %v", err)
 	}
-	if len(calls) != 3 || calls[0][1] != "-u" {
+	if len(calls) != 4 || calls[0][1] != "-u" {
 		t.Fatalf("expected an unset sequence for empty name, got %v", calls)
+	}
+}
+
+// TestLabelSyncsStoredLabelToBus covers syncLabelToBus end to end: `muster
+// label` must land the label in the STORE for every alias on the ambient
+// session (the daemon's resolver reads only the stored copy — see
+// daemon.resolveAgentTarget), and `muster label --clear` must clear it.
+// Without this push, a CLI sender (live tmux labels) and an MCP sender
+// (stored labels) would resolve the same label differently until the
+// session's next re-register.
+func TestLabelSyncsStoredLabelToBus(t *testing.T) {
+	sock := startCLITestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	registerViaDaemon(t, sock, "worker", "/tmp/sock", "$1")
+	registerViaDaemon(t, sock, "worker-2", "/tmp/sock", "$1")
+	registerViaDaemon(t, sock, "bystander", "/tmp/sock", "$9")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		if args[len(args)-1] == "#{session_id}" {
+			return "$1", nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdLabel([]string{"datalake"}, &buf); err != nil {
+		t.Fatalf("label: %v", err)
+	}
+	if strings.Contains(buf.String(), "warning") {
+		t.Fatalf("sync must succeed against the test daemon, got %q", buf.String())
+	}
+	want := map[string]string{"worker": "datalake", "worker-2": "datalake", "bystander": ""}
+	for _, a := range listAgentsForTest(t, sock) {
+		if a.Label != want[a.Alias] || (a.Label != "" && !a.LabelManual) {
+			t.Errorf("%s: stored label=(%q, manual=%v), want %q manual", a.Alias, a.Label, a.LabelManual, want[a.Alias])
+		}
+	}
+
+	if err := cmdLabel([]string{"--clear"}, &buf); err != nil {
+		t.Fatalf("label --clear: %v", err)
+	}
+	for _, a := range listAgentsForTest(t, sock) {
+		if a.Alias != "bystander" && (a.Label != "" || a.LabelManual) {
+			t.Errorf("%s: stored label must clear, got (%q, manual=%v)", a.Alias, a.Label, a.LabelManual)
+		}
 	}
 }
 

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -93,6 +93,31 @@ func (s *Store) DepartAgent(alias string) error {
 	return err
 }
 
+// SetSessionLabel updates the STORED label for every non-departed alias
+// registered to the (socketPath, sessionID) tuple — a label is a
+// session-level property, so all sibling aliases move together. This is the
+// daemon-side half of `muster label` (the set_label op): the CLI writes the
+// live tmux option and pushes the same value here in the same command, so
+// the stored copy the daemon's own resolver reads (resolveAgentTarget —
+// tmux-agnostic by rule, it never re-reads tmux) never drifts from what a
+// CLI caller resolving against live tmux sees. Clearing is label="",
+// manual=false. Returns how many rows changed; 0 with an empty tuple
+// component (nothing addressable to update — matches SessionUnread's
+// never-group-on-empty rule).
+func (s *Store) SetSessionLabel(socketPath, sessionID, label string, manual bool) (int64, error) {
+	if socketPath == "" || sessionID == "" {
+		return 0, nil
+	}
+	res, err := s.db.Exec(`
+UPDATE agents SET label=?, label_manual=?
+WHERE socket_path=? AND session_id=? AND departed=0`,
+		label, manual, socketPath, sessionID)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 // DepartStaleSiblings tombstones every OTHER non-departed alias registered to
 // the same (socketPath, sessionID) tuple whose session_created differs from
 // created — ghosts from a previous tmux server incarnation whose session ID

--- a/internal/store/stale_siblings_test.go
+++ b/internal/store/stale_siblings_test.go
@@ -73,3 +73,34 @@ func TestRegisterAgentRoundTripsSessionCreated(t *testing.T) {
 		t.Fatalf("ListAgents = (%+v, %v), want one row with SessionCreated 1784111111", list, err)
 	}
 }
+
+// TestSetSessionLabel: the set_label op's store half updates every
+// non-departed alias on the tuple and nothing else.
+func TestSetSessionLabel(t *testing.T) {
+	s := newTestStore(t)
+	for _, a := range []Agent{
+		{Alias: "a", SocketPath: "/s", SessionID: "$0"},
+		{Alias: "b", SocketPath: "/s", SessionID: "$0"},
+		{Alias: "other", SocketPath: "/s", SessionID: "$1"},
+	} {
+		if err := s.RegisterAgent(a); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.DepartAgent("b"); err != nil {
+		t.Fatal(err)
+	}
+	n, err := s.SetSessionLabel("/s", "$0", "datalake", true)
+	if err != nil || n != 1 {
+		t.Fatalf("SetSessionLabel = (%d, %v), want 1 row (departed sibling and other session spared)", n, err)
+	}
+	for alias, want := range map[string]string{"a": "datalake", "b": "", "other": ""} {
+		got, _, err := s.GetAgent(alias)
+		if err != nil || got.Label != want {
+			t.Errorf("%s: label=%q (err %v), want %q", alias, got.Label, err, want)
+		}
+	}
+	if n, err := s.SetSessionLabel("", "$0", "x", true); err != nil || n != 0 {
+		t.Fatalf("empty socket must be a no-op, got (%d, %v)", n, err)
+	}
+}


### PR DESCRIPTION
## The gap

`muster label` wrote only the tmux session option. The CLI's resolver re-reads labels live from tmux, but the daemon's resolver (`resolveAgentTarget`, the backstop for MCP senders) reads the **stored** label and is tmux-agnostic by rule — so after any relabel, `muster send datalake` and an MCP agent's `send_message` to `datalake` could resolve differently until the session happened to re-register. Surfaced while wiring up label addressing for the `datalake` session: its stored label was blank while the live label resolved fine.

## The fix

Close the gap at the writer, keeping the daemon tmux-agnostic:

- **store** — `SetSessionLabel(socket, session, label, manual)` updates every non-departed alias on the session tuple (a label is a session-level property; siblings move together). Departed rows and other sessions untouched.
- **daemon** — new `set_label` op wrapping it, returning the updated-row count.
- **humancli** — `cmdLabel` pushes the same value to the bus in the same command that sets/unsets the tmux option. A failed push warns and degrades to the old refresh-at-next-register behavior (the tmux option is the source of truth, so it's never *wrong*, just stale). Labeling an unregistered session is silently fine — register captures the option anyway.

Labels written by raw `tmux set-option` outside muster still only land at the next register; `muster label` is the supported path.

## Verification

- Daemon test: a label is **not** MCP-resolvable before `set_label`, **is** immediately after (thread lands on the right alias), and stops resolving on clear.
- CLI end-to-end test through `cmdLabel` against a real test daemon (both aliases updated, bystander session spared, clear works).
- Store-level matrix (departed sibling spared, empty-tuple no-op).
- `just verify` green.

No VERSION bump — rides the pending 0.7.2.

https://claude.ai/code/session_014jibpFJRR8FUXgSneriHWW