### PR TITLE
feat: project-scoped broadcast

### DIFF
--- a/docs/superpowers/plans/2026-07-22-project-broadcast.md
+++ b/docs/superpowers/plans/2026-07-22-project-broadcast.md
@@ -1,0 +1,757 @@
+# Project-Scoped Broadcast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a broadcast be scoped to one project — `to_kind='broadcast'` with `to_target='<project>'` reaches only that project's agents; empty target stays global — with daemon-side validation rejecting unknown projects.
+
+**Architecture:** Reuse the existing broadcast kind; the scope rides in `to_target`, which is empty for every historical row. The store's one canonical concern predicate gains the scope check; the daemon validates the project at send time (the black-hole backstop, same principle as alias resolution) and filters the wake fan-out; CLI grows a `--project` flag; MCP changes are description-only.
+
+**Tech Stack:** Go, pure-Go SQLite (`modernc.org/sqlite`), no cgo. Spec: `docs/superpowers/specs/2026-07-22-project-broadcast-design.md`.
+
+## Global Constraints
+
+- Work in the worktree `/Users/courtschuett/GitHub/worktrees/muster-project-broadcast` on branch `feat/project-broadcast`. Never touch the primary clone.
+- The full gate is `just verify` (gofmt, golangci-lint, `go test -race`, build). Run it before the final commit; per-task, run the named package tests.
+- `CGO_ENABLED=0` must keep building. Add no dependencies.
+- stdout is sacred in mcp mode; no stray prints (all daemon/MCP diagnostics go to stderr — this plan adds no prints at all).
+- Exact-match project validation only — no fuzzy/prefix matching (spec "Out of scope").
+- Error format, verbatim: `no registered agents in project "<target>" (known projects: <comma-space separated, sorted, deduped, non-departed, non-empty>)`.
+- Journal target format: `broadcast` (global) / `broadcast:<project>` (scoped).
+
+---
+
+### Task 1: Store — scoped broadcast in the canonical concern predicate
+
+**Files:**
+- Modify: `internal/store/threads.go:162-178` (`threadConcerns`, `threadConcernsJoin`)
+- Modify: `internal/store/threads.go:242` (Inbox bind args)
+- Modify: `internal/store/agents.go:194` (UnreadCount bind args)
+- Modify: `internal/store/events.go:64` (Events bind args)
+- Test: `internal/store/threads_test.go`, `internal/store/agents_test.go`
+
+**Interfaces:**
+- Consumes: existing `threadConcerns` / `threadConcernsJoin` SQL fragments and their call sites.
+- Produces: `threadConcerns` binding the alias **4** times (order: direct-target, role subselect, NEW project subselect, from_agent); `threadConcernsJoin` unchanged in bind count (uses `sess.alias`). Later tasks rely on: a thread `{ToKind: "broadcast", ToTarget: "projX"}` concerns exactly the agents whose registered `project` is `projX` (plus the originator), and departed rows keep matching via their preserved `project`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/store/threads_test.go`:
+
+```go
+func TestInboxScopedBroadcastMatchesProjectOnly(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "in-proj", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "other-proj", Project: "api"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "no-proj"}); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(toTarget string) {
+		if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", ToTarget: toTarget}, "hi"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("web") // scoped to web
+	mk("")    // global
+
+	for alias, want := range map[string]int{"in-proj": 2, "other-proj": 1, "no-proj": 1} {
+		in, err := s.Inbox(alias)
+		if err != nil {
+			t.Fatalf("inbox(%s): %v", alias, err)
+		}
+		if len(in) != want {
+			t.Fatalf("inbox(%s) = %d threads, want %d", alias, len(in), want)
+		}
+	}
+
+	// UnreadCount agrees with Inbox (same canonical predicate).
+	if n, err := s.UnreadCount("other-proj"); err != nil || n != 1 {
+		t.Fatalf("UnreadCount(other-proj) = %d (%v), want 1", n, err)
+	}
+	if n, err := s.UnreadCount("in-proj"); err != nil || n != 2 {
+		t.Fatalf("UnreadCount(in-proj) = %d (%v), want 2", n, err)
+	}
+}
+
+func TestScopedBroadcastConcernsDepartedAgentsProject(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "ghost", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DepartAgent("ghost"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", ToTarget: "web"}, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	// Tombstoned rows preserve project; a departed agent that re-registers
+	// into the same alias sees the scoped broadcast (read-time semantics).
+	in, err := s.Inbox("ghost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(in) != 1 {
+		t.Fatalf("departed ghost inbox = %d threads, want 1", len(in))
+	}
+}
+```
+
+Extend the fixture matrix in `TestThreadConcernsSessionJoinEquivalence` (`internal/store/agents_test.go:335-338`) — after the existing `mk(...)` calls add scoped-broadcast shapes, and give the agents projects so scoping discriminates. Replace the three `RegisterAgent` calls at lines 320-328 and the `mk` block so the test reads:
+
+```go
+	if err := s.RegisterAgent(Agent{Alias: "rev1", Role: "reviewer", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "rev2", Role: "reviewer", Project: "api"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "other", Role: "producer"}); err != nil {
+		t.Fatal(err)
+	}
+```
+
+and after `mk("task", "other", "agent", "rev1")` add:
+
+```go
+	mk("message", "backend", "broadcast", "web") // scoped: concerns rev1 only
+	mk("message", "backend", "broadcast", "api") // scoped: concerns rev2 only
+	mk("message", "backend", "broadcast", "gone") // scoped: concerns nobody
+```
+
+The loop body needs the extra bind on the literal form — change line 360 to bind the alias **four** times:
+
+```go
+		want := idsMatching(`SELECT id FROM threads WHERE `+threadConcerns+` ORDER BY id`, alias, alias, alias, alias)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/courtschuett/GitHub/worktrees/muster-project-broadcast && go test ./internal/store/ -run 'TestInboxScopedBroadcast|TestScopedBroadcastConcernsDeparted|TestThreadConcernsSessionJoinEquivalence' -v`
+Expected: FAIL — `TestInboxScopedBroadcastMatchesProjectOnly` fails because `other-proj`/`no-proj` see the scoped broadcast (predicate matches every broadcast); the equivalence test fails with a bind-count error ("not enough args") on the 4-bind literal form.
+
+- [ ] **Step 3: Change the predicate and the bind lists**
+
+In `internal/store/threads.go` replace the two fragments (keep the doc comments above them, appending one sentence to `threadConcerns`'s comment: "A scoped broadcast (to_target != '') concerns only agents whose registered project matches it exactly; binds the alias four times."):
+
+```go
+const threadConcerns = `((threads.to_kind='agent'  AND threads.to_target=?)
+   OR (threads.to_kind='role'      AND threads.to_target != '' AND threads.to_target=(SELECT role FROM agents WHERE alias=?))
+   OR (threads.to_kind='broadcast' AND (threads.to_target='' OR threads.to_target=(SELECT project FROM agents WHERE alias=?)))
+   OR (threads.from_agent=?))`
+```
+
+```go
+const threadConcernsJoin = `((threads.to_kind='agent' AND threads.to_target=sess.alias)
+   OR (threads.to_kind='role'     AND threads.to_target != '' AND threads.to_target=(SELECT role FROM agents WHERE alias=sess.alias))
+   OR (threads.to_kind='broadcast' AND (threads.to_target='' OR threads.to_target=(SELECT project FROM agents WHERE alias=sess.alias)))
+   OR (threads.from_agent=sess.alias))`
+```
+
+Update the three literal-form call sites to bind one more alias:
+- `internal/store/threads.go:242` (Inbox): `alias, alias, alias, alias, alias` → `alias, alias, alias, alias, alias, alias` (predicate now takes 4, unread CTE still takes 2).
+- `internal/store/agents.go:194` (UnreadCount): five `alias` args → six.
+- `internal/store/events.go:64` (Events): `q.Agent` six times → seven (three pre-predicate + four predicate).
+
+`SessionUnread` (`agents.go:236-251`) uses the join form only — no bind change.
+
+- [ ] **Step 4: Run the store package tests**
+
+Run: `go test -race ./internal/store/`
+Expected: PASS (all — including the pre-existing broadcast/inbox tests, which assert global behavior is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/
+git commit -m "feat(store): scoped broadcast in the canonical concern predicate"
+```
+
+---
+
+### Task 2: Daemon — validate the project at send time
+
+**Files:**
+- Modify: `internal/daemon/daemon.go:470-511` (send_message / task_create dispatch cases) plus a new helper near `resolveAgentTarget`'s pattern
+- Test: `internal/daemon/daemon_test.go` (or a new `internal/daemon/broadcast_test.go`)
+
+**Interfaces:**
+- Consumes: `d.s.ListAgents() ([]store.Agent, error)`; `store.Agent{Alias, Project, Departed}`; test harness `startWithNotifierAndStore(t, n)` / `call(t, sock, op, args)` from `wake_wiring_test.go`.
+- Produces: `(*Daemon) validateBroadcastTarget(project string) error` — nil for `""` or a known project; otherwise the exact error from Global Constraints. Both send_message and task_create call it when `to_kind=="broadcast"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/daemon/broadcast_test.go`:
+
+```go
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+// Scoped broadcast to a project nobody (non-departed) is registered under
+// must be rejected at the daemon — the black-hole backstop, same principle
+// as resolveAgentTarget for mistyped aliases.
+func TestScopedBroadcastUnknownProjectRejected(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "wbe", "subject": "typo", "body": "x",
+	})
+	if resp.OK {
+		t.Fatalf("expected rejection for unknown project, got OK")
+	}
+	if !strings.Contains(resp.Error, `no registered agents in project "wbe"`) || !strings.Contains(resp.Error, "known projects: web") {
+		t.Fatalf("error should name the project and list known ones, got: %q", resp.Error)
+	}
+}
+
+func TestScopedBroadcastKnownProjectAccepted(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "web2", "project": "web", "socket_path": "/s", "session_id": "$2"})
+
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "web", "subject": "ok", "body": "x",
+	})
+	if !resp.OK {
+		t.Fatalf("scoped broadcast to a live project should succeed: %s", resp.Error)
+	}
+}
+
+func TestScopedBroadcastDepartedOnlyProjectRejected(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "solo", "project": "api", "socket_path": "/s", "session_id": "$2"})
+	call(t, sock, "deregister_agent", map[string]any{"alias": "solo"})
+
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "api", "subject": "tombstones", "body": "x",
+	})
+	if resp.OK {
+		t.Fatalf("broadcast to a departed-only project should be rejected")
+	}
+}
+
+func TestGlobalBroadcastNeverValidated(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "", "subject": "all", "body": "x",
+	})
+	if !resp.OK {
+		t.Fatalf("global broadcast must not be validated: %s", resp.Error)
+	}
+}
+
+func TestScopedBroadcastTaskCreateValidatedToo(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	resp := call(t, sock, "task_create", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "nope", "subject": "t", "body": "x",
+	})
+	if resp.OK {
+		t.Fatalf("task_create must validate scoped broadcast targets too")
+	}
+}
+```
+
+The deregister op name is `deregister_agent` (`internal/daemon/daemon.go:655`); it tombstones the row (`departed=1`, project preserved), which is exactly what this test needs.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/daemon/ -run 'TestScopedBroadcast|TestGlobalBroadcast' -v`
+Expected: FAIL — unknown/departed/task cases get OK responses (no validation exists yet).
+
+- [ ] **Step 3: Implement the validator and wire it in**
+
+In `internal/daemon/daemon.go`, next to `senderProject` (~line 437), add:
+
+```go
+// validateBroadcastTarget is the send-time backstop for scoped broadcasts
+// (to_kind=broadcast, to_target=<project>): reject unless some non-departed
+// agent is registered under exactly that project, so a typo'd project never
+// creates a thread that concerns nobody — the same black-hole principle as
+// resolveAgentTarget for mistyped aliases. A global broadcast (empty
+// target) is never validated. Exact match only; project strings come from
+// tmux capture and are stable, so no fuzzy or prefix matching.
+func (d *Daemon) validateBroadcastTarget(project string) error {
+	if project == "" {
+		return nil
+	}
+	agents, err := d.s.ListAgents()
+	if err != nil {
+		return err
+	}
+	known := make(map[string]bool)
+	for _, ag := range agents {
+		if !ag.Departed && ag.Project != "" {
+			known[ag.Project] = true
+		}
+	}
+	if known[project] {
+		return nil
+	}
+	names := make([]string, 0, len(known))
+	for p := range known {
+		names = append(names, p)
+	}
+	sort.Strings(names)
+	return fmt.Errorf("no registered agents in project %q (known projects: %s)", project, strings.Join(names, ", "))
+}
+```
+
+Add `"sort"` and `"strings"` to the imports if not present (`fmt` already is). Then in `dispatch`, in **both** the `case "send_message":` and `case "task_create":` blocks, immediately after the existing `if toKind == "agent" { ... }` resolution block, add:
+
+```go
+		if toKind == "broadcast" {
+			if err := d.validateBroadcastTarget(toTarget); err != nil {
+				return fail(err)
+			}
+		}
+```
+
+- [ ] **Step 4: Run the daemon package tests**
+
+Run: `go test -race ./internal/daemon/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/daemon/
+git commit -m "feat(daemon): validate scoped broadcast projects at send time"
+```
+
+---
+
+### Task 3: Daemon — scoped fan-out and journal target
+
+**Files:**
+- Modify: `internal/daemon/daemon.go:362-366` (`notifyForThread` broadcast case)
+- Modify: `internal/daemon/daemon.go:447-457` (`targetOf`)
+- Test: `internal/daemon/broadcast_test.go` (extend)
+
+**Interfaces:**
+- Consumes: Task 2's registered-agents harness; `fakeNotifier.snap(&n.notified)`.
+- Produces: scoped broadcasts notify only same-project sessions; journal/event rows carry target `broadcast:<project>` (Task 4's renderer handles this string).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/daemon/broadcast_test.go`:
+
+```go
+func TestScopedBroadcastNotifiesOnlyProjectSessions(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "web2", "project": "web", "socket_path": "/s", "session_id": "$2"})
+	call(t, sock, "register_agent", map[string]any{"alias": "api1", "project": "api", "socket_path": "/s", "session_id": "$3"})
+
+	call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "web", "subject": "s", "body": "x",
+	})
+	got := n.snap(&n.notified)
+	if len(got) != 1 || got[0] != "$2" {
+		t.Fatalf("scoped broadcast should notify only web2's session $2 (sender excluded, api1 out of scope), got %v", got)
+	}
+}
+
+func TestTargetOfScopedBroadcast(t *testing.T) {
+	if got := targetOf("broadcast", ""); got != "broadcast" {
+		t.Fatalf("global: got %q", got)
+	}
+	if got := targetOf("broadcast", "web"); got != "broadcast:web" {
+		t.Fatalf("scoped: got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/daemon/ -run 'TestScopedBroadcastNotifies|TestTargetOfScoped' -v`
+Expected: FAIL — api1's session `$3` is also notified; `targetOf` returns `broadcast` for the scoped case.
+
+- [ ] **Step 3: Implement**
+
+`notifyForThread` broadcast case (`daemon.go:362-366`) becomes:
+
+```go
+	case "broadcast":
+		for _, a := range agents {
+			if th.ToTarget == "" || a.Project == th.ToTarget {
+				recipients[a.Alias] = struct{}{}
+			}
+		}
+```
+
+`targetOf` (`daemon.go:452-457`) becomes (extend its comment with: "a scoped broadcast journals 'broadcast:<project>'"):
+
+```go
+func targetOf(toKind, toTarget string) string {
+	if toKind == "broadcast" {
+		if toTarget == "" {
+			return "broadcast"
+		}
+		return "broadcast:" + toTarget
+	}
+	return toKind + ":" + toTarget
+}
+```
+
+- [ ] **Step 4: Run the daemon package tests**
+
+Run: `go test -race ./internal/daemon/`
+Expected: PASS (existing global-broadcast fan-out tests unchanged: empty target still matches every agent).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/daemon/
+git commit -m "feat(daemon): scoped broadcast fan-out and broadcast:<project> journal target"
+```
+
+---
+
+### Task 4: Display — renderer and station know `broadcast:<project>`
+
+**Files:**
+- Modify: `internal/render/renderer.go:124-132` (`dispTarget`)
+- Modify: `internal/station/model.go:1519-1530` (`dispToTarget`)
+- Test: Create `internal/render/renderer_test.go` (the render package has no test files today — it is covered indirectly via humancli's events tests); add the station case to `internal/station/model_test.go`.
+
+**Interfaces:**
+- Consumes: Task 3's `broadcast:<project>` journal-target string; thread rows with `ToKind=="broadcast"`, `ToTarget!=""`.
+- Produces: both surfaces display `broadcast:<project>` as-is (no alias/label resolution attempted on the project string).
+
+- [ ] **Step 1: Write the failing tests**
+
+Renderer — the danger is the fallthrough: `broadcast:web` misses every special case in `dispTarget` and lands in `r.disp(target)`, the bare-alias path, which label-resolves the whole string. Pin "a broadcast target is never label-resolved" by planting a label under the literal target string — current code returns the label, fixed code returns the target as-is. `NewRenderer`'s signature is `NewRenderer(rows []EventRow, labels map[string]string, aliases, fullTime bool, width int) *Renderer` (`renderer.go:43`).
+
+Create `internal/render/renderer_test.go`:
+
+```go
+package render
+
+import "testing"
+
+// dispTarget must show broadcast targets as-is — never label-resolve them
+// through the bare-alias fallthrough. The label planted under the literal
+// target string proves the fallthrough is not taken.
+func TestDispTargetScopedBroadcastShownAsIs(t *testing.T) {
+	r := NewRenderer(nil, map[string]string{"broadcast:web": "WRONG"}, false, false, 120)
+	if got := r.dispTarget("broadcast:web"); got != "broadcast:web" {
+		t.Fatalf("scoped broadcast target rendered %q, want broadcast:web", got)
+	}
+	if got := r.dispTarget("broadcast"); got != "broadcast" {
+		t.Fatalf("global broadcast target rendered %q, want broadcast", got)
+	}
+}
+```
+
+Station — append to `internal/station/model_test.go`:
+
+```go
+func TestDispToTargetScopedBroadcast(t *testing.T) {
+	var m Model
+	if got := m.dispToTarget(listThreadRow{ToKind: "broadcast", ToTarget: "web"}); got != "broadcast:web" {
+		t.Fatalf("got %q, want broadcast:web", got)
+	}
+	if got := m.dispToTarget(listThreadRow{ToKind: "broadcast"}); got != "broadcast" {
+		t.Fatalf("got %q, want broadcast", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/render/ ./internal/station/ -run 'ScopedBroadcast' -v`
+Expected: renderer FAIL (fallthrough label-resolves to "WRONG"); station FAIL (returns bare `broadcast`, dropping the project).
+
+- [ ] **Step 3: Implement**
+
+`renderer.go:128` — add the prefix to the show-as-is branch:
+
+```go
+	if strings.HasPrefix(target, "role:") || target == "broadcast" || strings.HasPrefix(target, "broadcast:") || target == "" {
+		return target
+	}
+```
+
+`model.go:1525-1526`:
+
+```go
+	case "broadcast":
+		if row.ToTarget != "" {
+			return "broadcast:" + row.ToTarget
+		}
+		return "broadcast"
+```
+
+- [ ] **Step 4: Run both package tests**
+
+Run: `go test -race ./internal/render/ ./internal/station/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/render/ internal/station/
+git commit -m "feat(display): render scoped broadcast targets as broadcast:<project>"
+```
+
+---
+
+### Task 5: MCP — advertise both broadcast forms (description-only)
+
+**Files:**
+- Modify: `internal/mcpserver/tools_messages.go:13-14,121` (SendMessageIn schema hints, send_message description)
+- Modify: `internal/mcpserver/tools_tasks.go:13-14` (TaskCreateIn schema hints)
+
+**Interfaces:**
+- Consumes: nothing new — the handlers already pass `to_target` through verbatim; Task 2's daemon validation covers this surface automatically.
+- Produces: tool schemas/descriptions that teach agents both forms. No handler code changes; no new tests (no behavior to test — the daemon tests own validation).
+
+- [ ] **Step 1: Update the strings**
+
+`tools_messages.go:13-14`:
+
+```go
+	ToKind   string `json:"to_kind" jsonschema:"agent, role, or broadcast"`
+	ToTarget string `json:"to_target,omitempty" jsonschema:"the recipient alias or role; for broadcast: empty reaches every agent on the bus, or a project name reaches only that project's agents (unknown projects are rejected)"`
+```
+
+`tools_messages.go:121` description becomes:
+
+```go
+mcp.AddTool(srv, &mcp.Tool{Name: "send_message", Description: "Send a message to another agent (to_kind=agent), a role (to_kind=role), or many agents at once (to_kind=broadcast). A broadcast with empty to_target reaches every agent on the bus; set to_target to a project name to reach only that project's agents. Set intent to fyi/reply-requested/action-requested so the recipient's inbox and drain reflect what you actually need back."}, sendMessageHandler)
+```
+
+`tools_tasks.go:14`:
+
+```go
+	ToTarget string `json:"to_target" jsonschema:"the assignee alias or role; for broadcast: empty for every agent, or a project name for that project's agents only"`
+```
+
+- [ ] **Step 2: Build and run the package tests**
+
+Run: `go build ./... && go test -race ./internal/mcpserver/`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/mcpserver/
+git commit -m "docs(mcp): advertise global and project-scoped broadcast on tool schemas"
+```
+
+---
+
+### Task 6: CLI — `--project` flag on `muster send --broadcast`
+
+**Files:**
+- Modify: `internal/humancli/humancli.go:186-277` (sendFlagVals, newSendFlagsWithVals, cmdSend)
+- Modify: `internal/humancli/registry.go:94-100` (send synopsis + help prose)
+- Test: new `internal/humancli/send_broadcast_test.go`. The harness is real, not stubbed: `startTestDaemon(t)` (`humancli_test.go:22`) starts a daemon on an isolated `MUSTER_HOME` and returns its `*store.Store`; `callData(op, args)` talks to it; `cmdSend(args, &buf)` does a full round trip (see `thread_test.go:18` for the pattern). Because the daemon is real, Task 2's validation applies — the scoped test must register an agent under the target project first.
+
+**Interfaces:**
+- Consumes: daemon `send_message` op accepting `to_kind=broadcast, to_target=<project>` (Tasks 1-3).
+- Produces: `muster send --broadcast --project <p> "body"` sends `{to_kind: "broadcast", to_target: "<p>"}`; `--project` without `--broadcast` errors; plain `--broadcast` keeps joining ALL positionals into the body.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/humancli/send_broadcast_test.go`:
+
+```go
+package humancli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSendBroadcastProjectFlag(t *testing.T) {
+	s := startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "w1", "project": "web", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := cmdSend([]string{"--broadcast", "--project", "web", "deploy", "landed", "--from", "tester"}, &buf); err != nil {
+		t.Fatalf("scoped broadcast send: %v", err)
+	}
+	ths, err := s.Threads(10)
+	if err != nil || len(ths) != 1 {
+		t.Fatalf("threads: %v (%d)", err, len(ths))
+	}
+	if ths[0].ToKind != "broadcast" || ths[0].ToTarget != "web" {
+		t.Fatalf("stored thread addressed %s:%q, want broadcast:web", ths[0].ToKind, ths[0].ToTarget)
+	}
+	_, entries, err := s.GetThread(ths[0].ID)
+	if err != nil || len(entries) != 1 || entries[0].Body != "deploy landed" {
+		t.Fatalf("unquoted body must join: %v / %+v", err, entries)
+	}
+}
+
+func TestSendProjectWithoutBroadcastErrors(t *testing.T) {
+	startTestDaemon(t)
+	var buf bytes.Buffer
+	err := cmdSend([]string{"--project", "web", "hello"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "--project requires --broadcast") {
+		t.Fatalf("want '--project requires --broadcast' error, got %v", err)
+	}
+}
+
+func TestSendBroadcastUnquotedBodyStaysGlobal(t *testing.T) {
+	s := startTestDaemon(t)
+	// "muster" is a real project on the roster — the exact collision the
+	// rejected positional form would have silently mis-scoped.
+	if _, err := callData("register_agent", map[string]any{"alias": "m1", "project": "muster", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := cmdSend([]string{"--broadcast", "muster", "is", "broken", "--from", "tester"}, &buf); err != nil {
+		t.Fatalf("global broadcast send: %v", err)
+	}
+	ths, err := s.Threads(10)
+	if err != nil || len(ths) != 1 {
+		t.Fatalf("threads: %v (%d)", err, len(ths))
+	}
+	if ths[0].ToTarget != "" {
+		t.Fatalf("unquoted broadcast body must stay global, got to_target=%q", ths[0].ToTarget)
+	}
+	_, entries, err := s.GetThread(ths[0].ID)
+	if err != nil || len(entries) != 1 || entries[0].Body != "muster is broken" {
+		t.Fatalf("body must join all positionals: %v / %+v", err, entries)
+	}
+}
+
+func TestSendBroadcastUnknownProjectSurfacesDaemonError(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "w1", "project": "web", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err := cmdSend([]string{"--broadcast", "--project", "wbe", "typo", "--from", "tester"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), `no registered agents in project "wbe"`) {
+		t.Fatalf("daemon validation error must surface through the CLI, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/humancli/ -run 'TestSendBroadcastProject|TestSendProjectWithout|TestSendBroadcastUnquoted' -v`
+Expected: FAIL — `--project` is an unknown flag.
+
+- [ ] **Step 3: Implement**
+
+`sendFlagVals` gains the field:
+
+```go
+type sendFlagVals struct {
+	from, subject, ref, intent, project *string
+	role, broadcast                     *bool
+}
+```
+
+`newSendFlagsWithVals` declares it:
+
+```go
+	v.project = fs.String("project", "", "with --broadcast: send only to this project's agents")
+```
+
+In `cmdSend`, after `validateIntent` (line 228-230) add:
+
+```go
+	if *v.project != "" && !*v.broadcast {
+		return fmt.Errorf("--project requires --broadcast")
+	}
+```
+
+and in the broadcast branch (lines 239-243), set the target:
+
+```go
+	if *v.broadcast {
+		if len(rest) < 1 {
+			return fmt.Errorf("usage: muster send --broadcast [--project <p>] <body> [--intent fyi|reply-requested|action-requested]")
+		}
+		toTarget = *v.project
+		body = strings.Join(rest, " ")
+	} else {
+```
+
+(`toTarget` is already sent on the wire at line 259 — no other change.)
+
+`registry.go:94-100`: synopsis becomes
+
+```
+send <target> "body" [--from <alias>] [--subject <s>] [--ref <r>] [--role] [--broadcast [--project <p>]] [--intent fyi|reply-requested|action-requested]
+```
+
+and in the help prose, after the sentence about `--broadcast`, add: "With --project, the broadcast reaches only agents registered under that exact project (the daemon rejects unknown projects and lists the known ones)."
+
+- [ ] **Step 4: Run the package tests**
+
+Run: `go test -race ./internal/humancli/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/humancli/
+git commit -m "feat(cli): muster send --broadcast --project <p> for scoped broadcasts"
+```
+
+---
+
+### Task 7: Gate and end-to-end sanity
+
+**Files:**
+- No source changes expected; fixes only if the gate finds drift.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: a green `just verify` on the branch.
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `cd /Users/courtschuett/GitHub/worktrees/muster-project-broadcast && just verify`
+Expected: gofmt clean, golangci-lint clean, `go test -race ./...` PASS, build OK.
+
+- [ ] **Step 2: End-to-end smoke on an isolated bus**
+
+```bash
+export MUSTER_HOME=/tmp/muster-pb-smoke
+rm -rf $MUSTER_HOME && mkdir -p $MUSTER_HOME
+go build -o /tmp/muster-pb-smoke/muster ./cmd/muster
+M=/tmp/muster-pb-smoke/muster
+MUSTER_ALIAS=w1 $M register w1
+MUSTER_ALIAS=w2 $M register w2
+$M send --broadcast --project nope "typo test" --from w1 || echo "REJECTED (expected)"
+# registered project of w1/w2 is captured from tmux ("muster" when run from this repo's session)
+$M send --broadcast --project muster "scoped hello" --from w1
+$M inbox w2      # expect: TO broadcast:muster (or to_target column showing the project), 1 unread
+$M send --broadcast "global hello" --from w1
+$M inbox w2      # expect: 2 threads
+$M events | tail -5   # expect a send row with target broadcast:muster
+pkill -f "muster-pb-smoke/muster serve"; rm -rf /tmp/muster-pb-smoke
+```
+
+Expected: the `nope` send prints the known-projects error; the scoped and global sends both land in w2's inbox; the journal shows `broadcast:muster`.
+
+- [ ] **Step 3: Commit any gate fixes, then final commit if dirty**
+
+```bash
+git status --short   # commit fixes with a descriptive message if the gate changed anything
+```

--- a/docs/superpowers/specs/2026-07-22-project-broadcast-design.md
+++ b/docs/superpowers/specs/2026-07-22-project-broadcast-design.md
@@ -37,10 +37,19 @@ no added capability at this scope.
 - Concern is evaluated at read time (same as global broadcast today): an
   agent that registers into the project *after* the send still sees the
   thread in its inbox.
-- No validation that the project exists or has live agents. Projects are
-  free-form strings; a scoped broadcast to a project with no agents simply
-  concerns no one (besides the sender, who always sees own-originated
-  threads).
+- **Project validation (daemon-side, hard reject):** a project-scoped
+  broadcast is rejected unless at least one **non-departed** agent is
+  registered with that exact project. This mirrors the existing
+  "black-hole fix" for mistyped aliases (see `internal/daemon/resolve.go`)
+  — the daemon is the only backstop before a thread gets created that
+  concerns nobody, and both surfaces (CLI and MCP) pass `to_target`
+  through unresolved. Departed-only projects are rejected too. The error
+  lists the known (non-departed) projects so the sender can correct in one
+  round trip, e.g.:
+  `no registered agents in project "bettor-hlep" (known projects: bettor-help, muster, …)`.
+  Global broadcast (empty target) is never validated — there is nothing to
+  typo. No fuzzy or prefix matching of project names: project strings come
+  from tmux capture and are stable, so it is exact-match-or-clear-error.
 - An agent with an empty `project` never matches a scoped broadcast; it
   still receives global broadcasts.
 - The sender's own session is excluded from wake/notify, as with all sends
@@ -66,6 +75,12 @@ bound-argument lists accordingly.
 
 ### Daemon (`internal/daemon/daemon.go`)
 
+- **Send-time validation:** in the send_message and task_create op
+  handlers, when `to_kind=='broadcast'` and `to_target != ''`, reject
+  unless some non-departed agent's `project` equals `to_target` exactly
+  (roster read via the store, consistent with `resolveAgentTarget`'s
+  pattern). Error format:
+  `no registered agents in project "<target>" (known projects: <sorted, deduped, non-departed>)`.
 - `notifyForThread`: the `case "broadcast"` fan-out filters recipients to
   `a.Project == th.ToTarget` when `th.ToTarget != ""`.
 - `targetOf`: journal target renders `broadcast` for global,
@@ -102,11 +117,15 @@ the discoverability fix.
   equivalence fixture; departed agents' preserved `project` behaves
   consistently.
 - **Daemon:** wake fan-out badges only same-project sessions for a scoped
-  broadcast; journal rows carry `broadcast:<project>`.
+  broadcast; journal rows carry `broadcast:<project>`; scoped broadcast to
+  an unknown project is rejected with the known-projects error; scoped
+  broadcast to a departed-only project is rejected; global broadcast is
+  never rejected.
 - **CLI:** arg parsing for one- and two-positional `--broadcast` forms.
 
 ## Out of scope
 
-Prefix/wildcard project matching, multi-project targets, broadcast to a
-named set of agents, any new `to_kind`, persistence/announcement semantics
-beyond the existing thread model.
+Prefix/wildcard project matching, fuzzy project-name correction,
+multi-project targets, broadcast to a named set of agents, any new
+`to_kind`, persistence/announcement semantics beyond the existing thread
+model.

--- a/docs/superpowers/specs/2026-07-22-project-broadcast-design.md
+++ b/docs/superpowers/specs/2026-07-22-project-broadcast-design.md
@@ -1,0 +1,112 @@
+# Project-scoped broadcast
+
+**Date:** 2026-07-22
+**Status:** Approved
+
+## Problem
+
+Global broadcast already exists end-to-end (`to_kind='broadcast'`, CLI
+`muster send --broadcast`, MCP `send_message`): it reaches every registered
+agent on the bus. On a busy machine (30+ agents across a dozen projects)
+that is too blunt — an announcement that matters to one project's agents
+badges every live session everywhere. The common case is "tell everyone in
+project X," and there is no way to express it.
+
+A secondary finding: the operator didn't know global broadcast existed, so
+the MCP tool description should advertise both forms more loudly.
+
+## Decision
+
+Reuse `to_kind='broadcast'` and carry the scope in `to_target`, which is
+empty for every existing broadcast row:
+
+- `to_target = ''` — global broadcast, everyone (unchanged semantics; all
+  historical rows already mean this).
+- `to_target = '<project>'` — reaches only agents whose registered
+  `project` equals that string exactly.
+
+No schema change, no new `to_kind`, backward compatible with old rows and
+old clients. A new `to_kind='project'` was considered and rejected: it
+touches every `to_kind` switch across daemon/store/station/render/MCP for
+no added capability at this scope.
+
+## Semantics
+
+- Scope matches the registered `project` string **exactly** — no prefix,
+  glob, or wildcard matching.
+- Concern is evaluated at read time (same as global broadcast today): an
+  agent that registers into the project *after* the send still sees the
+  thread in its inbox.
+- No validation that the project exists or has live agents. Projects are
+  free-form strings; a scoped broadcast to a project with no agents simply
+  concerns no one (besides the sender, who always sees own-originated
+  threads).
+- An agent with an empty `project` never matches a scoped broadcast; it
+  still receives global broadcasts.
+- The sender's own session is excluded from wake/notify, as with all sends
+  today.
+
+## Changes by component
+
+### Store (`internal/store/threads.go`)
+
+The one canonical concern predicate gains the scope check. In
+`threadConcerns`:
+
+```sql
+OR (threads.to_kind='broadcast' AND (threads.to_target=''
+     OR threads.to_target=(SELECT project FROM agents WHERE alias=?)))
+```
+
+`threadConcernsJoin` changes identically (with `sess.alias`). The existing
+equivalence test (`TestThreadConcernsSessionJoinEquivalence`) must keep
+passing; extend its fixture matrix with scoped-broadcast thread shapes.
+Note the alias bind count in `threadConcerns` increases; update callers'
+bound-argument lists accordingly.
+
+### Daemon (`internal/daemon/daemon.go`)
+
+- `notifyForThread`: the `case "broadcast"` fan-out filters recipients to
+  `a.Project == th.ToTarget` when `th.ToTarget != ""`.
+- `targetOf`: journal target renders `broadcast` for global,
+  `broadcast:<project>` for scoped.
+
+### Render / station
+
+`internal/render/renderer.go` and `internal/station` treat the literal
+string `broadcast` specially; teach them the `broadcast:<project>` form
+(display as-is or as `broadcast:<project>` — no resolution needed).
+
+### MCP (`internal/mcpserver`)
+
+No new tool. `send_message` / `task_create` descriptions and the
+`to_target` jsonschema hints are rewritten to advertise both forms:
+"to_kind=broadcast with empty to_target reaches every agent; set to_target
+to a project name to reach only that project's agents." This doubles as
+the discoverability fix.
+
+### CLI (`internal/humancli`)
+
+- `muster send --broadcast "body"` — global (unchanged).
+- `muster send --broadcast <project> "body"` — project-scoped. The
+  positional slot is currently a usage error when combined with
+  `--broadcast`, so it is free to claim: two positional args mean
+  project + body, one means body. Help text and `registry.go` synopsis
+  updated.
+
+## Testing
+
+- **Store:** scoped broadcast concerns same-project agents, not
+  other-project or empty-project agents; global broadcast still concerns
+  everyone; both predicate forms (direct + join) agree via the extended
+  equivalence fixture; departed agents' preserved `project` behaves
+  consistently.
+- **Daemon:** wake fan-out badges only same-project sessions for a scoped
+  broadcast; journal rows carry `broadcast:<project>`.
+- **CLI:** arg parsing for one- and two-positional `--broadcast` forms.
+
+## Out of scope
+
+Prefix/wildcard project matching, multi-project targets, broadcast to a
+named set of agents, any new `to_kind`, persistence/announcement semantics
+beyond the existing thread model.

--- a/docs/superpowers/specs/2026-07-22-project-broadcast-design.md
+++ b/docs/superpowers/specs/2026-07-22-project-broadcast-design.md
@@ -102,12 +102,17 @@ the discoverability fix.
 
 ### CLI (`internal/humancli`)
 
-- `muster send --broadcast "body"` — global (unchanged).
-- `muster send --broadcast <project> "body"` — project-scoped. The
-  positional slot is currently a usage error when combined with
-  `--broadcast`, so it is free to claim: two positional args mean
-  project + body, one means body. Help text and `registry.go` synopsis
-  updated.
+- `muster send --broadcast "body"` — global (unchanged, including
+  unquoted multi-word bodies: all positionals join into the body).
+- `muster send --broadcast --project <p> "body"` — project-scoped.
+- A positional project slot was considered and rejected: `--broadcast`
+  joins all positionals into the body today, so
+  `muster send --broadcast muster is broken` would silently become a
+  scoped broadcast to project `muster` with body "is broken" whenever the
+  first body word collides with a real project name. The flag form has no
+  such ambiguity.
+- `--project` without `--broadcast` is a usage error. Help text and
+  `registry.go` synopsis updated.
 
 ## Testing
 
@@ -121,7 +126,9 @@ the discoverability fix.
   an unknown project is rejected with the known-projects error; scoped
   broadcast to a departed-only project is rejected; global broadcast is
   never rejected.
-- **CLI:** arg parsing for one- and two-positional `--broadcast` forms.
+- **CLI:** `--project` with `--broadcast` sends a scoped broadcast;
+  `--project` without `--broadcast` is a usage error; plain `--broadcast`
+  with a multi-word unquoted body stays global.
 
 ## Out of scope
 

--- a/internal/daemon/broadcast_test.go
+++ b/internal/daemon/broadcast_test.go
@@ -76,3 +76,28 @@ func TestScopedBroadcastTaskCreateValidatedToo(t *testing.T) {
 		t.Fatalf("task_create must validate scoped broadcast targets too")
 	}
 }
+
+func TestScopedBroadcastNotifiesOnlyProjectSessions(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "web2", "project": "web", "socket_path": "/s", "session_id": "$2"})
+	call(t, sock, "register_agent", map[string]any{"alias": "api1", "project": "api", "socket_path": "/s", "session_id": "$3"})
+
+	call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "web", "subject": "s", "body": "x",
+	})
+	got := n.snap(&n.notified)
+	if len(got) != 1 || got[0] != "$2" {
+		t.Fatalf("scoped broadcast should notify only web2's session $2 (sender excluded, api1 out of scope), got %v", got)
+	}
+}
+
+func TestTargetOfScopedBroadcast(t *testing.T) {
+	if got := targetOf("broadcast", ""); got != "broadcast" {
+		t.Fatalf("global: got %q", got)
+	}
+	if got := targetOf("broadcast", "web"); got != "broadcast:web" {
+		t.Fatalf("scoped: got %q", got)
+	}
+}

--- a/internal/daemon/broadcast_test.go
+++ b/internal/daemon/broadcast_test.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+// Scoped broadcast to a project nobody (non-departed) is registered under
+// must be rejected at the daemon — the black-hole backstop, same principle
+// as resolveAgentTarget for mistyped aliases.
+func TestScopedBroadcastUnknownProjectRejected(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "wbe", "subject": "typo", "body": "x",
+	})
+	if resp.OK {
+		t.Fatalf("expected rejection for unknown project, got OK")
+	}
+	if !strings.Contains(resp.Error, `no registered agents in project "wbe"`) || !strings.Contains(resp.Error, "known projects: web") {
+		t.Fatalf("error should name the project and list known ones, got: %q", resp.Error)
+	}
+}
+
+func TestScopedBroadcastKnownProjectAccepted(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "web2", "project": "web", "socket_path": "/s", "session_id": "$2"})
+
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "web", "subject": "ok", "body": "x",
+	})
+	if !resp.OK {
+		t.Fatalf("scoped broadcast to a live project should succeed: %s", resp.Error)
+	}
+}
+
+func TestScopedBroadcastDepartedOnlyProjectRejected(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "solo", "project": "api", "socket_path": "/s", "session_id": "$2"})
+	call(t, sock, "deregister_agent", map[string]any{"alias": "solo"})
+
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "api", "subject": "tombstones", "body": "x",
+	})
+	if resp.OK {
+		t.Fatalf("broadcast to a departed-only project should be rejected")
+	}
+}
+
+func TestGlobalBroadcastNeverValidated(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "", "subject": "all", "body": "x",
+	})
+	if !resp.OK {
+		t.Fatalf("global broadcast must not be validated: %s", resp.Error)
+	}
+}
+
+func TestScopedBroadcastTaskCreateValidatedToo(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1"})
+	resp := call(t, sock, "task_create", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "to_target": "nope", "subject": "t", "body": "x",
+	})
+	if resp.OK {
+		t.Fatalf("task_create must validate scoped broadcast targets too")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -362,7 +362,9 @@ func (d *Daemon) notifyForThread(threadID int64, actor string) {
 		}
 	case "broadcast":
 		for _, a := range agents {
-			recipients[a.Alias] = struct{}{}
+			if th.ToTarget == "" || a.Project == th.ToTarget {
+				recipients[a.Alias] = struct{}{}
+			}
 		}
 	}
 	// Drop the actor's entire session: the literal alias always goes (an
@@ -481,10 +483,14 @@ func (d *Daemon) validateBroadcastTarget(project string) error {
 // '<to_kind>:<to_target>'. toTarget is the (possibly daemon-resolved) target
 // actually stored on the thread, not necessarily the raw request arg — so a
 // send_message/task_create addressed to a label journals the ALIAS it
-// resolved to, not the label a caller typed.
+// resolved to, not the label a caller typed. A scoped broadcast journals
+// 'broadcast:<project>'.
 func targetOf(toKind, toTarget string) string {
 	if toKind == "broadcast" {
-		return "broadcast"
+		if toTarget == "" {
+			return "broadcast"
+		}
+		return "broadcast:" + toTarget
 	}
 	return toKind + ":" + toTarget
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/schuettc/muster/internal/display"
@@ -444,6 +445,38 @@ func (d *Daemon) senderProject(alias string) string {
 	return ag.Project
 }
 
+// validateBroadcastTarget is the send-time backstop for scoped broadcasts
+// (to_kind=broadcast, to_target=<project>): reject unless some non-departed
+// agent is registered under exactly that project, so a typo'd project never
+// creates a thread that concerns nobody — the same black-hole principle as
+// resolveAgentTarget for mistyped aliases. A global broadcast (empty
+// target) is never validated. Exact match only; project strings come from
+// tmux capture and are stable, so no fuzzy or prefix matching.
+func (d *Daemon) validateBroadcastTarget(project string) error {
+	if project == "" {
+		return nil
+	}
+	agents, err := d.s.ListAgents()
+	if err != nil {
+		return err
+	}
+	known := make(map[string]bool)
+	for _, ag := range agents {
+		if !ag.Departed && ag.Project != "" {
+			known[ag.Project] = true
+		}
+	}
+	if known[project] {
+		return nil
+	}
+	names := make([]string, 0, len(known))
+	for p := range known {
+		names = append(names, p)
+	}
+	sort.Strings(names)
+	return fmt.Errorf("no registered agents in project %q (known projects: %s)", project, strings.Join(names, ", "))
+}
+
 // targetOf renders a thread address as a journal target: 'broadcast' or
 // '<to_kind>:<to_target>'. toTarget is the (possibly daemon-resolved) target
 // actually stored on the thread, not necessarily the raw request arg — so a
@@ -477,6 +510,11 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			}
 			toTarget = resolved
 		}
+		if toKind == "broadcast" {
+			if err := d.validateBroadcastTarget(toTarget); err != nil {
+				return fail(err)
+			}
+		}
 		id, err := d.s.CreateThread(store.Thread{
 			Kind: "message", FromAgent: from, ToKind: toKind,
 			ToTarget: toTarget, Subject: str(a, "subject"), Ref: str(a, "ref"),
@@ -497,6 +535,11 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 				return fail(err)
 			}
 			toTarget = resolved
+		}
+		if toKind == "broadcast" {
+			if err := d.validateBroadcastTarget(toTarget); err != nil {
+				return fail(err)
+			}
 		}
 		id, err := d.s.CreateThread(store.Thread{
 			Kind: "task", FromAgent: from, ToKind: toKind,

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -185,8 +185,8 @@ func validateIntent(intent string) error {
 
 // sendFlagVals holds cmdSend's parsed flag pointers.
 type sendFlagVals struct {
-	from, subject, ref, intent *string
-	role, broadcast            *bool
+	from, subject, ref, intent, project *string
+	role, broadcast                     *bool
 }
 
 // newSendFlagsWithVals declares send's flags and returns both the FlagSet
@@ -202,6 +202,7 @@ func newSendFlagsWithVals() (*flag.FlagSet, sendFlagVals) {
 	v.ref = fs.String("ref", "", "pointer to the work")
 	v.role = fs.Bool("role", false, "treat target as a role")
 	v.broadcast = fs.Bool("broadcast", false, "send to everyone")
+	v.project = fs.String("project", "", "with --broadcast: send only to this project's agents")
 	v.intent = fs.String("intent", "", "message intent: fyi, reply-requested, or action-requested")
 	return fs, v
 }
@@ -228,6 +229,9 @@ func cmdSend(args []string, out io.Writer) error {
 	if err := validateIntent(*v.intent); err != nil {
 		return err
 	}
+	if *v.project != "" && !*v.broadcast {
+		return fmt.Errorf("--project requires --broadcast")
+	}
 	toKind, toTarget := "agent", ""
 	switch {
 	case *v.broadcast:
@@ -238,8 +242,9 @@ func cmdSend(args []string, out io.Writer) error {
 	var body string
 	if *v.broadcast {
 		if len(rest) < 1 {
-			return fmt.Errorf("usage: muster send --broadcast <body> [--intent fyi|reply-requested|action-requested]")
+			return fmt.Errorf("usage: muster send --broadcast [--project <p>] <body> [--intent fyi|reply-requested|action-requested]")
 		}
+		toTarget = *v.project
 		body = strings.Join(rest, " ")
 	} else {
 		if len(rest) < 2 {

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -91,13 +91,15 @@ func init() {
 	Registry = []Command{
 		{
 			Name:     "send",
-			Synopsis: `send <target> "body" [--from <alias>] [--subject <s>] [--ref <r>] [--role] [--broadcast] [--intent fyi|reply-requested|action-requested]`,
+			Synopsis: `send <target> "body" [--from <alias>] [--subject <s>] [--ref <r>] [--role] [--broadcast [--project <p>]] [--intent fyi|reply-requested|action-requested]`,
 			Summary:  "Send a message to an agent, role, or everyone.",
 			Help: `target is an alias, a label, or a "project:label" pair, resolved the same
 way for every muster surface (send, nudge, inbox, tasks). --role treats
 target as a role name instead of an agent; --broadcast ignores target and
 sends to every registered agent (target is then omitted: 'muster send
---broadcast "body"'). --intent tags the message for the recipient's
+--broadcast "body"'). With --project, the broadcast reaches only agents
+registered under that exact project (the daemon rejects unknown projects and
+lists the known ones). --intent tags the message for the recipient's
 inbox/hook rendering: fyi (default, no action implied), reply-requested, or
 action-requested.`,
 			Group:    GroupTalk,

--- a/internal/humancli/send_broadcast_test.go
+++ b/internal/humancli/send_broadcast_test.go
@@ -1,0 +1,74 @@
+package humancli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSendBroadcastProjectFlag(t *testing.T) {
+	s := startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "w1", "project": "web", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := cmdSend([]string{"--broadcast", "--project", "web", "deploy", "landed", "--from", "tester"}, &buf); err != nil {
+		t.Fatalf("scoped broadcast send: %v", err)
+	}
+	ths, err := s.Threads(10)
+	if err != nil || len(ths) != 1 {
+		t.Fatalf("threads: %v (%d)", err, len(ths))
+	}
+	if ths[0].ToKind != "broadcast" || ths[0].ToTarget != "web" {
+		t.Fatalf("stored thread addressed %s:%q, want broadcast:web", ths[0].ToKind, ths[0].ToTarget)
+	}
+	_, entries, err := s.GetThread(ths[0].ID)
+	if err != nil || len(entries) != 1 || entries[0].Body != "deploy landed" {
+		t.Fatalf("unquoted body must join: %v / %+v", err, entries)
+	}
+}
+
+func TestSendProjectWithoutBroadcastErrors(t *testing.T) {
+	startTestDaemon(t)
+	var buf bytes.Buffer
+	err := cmdSend([]string{"--project", "web", "hello"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "--project requires --broadcast") {
+		t.Fatalf("want '--project requires --broadcast' error, got %v", err)
+	}
+}
+
+func TestSendBroadcastUnquotedBodyStaysGlobal(t *testing.T) {
+	s := startTestDaemon(t)
+	// "muster" is a real project on the roster — the exact collision the
+	// rejected positional form would have silently mis-scoped.
+	if _, err := callData("register_agent", map[string]any{"alias": "m1", "project": "muster", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := cmdSend([]string{"--broadcast", "muster", "is", "broken", "--from", "tester"}, &buf); err != nil {
+		t.Fatalf("global broadcast send: %v", err)
+	}
+	ths, err := s.Threads(10)
+	if err != nil || len(ths) != 1 {
+		t.Fatalf("threads: %v (%d)", err, len(ths))
+	}
+	if ths[0].ToTarget != "" {
+		t.Fatalf("unquoted broadcast body must stay global, got to_target=%q", ths[0].ToTarget)
+	}
+	_, entries, err := s.GetThread(ths[0].ID)
+	if err != nil || len(entries) != 1 || entries[0].Body != "muster is broken" {
+		t.Fatalf("body must join all positionals: %v / %+v", err, entries)
+	}
+}
+
+func TestSendBroadcastUnknownProjectSurfacesDaemonError(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "w1", "project": "web", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	err := cmdSend([]string{"--broadcast", "--project", "wbe", "typo", "--from", "tester"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), `no registered agents in project "wbe"`) {
+		t.Fatalf("daemon validation error must surface through the CLI, got %v", err)
+	}
+}

--- a/internal/mcpserver/tools_messages.go
+++ b/internal/mcpserver/tools_messages.go
@@ -11,7 +11,7 @@ import (
 type SendMessageIn struct {
 	From     string `json:"from" jsonschema:"the sending agent's alias"`
 	ToKind   string `json:"to_kind" jsonschema:"agent, role, or broadcast"`
-	ToTarget string `json:"to_target,omitempty" jsonschema:"the recipient alias or role (empty for broadcast)"`
+	ToTarget string `json:"to_target,omitempty" jsonschema:"the recipient alias or role; for broadcast: empty reaches every agent on the bus, or a project name reaches only that project's agents (unknown projects are rejected)"`
 	Subject  string `json:"subject" jsonschema:"a short subject line"`
 	Ref      string `json:"ref,omitempty" jsonschema:"optional pointer to the work (repo/branch/endpoint/file)"`
 	Body     string `json:"body" jsonschema:"the message body"`
@@ -118,7 +118,7 @@ func getThreadHandler(_ context.Context, _ *mcp.CallToolRequest, in GetThreadIn)
 // registerMessageTools registers send_message, reply, get_inbox, and
 // get_thread on srv.
 func registerMessageTools(srv *mcp.Server) {
-	mcp.AddTool(srv, &mcp.Tool{Name: "send_message", Description: "Send a message to another agent (to_kind=agent), a role (to_kind=role), or everyone (to_kind=broadcast). Set intent to fyi/reply-requested/action-requested so the recipient's inbox and drain reflect what you actually need back."}, sendMessageHandler)
+	mcp.AddTool(srv, &mcp.Tool{Name: "send_message", Description: "Send a message to another agent (to_kind=agent), a role (to_kind=role), or many agents at once (to_kind=broadcast). A broadcast with empty to_target reaches every agent on the bus; set to_target to a project name to reach only that project's agents. Set intent to fyi/reply-requested/action-requested so the recipient's inbox and drain reflect what you actually need back."}, sendMessageHandler)
 	mcp.AddTool(srv, &mcp.Tool{Name: "reply", Description: "Append a reply to an existing thread (message or task)."}, replyHandler)
 	mcp.AddTool(srv, &mcp.Tool{Name: "get_inbox", Description: "Read the threads that concern an agent — addressed to it (directly, by role, or broadcast) or originated by it, so replies on threads it started show up here — newest first. Rows carry last_from and an unread count — unread > 0 means entries you have not seen; read those threads with get_thread before reporting their state."}, getInboxHandler)
 	mcp.AddTool(srv, &mcp.Tool{Name: "get_thread", Description: "Fetch a single thread and all its entries in order."}, getThreadHandler)

--- a/internal/mcpserver/tools_tasks.go
+++ b/internal/mcpserver/tools_tasks.go
@@ -11,7 +11,7 @@ import (
 type TaskCreateIn struct {
 	From     string `json:"from" jsonschema:"the requesting agent's alias"`
 	ToKind   string `json:"to_kind" jsonschema:"agent, role, or broadcast"`
-	ToTarget string `json:"to_target" jsonschema:"the assignee alias or role"`
+	ToTarget string `json:"to_target" jsonschema:"the assignee alias or role; for broadcast: empty for every agent, or a project name for that project's agents only"`
 	Subject  string `json:"subject" jsonschema:"a short task title"`
 	Ref      string `json:"ref,omitempty" jsonschema:"optional pointer to the work (repo/branch/endpoint/file)"`
 	Body     string `json:"body" jsonschema:"task details"`

--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -125,7 +125,7 @@ func (r *Renderer) dispTarget(target string) string {
 	if a, ok := strings.CutPrefix(target, "agent:"); ok {
 		return r.disp(a)
 	}
-	if strings.HasPrefix(target, "role:") || target == "broadcast" || target == "" {
+	if strings.HasPrefix(target, "role:") || target == "broadcast" || strings.HasPrefix(target, "broadcast:") || target == "" {
 		return target
 	}
 	return r.disp(target) // nudge's bare alias

--- a/internal/render/renderer.go
+++ b/internal/render/renderer.go
@@ -120,7 +120,7 @@ func (r *Renderer) disp(alias string) string {
 }
 
 // dispTarget renders a journal target ('agent:x' / 'role:r' / 'broadcast' /
-// bare alias) for display.
+// 'broadcast:<project>' / bare alias) for display.
 func (r *Renderer) dispTarget(target string) string {
 	if a, ok := strings.CutPrefix(target, "agent:"); ok {
 		return r.disp(a)

--- a/internal/render/renderer_test.go
+++ b/internal/render/renderer_test.go
@@ -1,0 +1,16 @@
+package render
+
+import "testing"
+
+// dispTarget must show broadcast targets as-is — never label-resolve them
+// through the bare-alias fallthrough. The label planted under the literal
+// target string proves the fallthrough is not taken.
+func TestDispTargetScopedBroadcastShownAsIs(t *testing.T) {
+	r := NewRenderer(nil, map[string]string{"broadcast:web": "WRONG"}, false, false, 120)
+	if got := r.dispTarget("broadcast:web"); got != "broadcast:web" {
+		t.Fatalf("scoped broadcast target rendered %q, want broadcast:web", got)
+	}
+	if got := r.dispTarget("broadcast"); got != "broadcast" {
+		t.Fatalf("global broadcast target rendered %q, want broadcast", got)
+	}
+}

--- a/internal/station/model.go
+++ b/internal/station/model.go
@@ -1523,6 +1523,9 @@ func (m Model) dispToTarget(row listThreadRow) string {
 	case "role":
 		return "role:" + row.ToTarget
 	case "broadcast":
+		if row.ToTarget != "" {
+			return "broadcast:" + row.ToTarget
+		}
 		return "broadcast"
 	default:
 		return row.ToTarget

--- a/internal/station/model_test.go
+++ b/internal/station/model_test.go
@@ -304,3 +304,13 @@ func TestStaleTickEventsMsgDiscarded(t *testing.T) {
 		t.Fatalf("stale gen-1 msg must not trigger a regression-reset status note, got %q", m2.status)
 	}
 }
+
+func TestDispToTargetScopedBroadcast(t *testing.T) {
+	var m Model
+	if got := m.dispToTarget(listThreadRow{ToKind: "broadcast", ToTarget: "web"}); got != "broadcast:web" {
+		t.Fatalf("got %q, want broadcast:web", got)
+	}
+	if got := m.dispToTarget(listThreadRow{ToKind: "broadcast"}); got != "broadcast" {
+		t.Fatalf("got %q, want broadcast", got)
+	}
+}

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -191,7 +191,7 @@ WHERE `+threadConcerns+`
               WHERE e.thread_id = threads.id
                 AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)
                 AND e.from_agent != ?)`,
-		alias, alias, alias, alias, alias).Scan(&n)
+		alias, alias, alias, alias, alias, alias).Scan(&n)
 	return n, err
 }
 

--- a/internal/store/agents_test.go
+++ b/internal/store/agents_test.go
@@ -317,10 +317,10 @@ func TestSessionUnreadEmptyTupleNeverGroups(t *testing.T) {
 // and aliases — the "one canonical predicate" rule surviving a join.
 func TestThreadConcernsSessionJoinEquivalence(t *testing.T) {
 	s := newTestStore(t)
-	if err := s.RegisterAgent(Agent{Alias: "rev1", Role: "reviewer"}); err != nil {
+	if err := s.RegisterAgent(Agent{Alias: "rev1", Role: "reviewer", Project: "web"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.RegisterAgent(Agent{Alias: "rev2", Role: "reviewer"}); err != nil {
+	if err := s.RegisterAgent(Agent{Alias: "rev2", Role: "reviewer", Project: "api"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.RegisterAgent(Agent{Alias: "other", Role: "producer"}); err != nil {
@@ -337,6 +337,9 @@ func TestThreadConcernsSessionJoinEquivalence(t *testing.T) {
 	mk("message", "backend", "broadcast", "")
 	mk("message", "rev2", "agent", "someone-else")
 	mk("task", "other", "agent", "rev1")
+	mk("message", "backend", "broadcast", "web")  // scoped: concerns rev1 only
+	mk("message", "backend", "broadcast", "api")  // scoped: concerns rev2 only
+	mk("message", "backend", "broadcast", "gone") // scoped: concerns nobody
 
 	idsMatching := func(query string, args ...any) []int64 {
 		t.Helper()
@@ -357,7 +360,7 @@ func TestThreadConcernsSessionJoinEquivalence(t *testing.T) {
 	}
 
 	for _, alias := range []string{"rev1", "rev2", "other", "nobody"} {
-		want := idsMatching(`SELECT id FROM threads WHERE `+threadConcerns+` ORDER BY id`, alias, alias, alias)
+		want := idsMatching(`SELECT id FROM threads WHERE `+threadConcerns+` ORDER BY id`, alias, alias, alias, alias)
 		got := idsMatching(`WITH sess AS (SELECT ? AS alias) SELECT threads.id FROM threads JOIN sess ON `+threadConcernsJoin+` ORDER BY threads.id`, alias)
 		if !reflect.DeepEqual(want, got) {
 			t.Fatalf("alias=%q: threadConcerns=%v threadConcernsJoin=%v disagree", alias, want, got)

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -61,7 +61,7 @@ func (s *Store) Events(q EventQuery) ([]Event, error) {
    OR events.target = ?
    OR (events.thread_id > 0 AND EXISTS (
         SELECT 1 FROM threads WHERE threads.id = events.thread_id AND `+threadConcerns+`)))`)
-		args = append(args, q.Agent, q.Agent, q.Agent, q.Agent, q.Agent, q.Agent)
+		args = append(args, q.Agent, q.Agent, q.Agent, q.Agent, q.Agent, q.Agent, q.Agent)
 	}
 	if q.Kind != "" {
 		where = append(where, "events.kind = ?")

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -157,15 +157,16 @@ func (s *Store) GetThread(id int64) (Thread, []Entry, error) {
 // X. Every surface that answers that question — Inbox, UnreadCount, and (by
 // construction, since it walks originator+recipients) the daemon's notify
 // fan-out — must agree with this fragment; the surfaces diverging is exactly
-// how replies to originated threads once went invisible. Binds the alias
-// three times.
+// how replies to originated threads once went invisible. A scoped broadcast
+// (to_target != ”) concerns only agents whose registered project matches it
+// exactly; binds the alias four times.
 const threadConcerns = `((threads.to_kind='agent'  AND threads.to_target=?)
    OR (threads.to_kind='role'      AND threads.to_target != '' AND threads.to_target=(SELECT role FROM agents WHERE alias=?))
-   OR (threads.to_kind='broadcast')
+   OR (threads.to_kind='broadcast' AND (threads.to_target='' OR threads.to_target=(SELECT project FROM agents WHERE alias=?)))
    OR (threads.from_agent=?))`
 
 // threadConcernsJoin is threadConcerns re-expressed as a JOIN predicate
-// against a CTE column (sess.alias) instead of a literal alias bound three
+// against a CTE column (sess.alias) instead of a literal alias bound four
 // times — needed by SessionUnread, where "the alias" ranges over every alias
 // of a session rather than one bound value. It must stay semantically
 // identical to threadConcerns (update both together);
@@ -174,7 +175,7 @@ const threadConcerns = `((threads.to_kind='agent'  AND threads.to_target=?)
 // "sess" with an "alias" column.
 const threadConcernsJoin = `((threads.to_kind='agent' AND threads.to_target=sess.alias)
    OR (threads.to_kind='role'     AND threads.to_target != '' AND threads.to_target=(SELECT role FROM agents WHERE alias=sess.alias))
-   OR (threads.to_kind='broadcast')
+   OR (threads.to_kind='broadcast' AND (threads.to_target='' OR threads.to_target=(SELECT project FROM agents WHERE alias=sess.alias)))
    OR (threads.from_agent=sess.alias))`
 
 // threadLastEntryCTE is the ONE canonical CTE computing each thread's last
@@ -239,7 +240,7 @@ SELECT recent.id, recent.kind, recent.from_agent, recent.to_kind, recent.to_targ
        le.from_agent, le.created_at, last.n, COALESCE(unread.n, 0)
 FROM recent`+threadLastEntryJoin+`
 LEFT JOIN unread ON unread.thread_id = recent.id
-ORDER BY recent.updated_at DESC`, alias, alias, alias, alias, alias)
+ORDER BY recent.updated_at DESC`, alias, alias, alias, alias, alias, alias)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/threads_test.go
+++ b/internal/store/threads_test.go
@@ -432,3 +432,63 @@ func TestInboxUnreadDropsAfterMarkRead(t *testing.T) {
 		t.Fatalf("after mark-read: unread = %+v, want 0", after)
 	}
 }
+
+func TestInboxScopedBroadcastMatchesProjectOnly(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "in-proj", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "other-proj", Project: "api"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "no-proj"}); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(toTarget string) {
+		if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", ToTarget: toTarget}, "hi"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("web") // scoped to web
+	mk("")    // global
+
+	for alias, want := range map[string]int{"in-proj": 2, "other-proj": 1, "no-proj": 1} {
+		in, err := s.Inbox(alias)
+		if err != nil {
+			t.Fatalf("inbox(%s): %v", alias, err)
+		}
+		if len(in) != want {
+			t.Fatalf("inbox(%s) = %d threads, want %d", alias, len(in), want)
+		}
+	}
+
+	// UnreadCount agrees with Inbox (same canonical predicate).
+	if n, err := s.UnreadCount("other-proj"); err != nil || n != 1 {
+		t.Fatalf("UnreadCount(other-proj) = %d (%v), want 1", n, err)
+	}
+	if n, err := s.UnreadCount("in-proj"); err != nil || n != 2 {
+		t.Fatalf("UnreadCount(in-proj) = %d (%v), want 2", n, err)
+	}
+}
+
+func TestScopedBroadcastConcernsDepartedAgentsProject(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "ghost", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DepartAgent("ghost"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", ToTarget: "web"}, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	// Tombstoned rows preserve project; a departed agent that re-registers
+	// into the same alias sees the scoped broadcast (read-time semantics).
+	in, err := s.Inbox("ghost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(in) != 1 {
+		t.Fatalf("departed ghost inbox = %d threads, want 1", len(in))
+	}
+}


### PR DESCRIPTION
## Summary

Broadcasts can now be scoped to a single project: `to_kind='broadcast'` with `to_target='<project>'` concerns only agents registered under exactly that project, while an empty target keeps today's global semantics (all historical rows unchanged). Built per the spec and plan in `docs/superpowers/specs/` / `docs/superpowers/plans/`.

- **Store** — the one canonical concern predicate (`threadConcerns` / `threadConcernsJoin`) gains the scope check; equivalence test extended with scoped fixtures.
- **Daemon** — send-time validation rejects scoped broadcasts to unknown or departed-only projects with `no registered agents in project "<p>" (known projects: …)` (the alias black-hole backstop, applied to projects); wake fan-out notifies only same-project sessions; journal target is `broadcast:<project>`.
- **Display** — events renderer and station show `broadcast:<project>` as-is, never label-resolved.
- **MCP** — description-only: `send_message`/`task_create` schemas now advertise both broadcast forms (doubles as the discoverability fix — global broadcast already existed but wasn't findable).
- **CLI** — `muster send --broadcast --project <p> "body"`; `--project` without `--broadcast` errors. Flag form chosen over a positional project to avoid silently mis-scoping unquoted bodies whose first word is a real project name (regression-tested).

## Test plan

- `just verify` green (gofmt, golangci-lint, `go test -race ./...`, native + cross builds).
- New tests across store/daemon/render/station/humancli: scoped concern matching (incl. departed rows), validation (unknown/departed-only/global-never-validated/task_create parity), scoped fan-out, journal format, display fallthrough guard, CLI flag parsing + body-join regression.
- Isolated-bus end-to-end smoke (`MUSTER_HOME=/tmp/...`): unknown project rejected with known-projects error, scoped + global delivery to a second agent's inbox, journal shows `broadcast:muster`.

## Note for operators

The daemon is lazy and long-lived: after upgrading the binary, restart the daemon before relying on `--project` scoping — an old running daemon stores the target but delivers globally.