### PR TITLE
docs: station/watch plans + 'what it's for' landing section

### DIFF
--- a/docs/superpowers/plans/2026-07-16-muster-station.md
+++ b/docs/superpowers/plans/2026-07-16-muster-station.md
@@ -1,0 +1,221 @@
+# muster station Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+> **Normative companion:** `docs/superpowers/specs/2026-07-16-muster-station-design.md` — every task brief below names its spec sections; the spec text governs on any ambiguity. Implementers receive both files.
+
+**Goal:** `muster station` operator TUI + the four backend fixes (intent, session-level identity, list_threads, reply previews), shipped as v0.6.0.
+
+**Architecture:** Backend first (store → daemon identity rewiring → daemon surface → hook/nudge → CLI → release safety), each slice independently testable; then the TUI in three slices (scaffold → threads → actions/lifecycle) on Bubble Tea with a model-owned cursor; docs+ship last. Station is a peer daemon client over the unix socket — no MCP changes beyond the `intent` input field.
+
+**Tech Stack:** Go, modernc.org/sqlite, charmbracelet/bubbletea+bubbles+lipgloss (pinned; first UI dependency — pure Go). `CGO_ENABLED=0` everywhere including a new cross-build gate.
+
+## Global Constraints
+
+- `just verify` green after every task + standalone `golangci-lint run ./...; echo exit=$?`.
+- Socket-using tests: `internal/mustertest.ShortHome()`, never `t.TempDir()` for socket dirs.
+- stdout sacred in mcp mode; daemon/store stay tmux-agnostic; `internal/nudge` is the only send-keys path; no cgo; no LIKE against aliases; knobs not constants.
+- Journal writes stay best-effort. All migrations additive + idempotent (duplicate-column guard), fresh `schema.sql` updated in the same task as each ALTER.
+- Session tuple = exact `(socket_path, session_id)`, both non-empty; empty tuples are singletons, never grouped.
+- Branch `feat/station` in a worktree off `origin/dev`. VERSION → `0.6.0` in the final task only.
+
+---
+
+### Task 1: Store foundations — intent, entry-ID watermark, SessionUnread, Threads()
+
+**Spec:** §1, §2, §3 (store bullets), Testing (store). This is the largest store task; it is one task because the unread predicates, intent CASE, and watermark are one coherent semantic change.
+
+**Files:** Modify `internal/store/{schema.sql,store.go,models.go,threads.go,agents.go}`; Test `internal/store/{threads_test.go,agents_test.go,migrate_test.go}`.
+
+**Interfaces (later tasks consume exactly these):**
+
+```go
+// models.go
+const (IntentFYI = "fyi"; IntentReply = "reply-requested"; IntentAction = "action-requested")
+// Thread gains: Intent string `json:"intent"`; LastFrom string `json:"last_from"`;
+//               LastAt int64 `json:"last_at"`; EntryCount int `json:"entry_count"`
+//               (last three query-time only, populated by Threads()).
+// Agent gains: LastReadEntryID int64 `json:"last_read_entry_id"`.
+
+// threads.go
+// effectiveIntent is the ONE canonical SQL fragment (spec §2):
+const effectiveIntent = `CASE WHEN threads.kind='task' AND COALESCE(threads.intent,'')='' THEN 'action-requested' ELSE COALESCE(threads.intent,'') END`
+func (s *Store) Threads(limit int) ([]Thread, error) // updated_at DESC, id DESC; limit clamp [1..500], <=0 → 100
+// CreateThread validates intent ∈ {"", fyi, reply-requested, action-requested} → error otherwise.
+
+// agents.go
+func (s *Store) SessionUnread(socketPath, sessionID string) (total, action int, err error)
+// MarkRead(alias): in ONE transaction, read COALESCE(MAX(id),0) FROM entries and write it
+// to last_read_entry_id (last_read_at also updated, display-only).
+// UnreadCount(alias) predicate becomes e.id > agent's last_read_entry_id (drop the
+// wall-clock comparison; keep threadConcerns + from_agent != alias shape).
+```
+
+**Migrations (store.go alters list + schema.sql):**
+```sql
+ALTER TABLE threads ADD COLUMN intent TEXT NOT NULL DEFAULT ''
+ALTER TABLE agents  ADD COLUMN last_read_entry_id INTEGER NOT NULL DEFAULT 0
+-- one-time init, guarded by "only when column was just added" is NOT detectable;
+-- instead run always and idempotently:
+UPDATE agents SET last_read_entry_id =
+  COALESCE((SELECT MAX(e.id) FROM entries e WHERE e.created_at <= agents.last_read_at), 0)
+  WHERE last_read_entry_id = 0 AND last_read_at > 0
+```
+
+**SessionUnread SQL (spec §3 — COUNT DISTINCT threads, session-based actor exclusion):**
+```sql
+WITH sess AS (SELECT alias, last_read_entry_id FROM agents
+              WHERE socket_path = ?1 AND session_id = ?2 AND ?1 != '' AND ?2 != '')
+SELECT
+  COUNT(DISTINCT t.id),
+  COUNT(DISTINCT CASE WHEN <effectiveIntent> = 'action-requested' THEN t.id END)
+FROM threads t
+JOIN sess ON <threadConcerns with sess.alias>            -- see implementation note
+WHERE EXISTS (SELECT 1 FROM entries e WHERE e.thread_id = t.id
+              AND e.id > sess.last_read_entry_id
+              AND e.from_agent NOT IN (SELECT alias FROM sess))
+```
+Implementation note: `threadConcerns` binds a literal alias 3×; for the JOIN form, inline an equivalent predicate against `sess.alias` (agent-target = sess.alias OR role subquery on sess.alias OR broadcast OR from_agent = sess.alias) — keep it adjacent to `threadConcerns` with a comment binding the two, and add a test asserting both predicates agree on a fixture matrix (this is the "one canonical predicate" rule surviving a join).
+
+**Threads() shape (spec §1 — limit-first, last entry by MAX(id)):**
+```sql
+WITH recent AS (SELECT * FROM threads ORDER BY updated_at DESC, id DESC LIMIT ?),
+     last AS (SELECT e.thread_id, MAX(e.id) AS max_id, COUNT(*) AS n FROM entries e
+              WHERE e.thread_id IN (SELECT id FROM recent) GROUP BY e.thread_id)
+SELECT recent.<threadCols…>, <effectiveIntent> AS intent, le.from_agent, le.created_at, last.n
+FROM recent JOIN last ON last.thread_id = recent.id
+            JOIN entries le ON le.id = last.max_id
+ORDER BY recent.updated_at DESC, recent.id DESC
+```
+
+- [ ] Failing tests first, notably: `TestSessionUnreadCountsDistinctThreads` (broadcast concerning two sibling aliases → total 1), `TestSessionUnreadExcludesSiblingAuthors` (alias A writes; sibling B stays read), `TestMarkReadRecordsEntryWatermark` (same-millisecond entry after snapshot stays unread — no fake clock needed), `TestThreadsLastEntrySameMillisecond` (two entries same ts → MAX(id) wins), `TestIntentValidationAtStore`, `TestEffectiveIntentOldTasksAreAction` (pre-migration task row with intent '' counts in action), migration test on a hand-built v0.5 schema reopened twice with watermark init asserted.
+- [ ] Implement; existing UnreadCount tests will need the watermark rewrite (they get SIMPLER — delete fakeTick usage where it existed only for read-watermark ordering).
+- [ ] `just verify` + lint; commit `store: intent, entry-id read watermark, SessionUnread, Threads()`.
+
+---
+
+### Task 2: Daemon — session identity rewiring (locks, coalesced notify, strict get_inbox, session_aliases, reconciliation)
+
+**Spec:** §3 complete. **Files:** `internal/daemon/daemon.go`; tests `internal/daemon/{daemon_test.go,wake_wiring_test.go}`.
+
+**Interfaces:**
+```go
+// daemon.go
+type Daemon struct { …existing…; sessMu sync.Mutex; sessLocks map[string]*sync.Mutex }
+func (d *Daemon) sessionLock(socket, session string) *sync.Mutex // lazily created; key socket+"\x00"+session
+// notifyForThread: build affected SESSIONS (group originator+recipients' agents by tuple,
+// singletons for empty tuples), DROP the actor's entire session, then per session under
+// sessionLock: (total, action) := s.SessionUnread(...); n.Notify(socket, session, total);
+// ONE journal row {Kind:"notify", Agent:<the alias that put the session in scope>,
+// ThreadID, Count: total, Detail: lit/cleared/error…}.
+// get_inbox: threads := Inbox(alias); if MarkRead fails → fail(err), NO read event, badge
+// untouched. On success, under sessionLock: recompute SessionUnread; set option to total
+// (Clear when 0); journal read event; sum/tmux errors journal detail "error: …", never blind Clear.
+// New op session_aliases {socket_path, session_id} (both non-empty else fail) →
+// {"aliases": sorted deduped []string}.
+// register_agent / deregister_agent / gc's deregister path: after mutation, under
+// sessionLock recompute + rewrite the badge for every tuple touched (old AND new on re-register).
+```
+
+- [ ] Failing tests: `TestNotifyCoalescesSiblingAliases` (two aliases one tuple, one broadcast → exactly ONE notify row, one Notify call, count 1), `TestLit2Regression` (peer replies on threads concerning both siblings → badge = distinct count; drain ONE alias → badge rewritten to remainder, not cleared), `TestNotifyDrainInterleaving` (injectable notifier whose Notify blocks on a channel: start notify, complete a get_inbox drain mid-flight, release → final option value equals post-drain recompute, not the stale pre-drain count), `TestGetInboxFailsWhenMarkReadFails` (close the store's DB handle trick or an alias with no agent row per current MarkRead semantics — pick the injectable seam that exists; if none, add an error-injecting store wrapper seam in the test file), `TestSessionAliasesRejectsEmptyTuple`, `TestReRegisterReconcilesOldSessionBadge`.
+- [ ] Implement. The actor-session drop replaces `delete(recipients, actor)` — resolve the actor's tuple via its agent record; unregistered actor (e.g. "operator") falls back to alias-only exclusion.
+- [ ] `just verify` + lint; commit `daemon: session-level unread — coalesced notify, locked recompute, strict get_inbox, session_aliases`.
+
+---
+
+### Task 3: Daemon surface — list_threads, intent pass-through, get_thread pagination, reply preview + sanitizeForDisplay
+
+**Spec:** §1 (op), §2 (pass-through), §4. **Files:** `internal/daemon/daemon.go`, `internal/store/events.go` (events join gains intent), new `internal/humancli/display.go` — NO: sanitizer must be daemon-reachable without importing humancli → new package `internal/display` with `func Sanitize(s string, maxWidth int) string`; humancli re-exports/uses it. Tests alongside.
+
+**Interfaces:**
+```go
+// internal/display (new): Sanitize strips C0/C1 controls, ESC/CSI sequences, bidi controls
+// (U+202A–202E, U+2066–2069), NUL; collapses \t\n\r to single spaces; truncates by
+// DISPLAY WIDTH (go doesn't need a dep: use golang.org/x/text? NO new deps — implement
+// width via unicode.Is(unicode.Mn)==0-width + East Asian Wide/Fullwidth ranges table,
+// ~30 lines, tested). Appends '…' when cut.
+// daemon: send_message/task_create pass str(a,"intent") into CreateThread (store validates).
+// reply journals Detail: display.Sanitize(body, 80).
+// get_thread args gain {offset, limit} (both optional; absent/0 = everything, back-compat);
+// response unchanged in shape.
+// list_threads {limit} → {"threads": [...]} — side-effect-free.
+// store Events(): LEFT JOIN adds <effectiveIntent> AS intent; Event/eventRow gain Intent
+// (query-time, json:"intent").
+```
+
+- [ ] Failing tests: `TestListThreadsMarksNothingRead` (snapshot agents table + tmux option before/after — byte-identical), `TestIntentPassThroughAndRejection` (bad intent → fail from store validation), `TestGetThreadPagination` (offset/limit slices; no args = all), `TestReplyPreviewSanitized` (body with ESC sequence + newline → journal detail clean), display fuzz test (control corpus + wide runes; property: output printable, width ≤ max).
+- [ ] Implement; `just verify` + lint; commit `daemon: list_threads, intent pass-through, get_thread pagination, sanitized reply previews`.
+
+---
+
+### Task 4: Hook + nudge — multi-alias drain, action wording, drain-and-act nudge text
+
+**Spec:** §3 (hook bullet), §3b, §2 (drain wording). **Files:** `internal/humancli/hook.go`, `internal/nudge/nudge.go`; tests alongside.
+
+- Hook Stop: capture tuple via tmuxenv; call `session_aliases`; ≥1 alias → reason lists each: `Your muster aliases are 'a', 'b' (this tmux session). For EACH alias call get_inbox, read new threads with get_thread, handle, and reply.` Count line becomes `You have N unread muster thread(s)` and appends `, M needing action` when M>0 — N and M read from a new tiny op? NO: hook reads @muster_inbox for N as today (now the session count); M requires a query — add `session_aliases` sibling data? Simplest per spec: hook calls a new op `session_unread {socket_path, session_id}` → `{"total":n,"action":m}` (daemon: SessionUnread under the lock-free read path). Fall back to the tmux option value on op failure. (This op also serves station later.)
+- Nudge typed line becomes: `check your muster inbox: call get_inbox, read each new thread with get_thread, handle the request, and reply on the thread — act autonomously.` (One const in nudge.go; unknown-model typed-only unchanged.)
+- [ ] Failing tests: hook block message with two aliases (fake tmuxenv Run seam + test daemon), op-failure fallback to session-name text, action-count wording gated on M>0; nudge test asserts the new const typed.
+- [ ] Implement; `just verify` + lint; commit `hook+nudge: multi-alias drain, action counts, drain-and-act nudge`.
+
+---
+
+### Task 5: CLI — send --intent, journal intent tags + reply previews
+
+**Spec:** §2 (CLI/journal), §4 (renderer). **Files:** `internal/humancli/{humancli.go,events.go}`; tests.
+
+- `cmdSend` gains `--intent` flag (validated client-side against the three values + empty for a clearer error, though the store re-validates).
+- Renderer: eventRow gains Intent; `what()` appends ` [fyi]` / ` [reply?]` / ` [action]` for send/task rows with intent set; reply rows with non-empty Detail render `↳ <detail>` instead of the subject. `oneLine` call sites migrate to `display.Sanitize` (width-aware) — delete `oneLine`/rune `truncate` where superseded, keeping printed-width discipline from v0.5.1.
+- [ ] Failing tests: send --intent lands on the thread (via list_threads or DB); journal shows the tag; reply row shows `↳` preview not the duplicated subject (extends the v0.5.1 duplicate-look finding's test).
+- [ ] Implement; `just verify` + lint; commit `cli: send --intent; journal intent tags and reply previews`.
+
+---
+
+### Task 6: Release safety — cross-build gate before release creation
+
+**Spec:** §5 dependency bullet. **Files:** `justfile`, `.github/workflows/{ci.yml,release.yml}`.
+
+- `just cross`: loop darwin/linux × arm64/amd64, `CGO_ENABLED=0 GOOS=… GOARCH=… go build -o /dev/null ./cmd/muster`. Add to `verify` recipe (fast — build cache) and CI.
+- `release.yml`: reorder so all four target builds complete BEFORE `gh release create`; a build failure leaves NO release. Keep asset names/checksums identical.
+- [ ] Verify by reading the workflow diff carefully (no live release to test); `just cross` runs locally in the worktree.
+- [ ] Commit `release: cross-build all targets before creating the release; just cross gate`.
+
+---
+
+### Task 7: Station scaffold — dependency, model skeleton, tick-driven fetches, roster + feed
+
+**Spec:** §5 (dependency, identity, layout roster/feed, data loop, keys/flags subset). **Files:** new `internal/station/{station.go,model.go,poll.go,…}` (package station; humancli stays thin: `case "station": return station.Run(args[1:])`), `cmd/muster/main.go` usage, `go.mod` (pinned bubbletea/bubbles/lipgloss). Tests `internal/station/model_test.go` (model-level Update/View — no PTY).
+
+**Interfaces:** `station.Run(args []string) error`. Model owns `cursor int64`; `tickMsg` → three `tea.Cmd`s (events/agents/threads) each yielding its own msg type; cursor advances ONLY in the events-msg handler (spec data-loop section verbatim — including regression reset and never deriving decisions from mixed bundles). Registration/collision/conditional-deregister per spec §5 identity — implement registration in this task, defer-and-restore lifecycle hardening lands in Task 9.
+
+- [ ] Failing model tests: `TestCursorAdvancesOnlyOnAppliedEvents` (events msg applied → cursor moves; threads fetch failure msg → cursor untouched, nothing skipped on next tick), `TestRosterRendersLabelsAndCounts`, `TestFeedUsesRendererVocabulary` — the renderer lives in humancli today; EXTRACT it in THIS task: move the v0.5.1 renderer (renderer struct, eventRow/eventsPage, fetchEvents, loadLabels) into a new `internal/render` package consumed by both humancli and station (mechanical move; internal/render imports `internal/display` from Task 3 for Sanitize; all existing humancli tests keep passing against thin wrappers or updated imports).
+- [ ] Implement; `just verify` (now incl. cross — proves bubbletea survives the matrix) + lint; commit `station: scaffold — bubbletea skeleton, model-owned cursor, roster+feed`.
+
+---
+
+### Task 8: Station threads pane + thread view
+
+**Spec:** §5 threads/thread-view bullets. **Files:** `internal/station/…`; tests.
+
+- Threads pane from `list_threads`: intent groups (action → reply → rest; effective intent already server-side), `updated_at DESC, id DESC` in group; selection preserved by thread ID across refresh. Enter → thread view via paginated `get_thread` (limit 200, lazy "load older" on reaching top).
+- Open-to-acknowledge: opening a thread addressed to `station` (or station's chosen alias) triggers get_inbox for station's alias — the ONLY read station ever performs; focus alone reads nothing.
+- [ ] Failing model tests: grouping order, selection stability across regroup, opening a station-addressed thread acknowledges it (fake daemon asserts exactly one get_inbox, only on open), pagination lazy-load.
+- [ ] Implement; `just verify` + lint; commit `station: threads pane + paginated thread view + open-to-acknowledge`.
+
+---
+
+### Task 9: Station actions + lifecycle
+
+**Spec:** §5 composer/keys + identity lifecycle. **Files:** `internal/station/…`; tests.
+
+- Composer: `r` reply (thread context), `s` send (roster-filtered target picker), intent cycled F/R/A, Enter → `reply`/`send_message` ops, Esc cancel, errors to status line. `n` nudge with `y/n` confirm (calls the nudge package path — station is an operator surface; reuse `internal/nudge` exactly as cmdNudge does, including the self-report). `/` filter on focused pane; `a` aliases toggle; `q` quit.
+- Lifecycle: single deferred conditional deregister (tuple must still match) covering q/signal/panic; terminal restore on all exits; registration rollback if TUI init fails; goroutines stopped.
+- [ ] Failing model tests: composer send invokes op with intent (fake daemon), reply targets selected thread, nudge confirm gate, collision failover station-2, conditional deregister leaves re-registered alias untouched.
+- [ ] Implement; `just verify` + lint; commit `station: composer, nudge-with-confirm, filter, lifecycle hardening`.
+
+---
+
+### Task 10: Docs, VERSION, ship
+
+- README: station section (what it is, keys, addressable as `station`), intent flag, session-badge semantics note, gc/hook wording updates. site/index.html: one sentence where the CLI/mailbox is described, per the page's copy standards. Usage lines (main.go + humancli) gain `station`.
+- `printf '0.6.0\n' > VERSION`.
+- Live smoke ($TMUX/TMUX_PANE scrubbed for any register in the smoke — 07-16 lesson): run station against a scratch MUSTER_HOME with a scripted send; capture pane renders the thread; quit deregisters.
+- [ ] `just verify`; commit `docs+version: muster station ships as 0.6.0`. PR feat/station → dev; promote dev → main (release v0.6.0 auto-cuts, now build-gated); `contrib/release-sign.sh v0.6.0`.

--- a/docs/superpowers/plans/2026-07-16-muster-watch.md
+++ b/docs/superpowers/plans/2026-07-16-muster-watch.md
@@ -1,0 +1,947 @@
+# muster watch — bus journal + live tail: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every bus action becomes one journal row; `muster watch` tails that journal live with filters.
+
+**Architecture:** The v0.4 `events` table grows into the full bus journal (new kinds `send`/`reply`/`task`/`claim`/`transition`/`nudge` beside `notify`/`read`, plus a `target` column and a thread-subject join). The daemon journals at dispatch time, best-effort, action row before its notify rows. `muster watch` polls the existing one-request/one-response protocol with an explicit backlog/follow mode and a `max_id` cursor. Spec: `docs/superpowers/specs/2026-07-16-muster-watch-design.md` (read it first — it carries the reviewed decisions).
+
+**Tech Stack:** Go, modernc.org/sqlite (cgo-free), stdlib only. No new dependencies.
+
+## Global Constraints
+
+- `just verify` green after every task (gofmt, golangci-lint, `go test -race`, `CGO_ENABLED=0` build). Also run `golangci-lint run ./...` standalone and echo its exit code.
+- macOS sockets: tests that open a daemon socket use `internal/mustertest.ShortHome()` — never `t.TempDir()` for socket dirs.
+- stdout is sacred in mcp mode; nothing here may print from library code.
+- Knobs, not constants: every default in this plan is flag-tunable.
+- No LIKE against user-supplied aliases anywhere. Exact matches only.
+- The journal is best-effort: an `AppendEvent` failure must never fail or block the op it describes.
+- Work on branch `feat/watch` in a worktree off `origin/dev`. VERSION bumps to `0.5.0` in the final task.
+
+---
+
+### Task 1: Store — `target` + `subject` columns, journal kinds, migration
+
+**Files:**
+- Modify: `internal/store/schema.sql` (events CREATE gains `target`)
+- Modify: `internal/store/store.go` (migrate() gains the ALTER)
+- Modify: `internal/store/models.go` (Event gains `Target`, `Subject`)
+- Modify: `internal/store/events.go` (AppendEvent writes target)
+- Test: `internal/store/events_test.go`, `internal/store/migrate_test.go` (new)
+
+**Interfaces:**
+- Consumes: existing `store.Event`, `AppendEvent`, `Open`.
+- Produces: `Event{ID, TS int64; Kind, Agent, Target string; ThreadID int64; Count int; Detail, Subject string}` — `Subject` is query-time only (joined, never stored); `AppendEvent(e Event) error` persists `Target`.
+
+- [ ] **Step 1: Write the failing migration test**
+
+`internal/store/migrate_test.go`:
+
+```go
+package store
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestMigrateAddsTargetToV04Events builds the exact v0.4 events schema by
+// hand (current Open's CREATE IF NOT EXISTS would not alter it), inserts a
+// row, then opens the store twice: the ALTER must apply once, idempotently,
+// and the old row must read back with target ''.
+func TestMigrateAddsTargetToV04Events(t *testing.T) {
+	dir := t.TempDir() // no sockets here; plain file DB is fine
+	dbPath := filepath.Join(dir, "bus.db")
+	raw, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		ts INTEGER NOT NULL, kind TEXT NOT NULL,
+		agent TEXT NOT NULL DEFAULT '', thread_id INTEGER NOT NULL DEFAULT 0,
+		count INTEGER NOT NULL DEFAULT 0, detail TEXT NOT NULL DEFAULT '')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`INSERT INTO events (ts, kind, agent, thread_id, count, detail)
+		VALUES (1, 'notify', 'api', 7, 1, 'lit')`); err != nil {
+		t.Fatal(err)
+	}
+	_ = raw.Close()
+
+	for i := 0; i < 2; i++ { // reopen twice: migration must be idempotent
+		s, err := Open(dbPath)
+		if err != nil {
+			t.Fatalf("open %d: %v", i, err)
+		}
+		evs, err := s.Events(EventQuery{Backlog: true, Limit: 10})
+		if err != nil {
+			t.Fatalf("events %d: %v", i, err)
+		}
+		if len(evs) != 1 || evs[0].Target != "" || evs[0].Agent != "api" {
+			t.Fatalf("v0.4 row after migrate: %+v", evs)
+		}
+		_ = s.Close()
+	}
+}
+```
+
+(`Events`/`EventQuery` arrive in Task 2 — write this test now, it compiles
+after Task 2's types exist; within this task assert via `AppendEvent` + a
+direct `SELECT target FROM events` instead if you want it green earlier.
+The committed version at the END of Task 2 must be the one above.)
+
+For THIS task, the compiling failing test is the simpler round-trip in
+`events_test.go`:
+
+```go
+func TestAppendEventPersistsTarget(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.AppendEvent(Event{Kind: "send", Agent: "web", Target: "agent:api", ThreadID: 3, Detail: "subj"}); err != nil {
+		t.Fatal(err)
+	}
+	var target string
+	if err := s.DB().QueryRow(`SELECT target FROM events`).Scan(&target); err != nil {
+		t.Fatal(err)
+	}
+	if target != "agent:api" {
+		t.Fatalf("target = %q, want agent:api", target)
+	}
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `go test ./internal/store/ -run TestAppendEventPersistsTarget`
+Expected: compile error — `Event` has no field `Target`.
+
+- [ ] **Step 3: Implement**
+
+`models.go`: add to Event (after `Agent`):
+
+```go
+	Target string `json:"target"` // 'agent:x' / 'role:r' / 'broadcast' / bare alias (nudge)
+```
+
+and after `Detail`:
+
+```go
+	// Subject is joined from the event's thread at query time (empty for
+	// thread-less events). Never stored on the row.
+	Subject string `json:"subject"`
+```
+
+`schema.sql` events CREATE gains, after `agent`:
+
+```sql
+    target    TEXT NOT NULL DEFAULT '',    -- 'agent:x' / 'role:r' / 'broadcast' / bare alias (nudge)
+```
+
+`store.go` migrate() alters list gains:
+
+```go
+		`ALTER TABLE events ADD COLUMN target TEXT NOT NULL DEFAULT ''`,
+```
+
+`events.go` AppendEvent:
+
+```go
+	_, err := s.db.Exec(`
+INSERT INTO events (ts, kind, agent, target, thread_id, count, detail)
+VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		clock.NowMillis(), e.Kind, e.Agent, e.Target, e.ThreadID, e.Count, e.Detail)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/store/`
+Expected: PASS (RecentEvents still exists and ignores target — fine until Task 2).
+
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "store: events journal gains target column (schema + idempotent migration)"`
+
+---
+
+### Task 2: Store — `Events(EventQuery)`, `MaxEventID`, subject join
+
+**Files:**
+- Modify: `internal/store/events.go` (replace `RecentEvents` with `Events`; add `MaxEventID`)
+- Modify: `internal/daemon/daemon.go:` the `list_events` case only — mechanical swap to keep the build green (full op behavior is Task 5)
+- Test: `internal/store/events_test.go`, finalize `migrate_test.go` from Task 1
+
+**Interfaces:**
+- Consumes: `threadConcerns` (`internal/store/threads.go` — binds alias 3×), `threadCols`.
+- Produces:
+
+```go
+type EventQuery struct {
+	Agent    string // exact-alias concern filter ("" = all)
+	Kind     string // exact kind ("" = all)
+	ThreadID int64  // >0 filters to one thread
+	AfterID  int64  // follow mode: id > AfterID, oldest-first
+	Limit    int    // backlog mode row cap; 0 in backlog mode = no rows
+	Backlog  bool   // true: newest-first LIMIT; false: follow mode
+}
+func (s *Store) Events(q EventQuery) ([]Event, error)
+func (s *Store) MaxEventID() (int64, error)
+```
+
+Validation inside `Events`: `Limit` clamped to 1000; negative `AfterID`/`ThreadID` → error `fmt.Errorf("negative id")`; backlog `Limit <= 0` returns nil rows, no error. Unknown Kind matches nothing (plain equality).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `events_test.go` (replace the old `TestEventsAppendListFilterAndLimit` body where it calls `RecentEvents` — the semantics it asserted move here):
+
+```go
+func TestEventsBacklogAndFollowModes(t *testing.T) {
+	s := newTestStore(t)
+	for i, k := range []string{"send", "reply", "notify"} {
+		if err := s.AppendEvent(Event{Kind: k, Agent: "web", ThreadID: int64(i + 1)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	back, err := s.Events(EventQuery{Backlog: true, Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(back) != 2 || back[0].Kind != "notify" || back[1].Kind != "reply" {
+		t.Fatalf("backlog newest-first limit 2: %+v", back)
+	}
+	follow, err := s.Events(EventQuery{AfterID: back[1].ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(follow) != 1 || follow[0].Kind != "notify" {
+		t.Fatalf("follow after id %d: %+v", back[1].ID, follow)
+	}
+	if none, _ := s.Events(EventQuery{Backlog: true, Limit: 0}); len(none) != 0 {
+		t.Fatalf("backlog limit 0 must return no rows, got %d", len(none))
+	}
+	if _, err := s.Events(EventQuery{AfterID: -1}); err == nil {
+		t.Fatal("negative AfterID must error")
+	}
+	max, err := s.MaxEventID()
+	if err != nil || max != back[0].ID {
+		t.Fatalf("MaxEventID = %d (%v), want %d", max, err, back[0].ID)
+	}
+}
+
+// TestEventsAgentFilterMatchesThreadConcern is the finding-1 regression: a
+// reply row has empty target, so only the thread-concern join can match the
+// originator.
+func TestEventsAgentFilterMatchesThreadConcern(t *testing.T) {
+	s := newTestStore(t)
+	id, err := s.CreateThread(Thread{Kind: "message", FromAgent: "web", ToKind: "agent", ToTarget: "api"}, "req")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range []Event{
+		{Kind: "send", Agent: "web", Target: "agent:api", ThreadID: id, Detail: "req"},
+		{Kind: "reply", Agent: "api", ThreadID: id},
+		{Kind: "nudge", Target: "web"},
+		{Kind: "send", Agent: "x", Target: "agent:zzz", ThreadID: 999},
+	} {
+		if err := s.AppendEvent(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := s.Events(EventQuery{Agent: "web", Backlog: true, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 { // its send (actor), api's reply (thread concern), the nudge (bare target)
+		t.Fatalf("agent=web should match 3 events, got %d: %+v", len(got), got)
+	}
+	for _, e := range got {
+		if e.Agent == "x" {
+			t.Fatalf("unrelated event leaked through agent filter: %+v", e)
+		}
+	}
+}
+
+func TestEventsJoinsThreadSubject(t *testing.T) {
+	s := newTestStore(t)
+	id, err := s.CreateThread(Thread{Kind: "message", FromAgent: "web", ToKind: "agent", ToTarget: "api", Subject: "hello subj"}, "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(Event{Kind: "notify", Agent: "api", ThreadID: id, Count: 1, Detail: "lit"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendEvent(Event{Kind: "read", Agent: "api"}); err != nil {
+		t.Fatal(err)
+	}
+	evs, err := s.Events(EventQuery{Backlog: true, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evs[1].Subject != "hello subj" || evs[0].Subject != "" {
+		t.Fatalf("subject join: notify=%q (want hello subj), read=%q (want empty)", evs[1].Subject, evs[0].Subject)
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify failure** — `go test ./internal/store/ -run 'TestEvents'` → compile error (`EventQuery` undefined).
+
+- [ ] **Step 3: Implement `Events` + `MaxEventID`** in `events.go`:
+
+```go
+// maxEventLimit bounds any single Events query.
+const maxEventLimit = 1000
+
+// EventQuery selects journal rows. Mode is explicit: Backlog=true reads
+// newest-first up to Limit; otherwise follow mode reads id > AfterID
+// oldest-first. Agent matches events the alias is CONCERNED in — as actor,
+// as exact 'agent:<alias>' target, as bare-alias target (nudge), or via the
+// event's thread satisfying threadConcerns (what makes replies on your
+// threads match despite their empty target). Role matching uses the alias's
+// current role, same as threadConcerns everywhere else.
+type EventQuery struct {
+	Agent    string
+	Kind     string
+	ThreadID int64
+	AfterID  int64
+	Limit    int
+	Backlog  bool
+}
+
+func (s *Store) Events(q EventQuery) ([]Event, error) {
+	if q.AfterID < 0 || q.ThreadID < 0 {
+		return nil, fmt.Errorf("negative id in event query")
+	}
+	if q.Backlog && q.Limit <= 0 {
+		return nil, nil
+	}
+	limit := q.Limit
+	if limit <= 0 || limit > maxEventLimit {
+		limit = maxEventLimit
+	}
+	where := []string{"1=1"}
+	var args []any
+	if q.Agent != "" {
+		where = append(where, `(events.agent = ?
+   OR events.target = 'agent:'||?
+   OR events.target = ?
+   OR (events.thread_id > 0 AND EXISTS (
+        SELECT 1 FROM threads WHERE threads.id = events.thread_id AND `+threadConcerns+`)))`)
+		args = append(args, q.Agent, q.Agent, q.Agent, q.Agent, q.Agent, q.Agent)
+	}
+	if q.Kind != "" {
+		where = append(where, "events.kind = ?")
+		args = append(args, q.Kind)
+	}
+	if q.ThreadID > 0 {
+		where = append(where, "events.thread_id = ?")
+		args = append(args, q.ThreadID)
+	}
+	order := "events.id DESC"
+	if !q.Backlog {
+		where = append(where, "events.id > ?")
+		args = append(args, q.AfterID)
+		order = "events.id ASC"
+	}
+	args = append(args, limit)
+	rows, err := s.db.Query(`
+SELECT events.id, events.ts, events.kind, events.agent, events.target,
+       events.thread_id, events.count, events.detail,
+       COALESCE(threads.subject, '')
+FROM events LEFT JOIN threads ON threads.id = events.thread_id
+WHERE `+strings.Join(where, " AND ")+`
+ORDER BY `+order+` LIMIT ?`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Event
+	for rows.Next() {
+		var e Event
+		if err := rows.Scan(&e.ID, &e.TS, &e.Kind, &e.Agent, &e.Target, &e.ThreadID, &e.Count, &e.Detail, &e.Subject); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// MaxEventID returns the journal high-water mark (0 on an empty journal).
+func (s *Store) MaxEventID() (int64, error) {
+	var n int64
+	err := s.db.QueryRow(`SELECT COALESCE(MAX(id), 0) FROM events`).Scan(&n)
+	return n, err
+}
+```
+
+Delete `RecentEvents` and `defaultEventLimit`. In `daemon.go`'s `list_events` case, mechanical swap so the tree compiles (real op behavior is Task 5):
+
+```go
+	case "list_events":
+		evs, err := d.s.Events(store.EventQuery{Agent: str(a, "agent"), Backlog: true, Limit: 50})
+```
+
+Note `threadConcerns` binds the alias 3× — hence the six `q.Agent` args (3 for the direct forms + 3 for the join). Verify count against the fragment before committing.
+
+- [ ] **Step 4: Run** — `go test ./internal/store/ ./internal/daemon/ ./internal/humancli/` → PASS (humancli events still renders; its filter arg keeps working through the swap). Finalize `migrate_test.go` to the Events-based version from Task 1 Step 1.
+
+- [ ] **Step 5: Commit** — `git commit -am "store: EventQuery/Events with explicit modes, concern filter, subject join; MaxEventID"`
+
+---
+
+### Task 3: Store + daemon + gc — retention (`PruneEvents` → `prune_events` → `gc --events-keep`)
+
+**Files:**
+- Modify: `internal/store/events.go`, `internal/daemon/daemon.go`, `internal/humancli/identity.go` (cmdGC)
+- Test: `internal/store/events_test.go`, `internal/daemon/daemon_test.go`, `internal/humancli/identity_test.go`
+
+**Interfaces:**
+- Produces: `func (s *Store) PruneEvents(olderThanMillis int64) (int64, error)`; daemon op `prune_events` args `{older_than_ms}` (accepts string or number via `i64`) → `{"pruned": n}`, rejects `older_than_ms <= 0`; `muster gc [--events-keep <dur>]` default `720h`, rejects `<= 0`, reports both reap and prune results independently.
+
+- [ ] **Step 1: Failing store test** (fake clock, exact boundary):
+
+```go
+func TestPruneEventsExactBoundarySurvives(t *testing.T) {
+	fakeTick(t) // from threads_test.go — strictly increasing clock
+	s := newTestStore(t)
+	for i := 0; i < 3; i++ { // rows at ts 1, 2, 3
+		if err := s.AppendEvent(Event{Kind: "read", Agent: "a"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	n, err := s.PruneEvents(2) // DELETE WHERE ts < 2: only ts=1 goes
+	if err != nil || n != 1 {
+		t.Fatalf("pruned %d (%v), want 1", n, err)
+	}
+	left, _ := s.Events(EventQuery{Backlog: true, Limit: 10})
+	if len(left) != 2 { // ts=2 (exactly at cutoff) must survive
+		t.Fatalf("rows after prune = %d, want 2", len(left))
+	}
+}
+```
+
+- [ ] **Step 2: Run, fails** (`PruneEvents` undefined). Implement:
+
+```go
+// PruneEvents deletes journal rows with ts < olderThanMillis (a row exactly
+// at the cutoff survives), returning the count deleted.
+func (s *Store) PruneEvents(olderThanMillis int64) (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM events WHERE ts < ?`, olderThanMillis)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+```
+
+- [ ] **Step 3: Daemon op + test.** In dispatch (near `list_events`):
+
+```go
+	case "prune_events":
+		cutoff := i64(a, "older_than_ms")
+		if cutoff <= 0 {
+			return fail(fmt.Errorf("older_than_ms must be > 0"))
+		}
+		n, err := d.s.PruneEvents(cutoff)
+		if err != nil {
+			return fail(err)
+		}
+		return ok(map[string]any{"pruned": n})
+```
+
+Daemon test: append two events via store with fake clock, call op with the middle ts, assert `pruned: 1` and that `older_than_ms: 0` fails.
+
+- [ ] **Step 4: gc flag + test.** `cmdGC` gains a flag set (it currently takes none — give it one): `eventsKeep := fs.Duration("events-keep", 720*time.Hour, ...)`; reject `<= 0` with `fmt.Errorf("--events-keep must be > 0")`; after the reap loop, call `prune_events` with `older_than_ms = clock.NowMillis() - eventsKeep.Milliseconds()` **as a string** (`strconv.FormatInt`) and print `pruned N event(s)` on its own line; a prune error prints to the same writer but does not mask the reap summary. Test drives `Dispatch([]string{"gc", "--events-keep", "1h"})` against the test daemon after inserting an old event with the fake clock.
+
+- [ ] **Step 5: `just verify`, commit** — `git commit -am "retention: PruneEvents + prune_events op + gc --events-keep (720h default)"`
+
+---
+
+### Task 4: Daemon — journal the five bus actions; claim notifies
+
+**Files:**
+- Modify: `internal/daemon/daemon.go` (send_message, task_create, reply, task_claim, task_transition cases)
+- Test: `internal/daemon/wake_wiring_test.go`
+
+**Interfaces:**
+- Consumes: `logEvent`, `store.Event{Target, Subject}`.
+- Produces: journal rows per spec's kind table. Exact target encoding: `to_kind == "broadcast"` → `"broadcast"`; else `to_kind + ":" + to_target`. Ordering: journal row appended immediately after the successful mutation, **before** `notifyForThread`. `task_claim` now also calls `d.notifyForThread(threadID, by)`.
+
+- [ ] **Step 1: Failing test** (extend wake_wiring_test.go):
+
+```go
+// TestBusActionsJournalInOrder: one send + reply must produce an interleaved
+// journal — send row BEFORE its notify row, reply row BEFORE its notify row —
+// and task claim must both journal and notify.
+func TestBusActionsJournalInOrder(t *testing.T) {
+	n := &fakeNotifier{}
+	sock, s := startWithNotifierAndStore(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web", "model_type": "claude", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "api", "model_type": "claude", "socket_path": "/s", "session_id": "$2"})
+	resp := call(t, sock, "send_message", map[string]any{"from": "web", "to_kind": "agent", "to_target": "api", "subject": "subj", "body": "x"})
+	tid := threadIDOf(t, resp) // helper: unmarshal resp.Data.thread_id (extract from TestReplyNotifiesOriginatorWithUnread)
+	call(t, sock, "reply", map[string]any{"thread_id": tid, "from": "api", "body": "done"})
+
+	evs, err := s.Events(store.EventQuery{Backlog: true, Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// oldest-first for assertion readability
+	for i, j := 0, len(evs)-1; i < j; i, j = i+1, j-1 {
+		evs[i], evs[j] = evs[j], evs[i]
+	}
+	var kinds []string
+	for _, e := range evs {
+		kinds = append(kinds, e.Kind)
+	}
+	want := []string{"send", "notify", "reply", "notify"}
+	if len(kinds) != 4 || !slices.Equal(kinds, want) {
+		t.Fatalf("journal order = %v, want %v", kinds, want)
+	}
+	if evs[0].Target != "agent:api" || evs[0].Detail != "subj" || evs[0].Agent != "web" {
+		t.Fatalf("send row: %+v", evs[0])
+	}
+}
+
+func TestTaskClaimJournalsAndNotifies(t *testing.T) {
+	n := &fakeNotifier{}
+	sock, s := startWithNotifierAndStore(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web", "model_type": "claude", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "api", "model_type": "claude", "socket_path": "/s", "session_id": "$2"})
+	resp := call(t, sock, "task_create", map[string]any{"from": "web", "to_kind": "agent", "to_target": "api", "subject": "do it", "body": "x"})
+	tid := threadIDOf(t, resp)
+	before := len(n.snap(&n.notified))
+	call(t, sock, "task_claim", map[string]any{"thread_id": tid, "by": "api"})
+	if got := n.snap(&n.notified); len(got) != before+1 || got[len(got)-1] != "$1" {
+		t.Fatalf("claim must notify the originator's session, notified=%v", got)
+	}
+	evs, _ := s.Events(store.EventQuery{Kind: "claim", Backlog: true, Limit: 5})
+	if len(evs) != 1 || evs[0].Agent != "api" || evs[0].ThreadID != tid {
+		t.Fatalf("claim journal row: %+v", evs)
+	}
+}
+```
+
+- [ ] **Step 2: Run, fails** (no journal rows; claim doesn't notify).
+
+- [ ] **Step 3: Implement.** In each case, right after the successful store call and before `notifyForThread`:
+
+```go
+	// send_message:
+	d.logEvent(store.Event{Kind: "send", Agent: str(a, "from"), Target: targetOf(a), ThreadID: id, Detail: str(a, "subject")})
+	// task_create: same but Kind: "task"
+	// reply:
+	d.logEvent(store.Event{Kind: "reply", Agent: str(a, "from"), ThreadID: i64(a, "thread_id")})
+	// task_claim (also ADD the notify call after it):
+	d.logEvent(store.Event{Kind: "claim", Agent: str(a, "by"), ThreadID: i64(a, "thread_id")})
+	d.notifyForThread(i64(a, "thread_id"), str(a, "by"))
+	// task_transition:
+	d.logEvent(store.Event{Kind: "transition", Agent: str(a, "by"), ThreadID: i64(a, "thread_id"), Detail: str(a, "status")})
+```
+
+with one helper near `logEvent`:
+
+```go
+// targetOf renders a thread address as a journal target: 'broadcast' or
+// '<to_kind>:<to_target>'.
+func targetOf(a map[string]any) string {
+	if str(a, "to_kind") == "broadcast" {
+		return "broadcast"
+	}
+	return str(a, "to_kind") + ":" + str(a, "to_target")
+}
+```
+
+- [ ] **Step 4: Run** — `go test ./internal/daemon/`. The pre-existing `TestNotifySkipsAgentsWithoutSession` now sees a `send` journal row too — it asserts on `n.notified`, unaffected. PASS.
+
+- [ ] **Step 5: Commit** — `git commit -am "daemon: journal send/task/reply/claim/transition; task_claim now notifies"`
+
+---
+
+### Task 5: Daemon — `log_event` (canonical nudge row) + full `list_events`; nudge self-reports
+
+**Files:**
+- Modify: `internal/daemon/daemon.go`, `internal/humancli/humancli.go` (cmdNudge)
+- Test: `internal/daemon/daemon_test.go`, `internal/humancli/humancli_test.go`
+
+**Interfaces:**
+- Produces: op `log_event` args `{target, detail}` — target must be a registered alias (`GetAgent` found), detail must be `"typed"` or `"submitted"`; daemon constructs `Event{Kind: "nudge", Agent: "", Target: target, Detail: detail}`, everything else zero. Any other shape → `fail`.
+- Produces: op `list_events` args `{agent, kind, thread_id, after_id, limit, backlog}` (`after_id` arrives as a decimal **string**; `i64` already coerces) → `{"events": [...], "max_id": n}`; `max_id` present in every response.
+- cmdNudge: after typing, best-effort `callData("log_event", map[string]any{"target": alias, "detail": detailWord})` where `detailWord` is `"submitted"` unless `--no-submit` → `"typed"`; a log_event error must not fail the nudge (print nothing).
+
+- [ ] **Step 1: Failing daemon tests**
+
+```go
+func TestLogEventConstructsCanonicalNudge(t *testing.T) {
+	n := &fakeNotifier{}
+	sock, s := startWithNotifierAndStore(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "api", "model_type": "claude", "socket_path": "/s", "session_id": "$2"})
+	// attempted pollution: kind/agent/thread_id/count must all be overwritten
+	resp := call(t, sock, "log_event", map[string]any{"target": "api", "detail": "submitted", "kind": "send", "agent": "fake", "thread_id": 9, "count": 5})
+	if !resp.OK {
+		t.Fatalf("log_event: %+v", resp)
+	}
+	evs, _ := s.Events(store.EventQuery{Kind: "nudge", Backlog: true, Limit: 5})
+	if len(evs) != 1 {
+		t.Fatalf("want 1 nudge row, got %+v", evs)
+	}
+	e := evs[0]
+	if e.Agent != "" || e.Target != "api" || e.ThreadID != 0 || e.Count != 0 || e.Detail != "submitted" {
+		t.Fatalf("canonical nudge row violated: %+v", e)
+	}
+	if resp := call(t, sock, "log_event", map[string]any{"target": "ghost", "detail": "typed"}); resp.OK {
+		t.Fatal("unregistered target must be rejected")
+	}
+	if resp := call(t, sock, "log_event", map[string]any{"target": "api", "detail": "hacked"}); resp.OK {
+		t.Fatal("detail outside typed|submitted must be rejected")
+	}
+}
+
+func TestListEventsMaxIDAndFollow(t *testing.T) {
+	n := &fakeNotifier{}
+	sock, _ := startWithNotifierAndStore(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "api", "model_type": "claude", "socket_path": "/s", "session_id": "$2"})
+	// empty journal: backlog with limit 0 must still return max_id 0
+	resp := call(t, sock, "list_events", map[string]any{"backlog": true, "limit": 0})
+	var out struct {
+		Events []store.Event `json:"events"`
+		MaxID  int64         `json:"max_id"`
+	}
+	decode(t, resp, &out) // helper: json.Marshal(resp.Data) → Unmarshal
+	if out.MaxID != 0 || len(out.Events) != 0 {
+		t.Fatalf("empty journal: %+v", out)
+	}
+	call(t, sock, "send_message", map[string]any{"from": "web", "to_kind": "agent", "to_target": "api", "subject": "s", "body": "b"})
+	resp = call(t, sock, "list_events", map[string]any{"after_id": "0"})
+	decode(t, resp, &out)
+	if out.MaxID < 1 || len(out.Events) < 1 || out.Events[0].Kind != "send" {
+		t.Fatalf("follow from 0: %+v", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run, fails.** Implement both ops:
+
+```go
+	case "log_event":
+		target, detail := str(a, "target"), str(a, "detail")
+		if detail != "typed" && detail != "submitted" {
+			return fail(fmt.Errorf("log_event: detail must be typed|submitted"))
+		}
+		if _, found, err := d.s.GetAgent(target); err != nil || !found {
+			return fail(fmt.Errorf("log_event: unknown target %q", target))
+		}
+		// The daemon constructs the canonical event; client fields beyond
+		// target/detail are ignored so the journal can't be polluted.
+		d.logEvent(store.Event{Kind: "nudge", Target: target, Detail: detail})
+		return ok(nil)
+	case "list_events":
+		evs, err := d.s.Events(store.EventQuery{
+			Agent: str(a, "agent"), Kind: str(a, "kind"),
+			ThreadID: i64(a, "thread_id"), AfterID: i64(a, "after_id"),
+			Limit: int(i64(a, "limit")), Backlog: boolArg(a, "backlog"),
+		})
+		if err != nil {
+			return fail(err)
+		}
+		maxID, err := d.s.MaxEventID()
+		if err != nil {
+			return fail(err)
+		}
+		return ok(map[string]any{"events": evs, "max_id": maxID})
+```
+
+cmdNudge, after the type/submit succeeds:
+
+```go
+	detailWord := "submitted"
+	if *noSubmit {
+		detailWord = "typed"
+	}
+	_, _ = callData("log_event", map[string]any{"target": alias, "detail": detailWord}) // best-effort journal
+```
+
+humancli test: after a nudge against the test daemon (nudge needs a registered agent with a pane — follow the existing nudge test's fake setup), assert a `nudge` journal row exists via a `list_events` call.
+
+- [ ] **Step 3: Run both packages, PASS. Commit** — `git commit -am "daemon: log_event (canonical nudge) + list_events with max_id; nudge self-reports"`
+
+---
+
+### Task 6: CLI — shared event rendering; `events` gains filters + new columns
+
+**Files:**
+- Modify: `internal/humancli/events.go`
+- Test: `internal/humancli/events_test.go`
+
+**Interfaces:**
+- Consumes: `list_events` op (Task 5 shape).
+- Produces (Task 7 consumes all three):
+
+```go
+type eventRow struct {
+	ID       int64  `json:"id"`
+	TS       int64  `json:"ts"`
+	Kind     string `json:"kind"`
+	Agent    string `json:"agent"`
+	Target   string `json:"target"`
+	ThreadID int64  `json:"thread_id"`
+	Count    int    `json:"count"`
+	Detail   string `json:"detail"`
+	Subject  string `json:"subject"`
+}
+type eventsPage struct {
+	Events []eventRow `json:"events"`
+	MaxID  int64      `json:"max_id"`
+}
+// fetchEvents calls list_events; afterID < 0 means backlog mode.
+func fetchEvents(agent, kind string, threadID, afterID int64, limit int) (eventsPage, error)
+// printEventLine writes exactly one line; oneLine() maps \t and \n to spaces
+// and truncates subject to 60 runes.
+func printEventLine(w io.Writer, e eventRow)
+func eventHeader(w io.Writer)
+```
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestEventsFiltersAndOneLineRendering(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "api", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{"from": "web", "to_kind": "agent", "to_target": "api", "subject": "line1\nline2\ttabbed", "body": "b"}); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := Dispatch([]string{"events", "--kind", "send"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "SUBJECT") || !strings.Contains(got, "line1 line2") {
+		t.Fatalf("send row with sanitized subject expected:\n%s", got)
+	}
+	if lines := strings.Count(got, "\n"); lines != 2 { // header + one row
+		t.Fatalf("multi-line subject leaked, %d lines:\n%s", lines, got)
+	}
+	out.Reset()
+	if err := Dispatch([]string{"events", "--kind", "read", "--thread", "1"}, &out); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "send") {
+		t.Fatalf("kind filter leaked send rows:\n%s", out.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run, fails. Implement.** Rework `events.go`: `cmdEvents` gains `--kind` and `--thread` flags; calls `fetchEvents(*agent, *kind, int64(*thread), -1, *limit)` (backlog: pass `backlog: true`, omit after_id); default `--limit` stays 50 (flag). Rendering:
+
+```go
+func oneLine(s string) string {
+	s = strings.NewReplacer("\t", " ", "\n", " ", "\r", " ").Replace(s)
+	return s
+}
+
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
+}
+```
+
+Header `TIME\tKIND\tAGENT\tTARGET\tTHREAD\tCOUNT\tDETAIL\tSUBJECT`; row prints `truncate(oneLine(e.Subject), 60)` and `oneLine(e.Detail)`; thread renders empty when 0 as today. `fetchEvents` sends `after_id` as `strconv.FormatInt(afterID, 10)` when `afterID >= 0` and `backlog: true` otherwise — never both.
+
+- [ ] **Step 3: Run package, PASS. Commit** — `git commit -am "cli: events filters (--kind --thread), target+subject columns, one-line rendering"`
+
+---
+
+### Task 7: CLI — `muster watch`
+
+**Files:**
+- Create: `internal/humancli/watch.go`
+- Modify: `internal/humancli/humancli.go` (dispatch case), `cmd/muster/main.go` (usage string)
+- Test: `internal/humancli/watch_test.go`
+
+**Interfaces:**
+- Consumes: `fetchEvents`, `printEventLine`, `eventHeader` (Task 6).
+- Produces: `muster watch [--agent A] [--thread N] [--kind K] [--interval 1s] [--backlog 10]`. Internal seam for tests:
+
+```go
+// watchOpts carries the loop's injectable seams. Zero value = production:
+// wait sleeps interval or returns early on signal; maxPolls 0 = forever.
+type watchOpts struct {
+	wait     func(d time.Duration) bool // false = shutdown requested
+	maxPolls int
+	errw     io.Writer // stderr for retry/reset notes; nil = os.Stderr
+}
+func cmdWatch(args []string, out io.Writer, o watchOpts) error
+```
+
+Dispatch calls `cmdWatch(args[1:], out, watchOpts{})`.
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestWatchBacklogThenFollowsAndResets(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "api", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{"from": "web", "to_kind": "agent", "to_target": "api", "subject": "first", "body": "b"}); err != nil {
+		t.Fatal(err)
+	}
+	polls := 0
+	var out, errw bytes.Buffer
+	o := watchOpts{
+		maxPolls: 2,
+		errw:     &errw,
+		wait: func(time.Duration) bool {
+			polls++
+			if polls == 1 { // inject a new event between poll 1 and 2
+				if _, err := callData("reply", map[string]any{"thread_id": 1, "from": "api", "body": "done"}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			return true
+		},
+	}
+	if err := cmdWatch([]string{"--interval", "1ms"}, &out, o); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "send") || !strings.Contains(got, "first") {
+		t.Fatalf("backlog missing:\n%s", got)
+	}
+	if !strings.Contains(got, "reply") {
+		t.Fatalf("followed event missing:\n%s", got)
+	}
+	sendIdx, replyIdx := strings.Index(got, "send"), strings.Index(got, "reply")
+	if sendIdx > replyIdx {
+		t.Fatalf("backlog must print before followed rows:\n%s", got)
+	}
+}
+
+func TestWatchBacklogZeroPrintsNoHistory(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "api", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{"from": "web", "to_kind": "agent", "to_target": "api", "subject": "old", "body": "b"}); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	o := watchOpts{maxPolls: 1, wait: func(time.Duration) bool { return true }}
+	if err := cmdWatch([]string{"--backlog", "0"}, &out, o); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "old") {
+		t.Fatalf("--backlog 0 printed history:\n%s", out.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run, fails. Implement `watch.go`:**
+
+```go
+package humancli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// cmdWatch tails the bus journal: prints the last --backlog matching events,
+// then polls list_events with the max_id cursor every --interval until
+// interrupted. Side-effect-free: never marks anything read.
+func cmdWatch(args []string, out io.Writer, o watchOpts) error {
+	fs := flag.NewFlagSet("watch", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	agent := fs.String("agent", "", "only events concerning this alias")
+	kind := fs.String("kind", "", "only this event kind")
+	thread := fs.Int64("thread", 0, "only this thread")
+	interval := fs.Duration("interval", time.Second, "poll interval")
+	backlog := fs.Int("backlog", 10, "history lines to print before following (0 = none)")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("usage: muster watch [--agent <alias>] [--thread <id>] [--kind <k>] [--interval <dur>] [--backlog <n>]")
+	}
+	if o.errw == nil {
+		o.errw = os.Stderr
+	}
+	if o.wait == nil {
+		o.wait = signalWait()
+	}
+
+	page, err := fetchEvents(*agent, *kind, *thread, -1, *backlog) // backlog mode
+	if err != nil {
+		return err
+	}
+	eventHeader(out)
+	for i := len(page.Events) - 1; i >= 0; i-- { // newest-first → print oldest-first
+		printEventLine(out, page.Events[i])
+	}
+	cursor := page.MaxID
+
+	for polls := 0; o.maxPolls == 0 || polls < o.maxPolls; polls++ {
+		if !o.wait(*interval) {
+			return nil // interrupted
+		}
+		page, err := fetchEvents(*agent, *kind, *thread, cursor, 0) // follow mode
+		if err != nil {
+			fmt.Fprintln(o.errw, "watch: poll failed, retrying:", err)
+			continue
+		}
+		if page.MaxID < cursor {
+			fmt.Fprintf(o.errw, "watch: journal reset (max id %d < cursor %d) — DB replaced? following from the new tail\n", page.MaxID, cursor)
+			cursor = page.MaxID
+			continue
+		}
+		for _, e := range page.Events { // follow mode is oldest-first
+			printEventLine(out, e)
+		}
+		cursor = page.MaxID
+	}
+	return nil
+}
+
+// signalWait returns the production wait: sleep d, but return false
+// immediately on SIGINT/SIGTERM so Ctrl-C never waits out an interval.
+func signalWait() func(time.Duration) bool {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	return func(d time.Duration) bool {
+		select {
+		case <-sig:
+			return false
+		case <-time.After(d):
+			return true
+		}
+	}
+}
+```
+
+`watchOpts` as in Interfaces. Dispatch gains `case "watch": return cmdWatch(args[1:], out, watchOpts{})`. Usage line in `cmd/muster/main.go` becomes `usage: muster <serve|debug|mcp|agents|inbox|send|tasks|events|watch|nudge|register|deregister|gc|hook|label> [args]`. Note the tabwriter used by `eventHeader`/`printEventLine` must flush per line in watch (streaming) — have both helpers write through a plain `fmt.Fprintf` with fixed-width columns OR flush the tabwriter after every row; pick per-line flush.
+
+- [ ] **Step 3: Run package tests, then `just verify`. PASS.**
+
+- [ ] **Step 4: Commit** — `git commit -am "cli: muster watch — poll-follow journal tail with cursor discipline"`
+
+---
+
+### Task 8: Docs, VERSION, ship
+
+**Files:**
+- Modify: `README.md`, `site/index.html` (tools/CLI mentions), `VERSION` → `0.5.0`
+- Test: `just verify` + live smoke
+
+- [ ] **Step 1: README.** CLI block gains `muster watch` line (`# follow the bus live — every message, task, wake and read as it happens`); the events paragraph in *Notifications & nudging* mentions watch and the subject column; gc paragraph mentions `--events-keep 720h` default.
+
+- [ ] **Step 2: site/index.html.** In the tools section's plain-language chips / CLI mentions, add watch alongside events where the mailbox render is described (one sentence, defined terms, full sentences — match the page's copy standards; no new sections).
+
+- [ ] **Step 3: VERSION** — `printf '0.5.0\n' > VERSION`.
+
+- [ ] **Step 4: `just verify`; live smoke** — build to a temp path, run `muster watch --backlog 5` in one shell while `muster send`ing from another; confirm interleaved send→notify lines appear within an interval, Ctrl-C exits instantly.
+
+- [ ] **Step 5: Commit** — `git commit -am "docs+version: muster watch ships as 0.5.0"`. PR `feat/watch → dev`, then promote dev → main (release v0.5.0 auto-cuts; sign darwin assets with `contrib/release-sign.sh v0.5.0`).

--- a/docs/superpowers/specs/2026-07-16-muster-station-design.md
+++ b/docs/superpowers/specs/2026-07-16-muster-station-design.md
@@ -1,0 +1,317 @@
+# muster station — operator TUI + intent + session identity (design)
+
+Date: 2026-07-16 · Status: reviewed (muster-2 adversarial pass, thread 27 —
+22 findings, 6 blockers; all folded in or explicitly decided), approved to
+build
+Local-only spec (docs/ is untracked in the public repo). Ships as v0.6.0.
+
+## Problem
+
+The operator has no live surface: watching the bus means a `muster watch`
+tail in one shell, `muster agents` in another, and `get_thread` spelunking to
+read anything. Three defects found during live use ride along because the
+station is half-blind without them:
+
+1. **No intent on messages** — "1.2.2 shipped, FYI" and "please review this
+   spec" are indistinguishable to inboxes, drains, and the journal.
+2. **Split-alias identity** — a session registered under both its tmux
+   session name and a chosen alias (bettor-help-workspace-2 +
+   nfl-research-agent, live case) has two read-states. The Stop hook drains
+   the session-name alias while peers address the chosen one, so the chosen
+   alias's unread count accretes wrongly (`lit(2)` incident).
+3. **Reply rows masquerade as duplicates** — journal reply rows render the
+   thread subject, so an announcement and its reply look like a double-send.
+
+## Goal
+
+`muster station`: a full-screen operator TUI — roster, live feed, threads,
+and the ability to act (read / reply / send / nudge) — plus the three backend
+fixes. Station is a **peer client of the daemon** over the unix socket (no
+MCP; MCP is the LLM-agent adapter) and is **addressable**: it registers as
+agent `station`.
+
+## Non-goals
+
+- No MCP server changes beyond the `intent` input field.
+- No push/streaming transport — station polls like watch does.
+- No mouse support, no themes/config files. Keyboard only; knobs are flags.
+- The dedicated tmux session that launches station is dotfiles work,
+  requested over the bus after release — out of scope here.
+
+## Design
+
+### 1. Backend: `list_threads` op (side-effect-free)
+
+The threads pane must never consume an agent's mailbox (`get_inbox`
+mark-reads — the peek problem, which stranded a live message on 07-16).
+
+- Store: `Threads(limit int) ([]Thread, error)` — newest `updated_at` first
+  (ties broken by `id DESC`), `limit` clamped to 500 (default 100 when
+  <= 0). The entry annotations aggregate ONLY over the already-limited
+  thread set (subquery first, then join), never the full entries table —
+  station polls this every second.
+- Last-entry identification is by `MAX(entries.id)` (the append order), and
+  `last_from`/`last_at` come from that same row — never a GROUP BY picking a
+  non-aggregated column, never `MAX(created_at)` (millisecond ties).
+- Daemon op `list_threads` args `{limit}` → `{"threads": [...]}`. Reads
+  nothing else, marks nothing, notifies nobody (regression test: all flags
+  and read-states identical before/after).
+- Wire Thread gains `intent` (effective value, §2), `last_from`, `last_at`,
+  `entry_count`.
+
+### 2. Backend: message `intent`
+
+- Schema: `ALTER TABLE threads ADD COLUMN intent TEXT NOT NULL DEFAULT ''`
+  (additive migration; fresh CREATE updated to match).
+- Vocabulary: `''` (unspecified) | `fyi` | `reply-requested` |
+  `action-requested`. Validation and defaulting live at the STORE boundary
+  (`CreateThread` rejects unknown values) so MCP, CLI, station, and tests
+  cannot diverge; the daemon just passes through.
+- **Effective intent is a derived value, one canonical SQL fragment**:
+  `CASE WHEN kind='task' AND intent='' THEN 'action-requested' ELSE intent
+  END` — used by every read surface (Threads, SessionUnread action count,
+  the events join). A task IS a request for action, including every
+  pre-existing v0.5 task row; no migration backfill, no retroactive
+  inconsistency between old and new tasks.
+- Surfaces:
+  - MCP `send_message`/`task_create` inputs gain optional `intent` (schema
+    docs teach agents to mark FYIs — the drain loop gets cheaper).
+  - CLI: `muster send --intent fyi|reply-requested|action-requested`.
+  - Journal: send/task rows append ` [fyi]` / ` [action]` / ` [reply?]` to
+    WHAT when intent is set. No schema change to events: `Events()` adds
+    `COALESCE(threads.intent,'')` to its existing LEFT JOIN (exactly like
+    subject) and the wire Event/eventRow gain a query-time `intent` field;
+    the renderer maps it to the tag.
+  - Stop hook drain text: unchanged wording plus, when any unread thread's
+    effective intent is `action-requested`, the count is split: "You have N
+    unread muster thread(s), M needing action." Both numbers come from
+    `SessionUnread` (§3) — one query, session-level, no second counting
+    path.
+- Inbox ordering: `Inbox()` unchanged (newest first). Station groups by
+  intent client-side; the MCP surface stays stable.
+
+### 3. Backend: split-alias identity fix — session-level unread model
+
+Design principle (review finding): **all aliases sharing one exact
+`(socket_path, session_id)` tuple are ONE actor identity** for unread math,
+actor exclusion, and notification. Records are not deduped (a session may
+keep its session-name alias and a chosen alias); their accounting is
+unified. Empty socket/session tuples are never grouped (an agent without
+tmux identity is its own singleton).
+
+- **Read watermark becomes an entry ID, not a wall clock.** `agents` gains
+  `last_read_entry_id INTEGER NOT NULL DEFAULT 0` (additive migration;
+  initialized once from the max `entries.id` with `created_at <=
+  last_read_at` so existing read-states carry over). `MarkRead` records the
+  max entry ID visible in the same transaction as the Inbox read. All
+  unread predicates become `e.id > last_read_entry_id` — the strict-`>`
+  same-millisecond loss class (and its fake-clock test contortions) goes
+  away. `last_read_at` stays for display only.
+- **One canonical session-unread query.**
+  `SessionUnread(socketPath, sessionID string) (total, action int)`:
+  `COUNT(DISTINCT t.id)` over threads T where ∃ alias A in the session such
+  that T concerns A (threadConcerns) AND ∃ entry `e.id >
+  A.last_read_entry_id` whose `from_agent` is **not any alias of the
+  session** (actor exclusion is session-based — a session's own writes
+  under either alias never make it unread). `action` counts the subset
+  whose effective intent is action-requested. No summing of per-alias
+  counts anywhere — that double-counts shared threads.
+- **Notify coalesces by session.** `notifyForThread` builds the affected
+  *sessions* (originator + recipients, grouped by tuple), drops the actor's
+  entire session, and per session: computes `SessionUnread` once, sets
+  `@muster_inbox` once, journals ONE notify row (Agent = the addressed
+  alias that put the session in scope; Count = the session count). No
+  duplicate lit rows for sibling aliases.
+- **Mutation→recompute→write is locked.** The daemon holds a per-session-
+  tuple mutex (lazily created map) around the {store mutation, SessionUnread
+  recompute, tmux option write} sequence in both notify and get_inbox
+  paths, with the recompute inside the lock — closes the stale-write race
+  where a concurrent drain's smaller count is overwritten by an in-flight
+  notify's larger one. Tests drive deterministic interleavings via the
+  injectable notifier, not just sequential flows.
+- **get_inbox semantics.** If Inbox succeeds but MarkRead fails, the op
+  FAILS (no read event journaled, badge untouched) — a read that didn't
+  persist must not report success. On success it recomputes the session
+  count inside the lock: drains of one alias leave the badge at the
+  remainder (the lit(2) fix). Sum-query or tmux failures journal
+  `detail: "error: …"` and never blind-Clear.
+- **Hook drains every alias of the session.** New op `session_aliases` args
+  `{socket_path, session_id}` (both non-empty or the op fails) →
+  `{"aliases": [...]}` sorted, deduplicated. The hook's block message lists
+  them all with get_inbox instructions per alias; zero rows or op failure →
+  current behavior (session name). Documented as a point-in-time hint over
+  mutable registration data, not identity.
+- **Reconciliation on identity changes.** register/deregister/gc recompute
+  and rewrite the badge for any session tuple they touch, so stale flags
+  don't survive re-registration or reaping.
+
+### 3b. Backend: nudge text carries the drain instruction
+
+Live finding (2026-07-16, thread 27): a nudged Codex checked its inbox,
+*listed* the new thread, and idled — "check your inbox" satisfies itself,
+and by then its own get_inbox has cleared the flag so the Stop hook never
+escalates. The nudge line becomes the hook's wording: "check your muster
+inbox: call get_inbox, read each new thread with get_thread, handle the
+request, and reply on the thread — act autonomously." One string in
+`internal/nudge`; the typed-only path for unknown models unchanged.
+
+### 4. Backend: reply rows carry a body preview
+
+`reply` journal rows get `Detail = sanitizeForDisplay(body, 80)` at journal
+time (detail is currently empty for replies; the duplication into the
+30-day-pruned local journal is accepted deliberately — no entry_id column).
+Renderer: reply WHAT becomes `↳ <detail>` when detail is non-empty, else
+the subject. `claim`/`transition` unchanged.
+
+**`sanitizeForDisplay` becomes the one display sanitizer** (renderer +
+journal previews + station panes): strips ALL control characters — ESC/CSI
+sequences, NUL, bidi controls — not just `\t\n\r`, and truncates by
+**display width** (wide/combining runes counted properly) rather than rune
+count, so one hostile subject can't corrupt the TUI or wrap a line.
+Fuzz-tested with control-sequence and wide-character corpora.
+
+### 5. `muster station` (TUI)
+
+- **Dependency**: `github.com/charmbracelet/bubbletea` + `bubbles` +
+  `lipgloss`, versions pinned (pure Go — the build stays `CGO_ENABLED=0`).
+  First dependency beyond modernc sqlite and the MCP SDK; accepted
+  deliberately. **Gated, not asserted**: `just verify` gains a `cross`
+  step building all four release targets (darwin/linux × arm64/amd64)
+  under `CGO_ENABLED=0`, and `release.yml` is reordered to BUILD all
+  targets before creating the GitHub release — today a failed cross-build
+  leaves an already-created empty release (pre-existing defect, fixed
+  here because the new dependency raises the odds of hitting it).
+- **Identity, collision-safe**: on start, station registers alias
+  `station` (role `operator`, model `station`) with its real tmux identity.
+  If the alias already exists on a LIVE record with a *different* session
+  tuple, registration fails over to `station-2`, `station-3`, … (a dead
+  record is taken over). Deregistration is deferred (runs on q, signal, and
+  panic paths after terminal restore) and CONDITIONAL: it re-fetches the
+  record and deregisters only if the session tuple still matches its own —
+  a second station or a re-registered agent is never deleted by the first's
+  exit. TUI init failure rolls the registration back. `gc` covers hard
+  crashes. `nudge` treats model `station` as typed-only (existing
+  unknown-model default).
+- **Layout** (three panes + status line, focus cycles with Tab):
+  - **Roster** (left, ~30 cols): project-grouped agents — live dot, label
+    (alias fallback, the v0.5.1 `disp` rules), unread count. Cursor selects
+    an agent; `n` nudges it (confirmation line first: "nudge <label>? y/n").
+  - **Feed** (right-top): the journal tail, v0.5.1 renderer verbatim (WHO
+    arrows, labels, width-capped WHAT). Follows unless scrolled up;
+    `End`/`G` snaps back to live.
+  - **Threads** (right-bottom): from `list_threads` — id, intent tag,
+    participants (from → to, labels), last speaker + age, subject.
+    `action-requested` group pinned on top, then `reply-requested`, then
+    the rest, newest first within groups. Enter opens the thread view.
+  - **Thread view** (overlay): entries oldest first, wrapped, loaded via
+    `get_thread` with its new `{offset, limit}` pagination (station passes
+    limit 200 with lazy "load older"; args absent = everything, so existing
+    callers are untouched). `r` opens the composer as a reply; Esc closes.
+    Reading is side-effect-free everywhere, with ONE explicit exception:
+    **opening** a thread addressed to `station` acknowledges it (a targeted
+    read for station's alias) — there is NO focus-based or pane-based
+    auto-read, so a station left running unattended never silently consumes
+    requests (review finding; the earlier auto-read design is dropped).
+  - **Composer** (bottom line, opens on `s`/`r`): single-line input; for
+    `s`, a target picker filtered from the roster precedes it (label or
+    alias match); `--intent` cycled with a keystroke (F/R/A indicator);
+    Enter sends via the same `send_message`/`reply` ops the CLI uses; Esc
+    cancels. Errors land in the status line, never a crash.
+- **Data loop — the MODEL owns the cursor.** No free-running poller
+  goroutine: on each `tea.Tick` (default `--interval` 1s) the model issues
+  three independent Cmds — `list_events after_id=<model's cursor>`,
+  `list_agents`, `list_threads` — each returning its own message. The event
+  cursor advances only when the model APPLIES an event page, so a dropped
+  or failed delivery can never skip events; roster/threads failures don't
+  block the feed. Panes are independently versioned — no decision is ever
+  derived from a mixed tick bundle (there is no cross-pane snapshot to
+  trust). Cursor discipline otherwise identical to watch (max_id,
+  regression reset). Errors: status-line note + retry, never exit. Thread
+  selection is preserved by thread ID across regrouping, so a poll never
+  jumps the operator's cursor.
+- **Keys**: Tab focus · j/k or arrows move · Enter open · Esc back · `s`
+  send · `r` reply · `n` nudge · `/` filter (fuzzy over the focused pane) ·
+  `a` toggle aliases/labels · `q` quit (deregisters).
+- **Flags**: `--interval` (1s), `--aliases`, `--width` handled by the
+  framework, `--alias` (default `station`, so two stations on one machine
+  don't collide).
+
+### 6. Testing
+
+- **store**: `Threads()` ordering (updated_at DESC, id DESC ties),
+  limit-first aggregation, last-entry-by-max-id under same-millisecond
+  entries; intent + `last_read_entry_id` migrations on a hand-built v0.5
+  DB (reopened twice, watermark initialized from last_read_at); intent
+  validation + effective-intent CASE at every read surface (old task rows
+  count as action); `SessionUnread` — the double-count case (broadcast
+  concerning both sibling aliases counts ONCE), session-based actor
+  exclusion (sibling alias's write is not unread), empty-tuple singleton.
+- **daemon**: `list_threads` marks nothing read (flags/read-states
+  byte-identical before/after); session-coalesced notify — two sibling
+  aliases, one lit row, one badge write; the lit(2) regression (drain one
+  alias → badge shows remainder); deterministic interleaving of
+  notify-vs-drain under the session lock (injectable notifier ordering);
+  get_inbox fails when MarkRead fails (no read event, badge untouched);
+  `session_aliases` rejects empty fields, returns sorted/deduped;
+  register/deregister/gc badge reconciliation; reply preview sanitized;
+  get_thread pagination back-compat (no args = all entries).
+- **hook**: multi-alias drain text (sorted); op-failure fallback; "M
+  needing action" wording gated on action-requested unread; nudge line
+  carries the full drain-and-act instruction (§3b).
+- **station**: model-level Update/View tests (no PTY): cursor advances only
+  on applied event pages (fail the threads fetch after a successful events
+  fetch → nothing skipped); roster labels/counts; intent grouping with
+  selection preserved across regroup; open-to-acknowledge (opening a
+  station thread reads it; focus alone reads nothing); composer send/reply
+  invoke the real ops against a test daemon; nudge confirmation; collision
+  fail-over to station-2; conditional deregister leaves a re-registered
+  alias alone.
+- **rendering**: `sanitizeForDisplay` fuzz — ESC/CSI/NUL/bidi stripped,
+  display-width truncation with wide/combining runes.
+- Full `just verify` incl. the new `cross` matrix step; VERSION `0.6.0`.
+
+## Sequencing (implementation slices)
+
+1. Store foundations: intent column + store-boundary validation +
+   effective-intent fragment; `last_read_entry_id` migration + ID-watermark
+   MarkRead; `SessionUnread`; `Threads()`; migration tests.
+2. Daemon identity/notify rewiring: session grouping + per-session lock,
+   coalesced notify, get_inbox strict semantics, `session_aliases`,
+   register/deregister/gc reconciliation + interleaving tests.
+3. Daemon surface: `list_threads`, intent pass-through, get_thread
+   pagination, reply preview + `sanitizeForDisplay` (shared with renderer)
+   + fuzz tests.
+4. Hook + nudge: multi-alias drain, action-count wording, nudge
+   drain-and-act text + tests.
+5. CLI: `send --intent`, journal intent tag + `↳` preview rendering +
+   tests.
+6. Release safety: `just cross` matrix step in verify/CI; release.yml
+   builds before creating the release.
+7. Station scaffold: pinned dependencies, model/update/view skeleton,
+   tick-driven Cmds with model-owned cursor, roster + feed panes + model
+   tests.
+8. Station threads + thread view (paginated) + intent grouping +
+   open-to-acknowledge.
+9. Station actions + lifecycle: composer (send/reply with intent picker),
+   nudge with confirm, filter, aliases toggle; collision fail-over,
+   conditional deferred deregister, terminal restore on all exit paths.
+10. Docs (README + site one-sentence mention), usage line, VERSION 0.6.0,
+    live smoke ($TMUX-scrubbed per the 07-16 lesson), ship.
+
+## Risks / notes
+
+- bubbletea is the first sizeable dependency; it is pure Go and vendored by
+  go.sum like everything else. If it ever blocks `CGO_ENABLED=0`, that is a
+  release blocker by rule.
+- The session-level badge changes `@muster_inbox` semantics from per-alias
+  to per-session distinct-thread counts. The tmux render and hook read the
+  option identically; only the number can differ (it becomes truthful).
+  Documented in README.
+- `last_read_entry_id` supersedes wall-clock read semantics; `last_read_at`
+  is retained as display metadata only. The one-time watermark
+  initialization is approximate for pre-migration edge cases (entries at
+  exactly last_read_at count as read) — acceptable, matches prior strict-`>`
+  behavior.
+- Two records per session remain legal; the fix makes them coherent, not
+  forbidden. A future `muster register --takeover` could absorb the
+  session-name record; deliberately out of scope.

--- a/docs/superpowers/specs/2026-07-16-muster-watch-design.md
+++ b/docs/superpowers/specs/2026-07-16-muster-watch-design.md
@@ -1,0 +1,210 @@
+# muster watch — bus journal + live tail (design)
+
+Date: 2026-07-16 · Status: reviewed (muster-2 adversarial pass, thread 19 —
+all 16 findings folded in or explicitly decided), pending user approval
+Local-only spec (docs/ is untracked in the public repo).
+
+## Problem
+
+The bus has no live observability surface. The 2026-07-16 originator-blindness
+incident took an hour of SQLite + transcript forensics to reconstruct a
+timeline the operator should have been able to *watch*. v0.4.x added an events
+table, but it records only the wake layer (mailbox notifies and inbox reads),
+not the bus traffic itself — sends, replies, task claims and transitions. The
+incident needed both halves interleaved.
+
+## Goal
+
+1. **The events table becomes the full bus journal**: every bus action is one
+   append-only row, written by the daemon at dispatch time.
+2. **`muster watch` is a plain streaming tail of that journal** — one line per
+   event, filters, runs until Ctrl-C. No TUI: that is the next milestone, and
+   it consumes exactly what this slice builds (journal + incremental fetch +
+   filters).
+
+## Non-goals
+
+- No TUI / curses / screen redraws (v3 milestone).
+- No streaming protocol change: the daemon keeps its one-request/one-response
+  newline-JSON protocol; watch polls.
+- No `inbox --wait` for agents (separate idea; the Stop-hook drain covers
+  agents today).
+
+## Design
+
+### 1. Journal schema (store)
+
+`events` gains one column (additive migration — v0.4.x DBs already have the
+table):
+
+```sql
+ALTER TABLE events ADD COLUMN target TEXT NOT NULL DEFAULT ''
+```
+
+Event kinds (existing + new):
+
+| kind         | agent (actor)     | target                      | thread_id | count  | detail                  |
+|--------------|-------------------|-----------------------------|-----------|--------|-------------------------|
+| `send`       | from-agent        | `agent:x` / `role:r` / `broadcast` | id  | 0      | subject                 |
+| `reply`      | from-agent        | ''                          | id        | 0      | ''                      |
+| `task`       | from-agent        | `agent:x` / `role:r` / `broadcast` | id  | 0      | subject                 |
+| `claim`      | claiming agent    | ''                          | id        | 0      | ''                      |
+| `transition` | acting agent      | ''                          | id        | 0      | new status              |
+| `nudge`      | operator (`''`)   | nudged alias                | 0         | 0      | `typed` / `submitted`   |
+| `notify`     | notified agent    | ''                          | id        | unread | `lit`/`cleared`/`skipped: …`/`error: …` |
+| `read`       | reading agent     | ''                          | 0         | 0      | ''                      |
+
+Store API changes:
+
+- `AppendEvent` unchanged (Event struct gains `Target string`; `eventRow` in
+  the CLI gains `ID` and `Target` — watch needs the ID for its cursor).
+- `RecentEvents(agent string, limit int)` becomes
+  `Events(q EventQuery) ([]Event, error)` with
+  `EventQuery{Agent, Kind string, ThreadID, AfterID int64, Limit int,
+  Backlog bool}` — mode is **explicit** (`Backlog`), never inferred from
+  `AfterID == 0`:
+  - Backlog mode: newest-first, `LIMIT` rows (`Limit == 0` returns none —
+    watch uses that to learn the cursor without printing history).
+  - Follow mode: `id > AfterID`, **oldest-first**.
+  - The **agent filter** matches events the alias is concerned in, exactly
+    (no LIKE — aliases must never become SQL patterns):
+    `agent = ?` OR `target = 'agent:'||?` OR `target = ?` (nudge's bare
+    alias) OR, for events with `thread_id > 0`, the event's thread satisfies
+    `threadConcerns` for the alias — this is what makes replies/claims/
+    transitions on *your* threads match even though their `target` is empty.
+    Role matching uses the alias's *current* role (same semantics as
+    `threadConcerns` everywhere else); historical-role drift is accepted and
+    documented.
+  - Validation: `Limit` clamped to 1000; negative `AfterID`/`ThreadID`
+    rejected; an unknown `Kind` just matches nothing.
+- `Events()` LEFT JOINs `threads` to attach each event's thread **subject**
+  (empty for thread-less events) — dogfooding showed a bare thread id makes
+  the journal unreadable without a second lookup ("what are those two
+  messages?"). The wire event gains a `subject` field.
+- `MaxEventID() (int64, error)` — the journal high-water mark.
+- `PruneEvents(olderThanMillis int64) (int64, error)`: `DELETE WHERE ts <
+  cutoff` (a row exactly at the cutoff survives; boundary tested).
+
+### 2. Daemon journaling
+
+Each dispatch handler appends its journal row **immediately after the
+successful store mutation and before `notifyForThread`**, so a bus action
+always precedes the wake rows it causes. Journaling stays best-effort
+(`logEvent`): an append failure never fails or blocks the op. Consequence,
+stated plainly: the journal is an operator/forensics feed with append-order
+IDs, not a transactional audit log — a crash between mutation and append can
+drop a row, and concurrent handlers can interleave. Acceptable for v1; a
+transactional outbox is a deliberate non-goal.
+
+- `send_message` → `send`, `task_create` → `task`, `reply` → `reply`,
+  `task_claim` → `claim`, `task_transition` → `transition`.
+- **`task_claim` also gains `notifyForThread`** — today it's the one mutation
+  that wakes nobody (an originator never learns their task was claimed).
+  Journaling all activity makes that asymmetry visible; fix it deliberately
+  rather than inherit it.
+- New op `log_event`: lets a client report an action the daemon cannot see.
+  The daemon **constructs the canonical event itself** — the client supplies
+  only `target` (must be a registered alias; verified) and `detail`
+  (`typed` | `submitted`, validated); kind is forced to `nudge`, agent to
+  `""`, thread/count to 0. Note the unix socket has no authenticated caller
+  identity — this is a constrained client assertion, not provenance.
+- `list_events` op args: `agent`, `kind`, `thread_id`, `after_id` (sent as a
+  **decimal string** — the proto's float64 numbers lose integer precision
+  past 2^53), `limit`, `backlog`. The response is `{events, max_id}` —
+  `max_id` is the journal high-water mark at query time, returned in **every**
+  response so a caller always has a cursor even when zero rows match.
+- New op `prune_events` (`older_than_ms` > 0, validated) — gc's path to
+  retention; the CLI has no direct store access.
+
+`muster nudge` reports itself via `log_event` after typing. The daemon still
+never types into panes.
+
+### 3. `muster watch` (CLI)
+
+```
+muster watch [--agent <alias>] [--thread <id>] [--kind <k>] \
+             [--interval <dur>] [--backlog <n>]
+```
+
+- Prints the last `--backlog` (default **10**; `0` = follow only, no history)
+  matching events, then follows: polls `list_events` with `after_id = cursor`
+  every `--interval` (default **1s**), printing one line per event until
+  Ctrl-C / SIGTERM.
+- **Cursor discipline:** the cursor starts at the backlog response's
+  `max_id` (never inferred from printed-slice position, which is fragile
+  across the newest-first/oldest-first flip) and advances to each response's
+  `max_id`. If a response's `max_id` is *lower* than the cursor, the DB was
+  replaced under a respawned daemon — watch resets the cursor to the new
+  `max_id` and says so on stderr rather than silently going quiet forever.
+- **Errors and shutdown:** a failed poll (daemon restarting, socket blip)
+  retries on the next interval with a one-line stderr note — a live tail
+  must survive a daemon respawn, not die mid-incident. The wait is
+  signal-aware (select on signal channel + timer), so Ctrl-C is immediate,
+  never delayed up to an interval.
+- Line format matches `muster events`: TIME KIND AGENT TARGET THREAD COUNT
+  DETAIL SUBJECT — subject joined from the thread so a row like
+  `notify muster-2 19 2 lit` reads as *what* lit, not just that something
+  did. Tabs/newlines in subjects and details are replaced with spaces at
+  render time so one event is always exactly one line; subject truncated to
+  keep lines sane (60 chars, render-side).
+- `muster events` and `watch` are **side-effect-free observers**: they never
+  mark anything read and never touch mailboxes. (Contrast: `muster inbox
+  <alias>` runs the real `get_inbox`, which marks the agent's inbox read and
+  clears its 📬 — an operator peeking at an agent's inbox consumes its flag.
+  A `--peek` mode for inbox is noted as a follow-up, out of scope here; watch
+  removes most reasons to peek.)
+- The poll loop takes an injectable wait func and an optional max-iterations
+  bound used by tests.
+- `muster events` gains the same `--kind` / `--thread` filters for parity
+  (one-shot view over the same query). Both subcommands appear in the usage
+  line (routing already flows through `humancli.Dispatch` — v0.4.1).
+
+### 4. Retention
+
+`muster gc` prunes journal rows older than `--events-keep` (a Go duration,
+default **720h** = 30 days; Go's duration syntax has no "d" unit) via the
+`prune_events` op, reporting the pruned count. `--events-keep <= 0` is
+rejected ("delete everything" must not be a typo away). gc reaps dead agents
+first, then prunes; each step reports its own result or error so a failure
+in one never masquerades as success in the other. Nothing else expires.
+
+### 5. Testing
+
+- **store**: journal row per kind; follow ordering (oldest-first) vs backlog
+  (newest-first) with `Limit > 1` under interleaved inserts; agent filter
+  matches actor, `agent:` target, bare-alias target, AND thread-concern
+  (reply on an originated thread with empty target — the finding-1 case);
+  migration: a **hand-built v0.4 schema with data** (not one created by
+  current `Open`) gains `target` with `''` defaults, reopened twice;
+  `MaxEventID`; prune exact-boundary (`ts == cutoff` survives); limit clamp
+  and negative-arg rejection.
+- **daemon**: each of the five ops journals the right row **in order**
+  (action row before its notify rows — assert interleaving, not just
+  presence); claim now notifies; `log_event` forces canonical fields,
+  rejects unregistered targets and non-nudge kinds; `list_events` honors
+  after_id (as string)/kind/thread/backlog and always returns `max_id`;
+  `prune_events` validates.
+- **humancli**: watch with injectable wait + iteration bound — backlog then
+  follow, `--backlog 0`, cursor-regression reset, poll-error retry, filters;
+  events filter flags; gc `--events-keep` validation; one-line rendering of
+  a subject containing a newline.
+- Full `just verify` gate; VERSION bump `0.5.0` on ship.
+
+## Sequencing (implementation slices)
+
+1. Store: `target` column + `EventQuery`/`Events()` + `PruneEvents` + tests.
+2. Daemon: journal appends in the five handlers + `log_event` + richer
+   `list_events` + tests.
+3. CLI: `watch` + `events` filters + nudge self-report + `gc --events-keep` +
+   tests.
+4. Docs: README (watch/events/gc), site tools section touch. Release 0.5.0.
+
+## Risks / notes
+
+- Journal writes add one INSERT per op on the daemon's single connection —
+  negligible at this scale; best-effort so a journaling failure never blocks
+  the bus.
+- Polling latency ≤ interval; acceptable for a human tail. The TUI can revisit
+  transport later if it ever needs sub-second push.
+- `log_event` is the first client-asserted journal row; constraining v1 to
+  `nudge` keeps the journal trustworthy as forensics.

--- a/docs/superpowers/specs/2026-07-17-agent-status-design.md
+++ b/docs/superpowers/specs/2026-07-17-agent-status-design.md
@@ -1,0 +1,108 @@
+# Self-published agent status (tier-2 enrichment) — design
+
+Date: 2026-07-17 · Status: REVISED after muster-2 adversarial review (thread
+37, 22 findings — all folded or explicitly decided). Build order: after the
+station UX settles; hook slice LAST (finding 22).
+
+## Problem
+
+Station shows who exists and what they said, not what they're doing. Wanted,
+per session: optional one-line status, last turn end, context/token pressure.
+Enrichment is an optional convention (like labels): absent agents show less,
+muster stays a lean bus, dotfiles and non-dotfiles identical.
+
+## Store (additive; fresh CREATE + guarded ALTERs in one slice)
+
+```sql
+status_text   TEXT    NOT NULL DEFAULT ''   -- explicit, per-alias
+status_at     INTEGER NOT NULL DEFAULT 0    -- stamps ONLY status_text changes
+turn_ended_at INTEGER NOT NULL DEFAULT 0    -- vitals: stamped daemon-side
+ctx_tokens    INTEGER NOT NULL DEFAULT 0
+out_tokens    INTEGER NOT NULL DEFAULT 0
+ctx_window    INTEGER NOT NULL DEFAULT 0    -- publisher-supplied; 0 = unknown
+```
+Wire Agent mirrors all six (station/MCP/humancli mirrors updated same slice).
+RegisterAgent's upsert DOES NOT touch these (refresh preserves status —
+regression-tested); deregister loses them deliberately (documented). Values
+validated: 0 <= v <= 10^12; checked addition when summing usage components.
+
+## Daemon ops
+
+- `set_status {alias, status_text?}` — text only, per-alias. Key-PRESENCE
+  semantics: absent = preserve; present (incl. "") = set + stamp status_at
+  (clear = ''+stamp: auditable, invisible). Sanitized at the daemon
+  (display.Sanitize, 120 cols). Unknown alias fails — never creates rows.
+  One atomic UPDATE. No journal row, no notify.
+- `set_session_vitals {socket_path, session_id, ctx_tokens?, out_tokens?,
+  ctx_window?, stamp_turn?}` — metrics for ALL aliases of one exact tuple,
+  atomically, one round trip (finding 14). `stamp_turn: true` sets
+  turn_ended_at = daemon clock — clients never supply epochs (finding 7).
+  Presence semantics as above; touches ONLY metric columns, never
+  status_text/status_at. Empty tuple fields fail.
+- Vitals/status are NOT journaled (current-state, not bus actions); their
+  absence from forensics is deliberate and documented. Observability = the
+  fields themselves on list_agents/get_agent (staleness self-describing).
+
+## Publishers
+
+- CLI `muster status "text" | --clear` — mutually exclusive, extra args
+  rejected, flag-like text after `--` supported; alias resolution as
+  register; in both usage lines.
+- MCP `set_status {status_text}` — NO alias input. The mcp server binds
+  identity ONCE at startup exactly as register does (MUSTER_ALIAS → tmux
+  session name via captured env); unbound identity → tool errors with
+  guidance. Local-socket trust model unchanged (documented: any local
+  client could call the daemon op directly; the MCP surface simply doesn't
+  invite cross-agent writes).
+- Hook (automatic; LAST slice; opt-out MUSTER_NO_VITALS=1):
+  1. **Decision first.** hookStop computes and WRITES the drain decision
+     (or nothing) before any enrichment. Enrichment runs after, with every
+     diagnostic discarded (no stdout/stderr writes anywhere in the path,
+     incl. panic recovery); stdin read via io.LimitReader (1MB).
+  2. Skipped entirely when stop_hook_active=true (finding 13; the original
+     invocation publishes even when it emits decision:block — tested both
+     halves).
+  3. **No-spawn, deadline-bounded client**: a dial-only connection (never
+     spawns the daemon) with a 250ms total deadline; daemon down → skip.
+  4. Transcript read hardening: Lstat (reject symlinks — product decision,
+     documented; harnesses write real files), open, fstat the FD (regular
+     file, snapshot size), ReadAt within snapshot, discard first partial
+     line, ignore incomplete final line, shrink/rotation → fail closed.
+  5. Parser: versioned, evidence-based, Claude-first — exact supported
+     record shape (assistant message.usage), backward scan over COMPLETE
+     newline-delimited records with an expanding window (64KB → 1MB hard
+     cap; a final record bigger than the cap → skip, finding 1). JSON
+     numbers decoded without float conversion; negative/fractional/
+     overflow rejected; fixtures captured per supported harness version;
+     unknown shapes unsupported → skip. Codex parser ships only when its
+     format is verified.
+  6. ctx = checked-sum of input + cache_read (+ cache_creation ONLY where
+     the provider doesn't fold it in — decided per fixture evidence, not
+     assumed); ctx_window from the payload's concrete model id via a
+     publisher-side table (hook knows the real model; daemon/station never
+     guess — finding 5).
+  7. Publishes via set_session_vitals (tuple from its own captured env;
+     session_aliases not needed). Failure silent.
+
+## Station display (separate UI slice)
+
+Three independent freshness clocks (finding 17): tmux liveness ("offline"
+overrides everything, metrics grayed); status_text aged by status_at
+("working on X · 3h ago"); ctx aged by turn_ended_at (suppressed > 1h or
+when 0). Percentage rendered ONLY when ctx_window > 0: `~85k (42%)`;
+otherwise raw tokens. Future timestamps render as "clock skew?" not fresh.
+
+## Privacy scope (stated, not absolute)
+
+Numbers are behavioral metadata: they reveal activity timing, workload
+scale, and (with window) model tier to any local bus client — never
+transcript content. transcript_path and parse errors are never persisted,
+journaled, or copied into status/errors. Auto-publication is opt-out.
+
+## Testing (highlights beyond the per-item tests above)
+
+Fuzz the tail parser on arbitrary bytes/nesting; wall-time test: hookStop
+returns within budget under FIFO path, missing daemon, huge stdin, and a
+concurrently-appending writer, with stdout byte-identical in all cases;
+absent-vs-0-vs-null-vs-negative-vs-string matrix for both ops; pre-status
+hand-built DB reopened twice.

--- a/site/index.html
+++ b/site/index.html
@@ -31,6 +31,7 @@
 
 <nav class="toc" aria-label="Sections">
   <a href="#top">muster</a>
+  <a href="#for">what it's for</a>
   <a href="#flow">the flow</a>
   <a href="#what">what it is</a>
   <a href="#tools">the tools</a>
@@ -71,6 +72,68 @@ api-2   reply  <span class="c-sig">"fixed — createdAt added"</span>
     </div>
   </div>
 </header>
+
+<section id="for">
+  <div class="wrap">
+    <p class="kicker">what it's for</p>
+    <h2>The problem is inter-session communication.</h2>
+    <p class="lead">
+      If you run more than one coding-agent session, the sessions know nothing about each other.
+      Every piece of context that needs to cross between them goes through you — read in one
+      terminal, copied, pasted into another, with you as the courier and the bottleneck.
+      <span class="mstr">muster</span> replaces that copy/paste with a channel the sessions use
+      themselves. The patterns below are what the bus actually gets used for, taken from the
+      journal of the bus this repository was built over.
+    </p>
+    <div class="toolgroups">
+      <div class="tg">
+        <h3>independent review</h3>
+        <p>One session writes the code and a different session reviews it — a peer with no
+        stake in the diff, often a <b>different model</b> entirely. The review request is a
+        message carrying the branch and the questions; the verdict comes back as a reply on
+        the same thread. The longest review thread on our bus ran <b>25 entries</b> before
+        the pull request merged.</p>
+      </div>
+      <div class="tg">
+        <h3>handoffs</h3>
+        <p>A session that is winding down writes what the next one needs to know — the current
+        state, the decisions already made, what remains — to the session taking over. The
+        successor reads it when it starts, and when something turns out to be missing it
+        <b>asks the predecessor on the same thread</b> instead of re-deriving the answer
+        from the repository.</p>
+      </div>
+      <div class="tg">
+        <h3>notes &amp; journaling</h3>
+        <p>A build session streams raw material — decisions, failures, numbers — to a
+        note-taking session in another terminal <b>while the work happens</b>. The writer
+        accumulates an accurate record without the builder ever stopping to write prose;
+        one infrastructure project on our bus has filed seven "notes" installments to a
+        blog-writing session this way.</p>
+      </div>
+      <div class="tg">
+        <h3>cross-repo coordination</h3>
+        <p>When two repositories share a contract — a producer writing data, a consumer
+        reading it — their two sessions keep a running thread: status checks, deploy
+        verdicts, and flags like <b>"these two plans contradict each other"</b> that need
+        the other side's answer before work can continue. These threads run for days and
+        dozens of entries.</p>
+      </div>
+    </div>
+    <div class="term" role="img" aria-label="An inbox listing of real thread subjects from this repository's own bus: review requests, handoffs, notes installments, a contradiction flag, and a release-signing request.">
+      <div class="term-bar"><span class="lamp"></span><span class="lamp"></span><span class="lamp"></span><span class="title">~ real traffic</span></div>
+<pre><span class="c-dim"># subjects from this repo's own bus journal (private repo names redacted)</span>
+<span class="c-dim">KIND     SUBJECT                                                    ENTRIES</span>
+message  Spec review: muster station (operator TUI + intent)        3
+message  Independent review request: PR #637 (weather cutover)      25
+message  HANDOFF: repo has NO PR-gating CI — full context inside    20
+message  Plans 3–7 handoff — START HERE doc + current dev state     1
+message  CONTRADICTION: "Plan 2 COMPLETE" vs tasks 6–9 absent       4
+message  MicroVM notes #5: the overnight build — 11 tasks           1
+message  v0.7.1 shipped — please sign release; flaky test filed     4
+</pre>
+    </div>
+  </div>
+</section>
 
 <section id="flow">
   <div class="wrap">

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -8,6 +8,24 @@
 > notification, and never calls a model itself; it only routes between agent
 > sessions that are already running on their own.
 
+## What it's for
+
+The problem muster solves is inter-session communication: without it, context
+crosses between agent sessions only by a human copying it from one terminal and
+pasting it into another. Observed usage patterns from the bus this repository
+was built over:
+
+- Independent review: one session writes the code, a peer session (often a
+  different model) reviews the branch and replies with a verdict on the same
+  thread.
+- Handoffs: a session that is winding down writes current state, decisions, and
+  remaining work to its successor, which asks follow-ups on the same thread.
+- Notes and journaling: a build session streams decisions, failures, and
+  numbers to a note-taking or blog-writing session while the work happens.
+- Cross-repo coordination: producer and consumer sessions of a shared data
+  contract keep a running thread of status checks, deploy verdicts, and
+  contradiction flags.
+
 ## Docs
 
 - [muster.tools](https://muster.tools/): landing page — the pitch, the message-flow walkthrough, and the MCP tool groups.


### PR DESCRIPTION
Two docs deliverables, no code changes:

1. **Land the Jul 16–17 superpowers plans/specs** (muster watch, muster station, tier-2 agent status) that were left untracked in the primary clone — the Jul 18 badge/hook docs were committed by their feature sessions, so this completes the convention.
2. **Landing page "what it's for" section** (plus matching llms.txt prose): names the problem — inter-session communication — and grounds it in the four usage patterns observed in this repo's own bus journal (66 threads / 292 entries): independent review, handoffs, notes & journaling, cross-repo coordination, with a terminal block of real (redacted) thread subjects. Rendered and operator-approved before this PR.

https://claude.ai/code/session_014jibpFJRR8FUXgSneriHWW