### PR TITLE
feat: paneless agents — first-class identity for sessions with no tmux pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,20 @@ deleted (default `720h`, i.e. 30 days), so the journal doesn't grow without
 bound on a long-running daemon.
 
 `register` captures the tmux pane automatically. Alias precedence: explicit
-arg → `$MUSTER_ALIAS` → tmux session name. `--model` is stored on the agent and
+arg → `$MUSTER_ALIAS` → tmux session name → working-directory basename.
+
+**Paneless sessions.** A session with no tmux in its environment (Claude
+Code's daemon-hosted sessions and background jobs execute outside the pane
+you launched them from) registers *paneless*: alias from the working
+directory, project from the enclosing git checkout, identity keyed on the
+harness session UUID. The session hooks work unchanged — auto-register at
+start, deregister at end, and the Stop hook checks the inbox via the daemon
+directly (there's no tmux badge to poll). Paneless agents show `◌` in the
+LIVE column (liveness is unknowable without a pane), are exempt from `gc`'s
+tmux-liveness reaping, and can't be reached by `muster nudge` — mail waits in
+the inbox for their next Stop.
+
+`--model` is stored on the agent and
 tunes `muster nudge`'s submit keystroke (`claude` and `codex` auto-submit; other
 values are typed without submitting).
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,12 @@ arg → `$MUSTER_ALIAS` → tmux session name → working-directory basename.
 Code's daemon-hosted sessions and background jobs execute outside the pane
 you launched them from) registers *paneless*: alias from the working
 directory, project from the enclosing git checkout, identity keyed on the
-harness session UUID. The session hooks work unchanged — auto-register at
+harness session UUID. Every session in a directory derives the same base, so
+the alias is **allocated unique** — `dotfiles`, then `dotfiles-2`, `-3`, … —
+never taken over from another live session; a resumed session revives its own
+alias instead of taking a new suffix. (The numbers are bus-side allocation
+order and won't necessarily match your tmux session numbering — the session
+can't see its tmux name, which is the whole reason it's paneless.) The session hooks work unchanged — auto-register at
 start, deregister at end, and the Stop hook checks the inbox via the daemon
 directly (there's no tmux badge to poll). Paneless agents show `◌` in the
 LIVE column (liveness is unknowable without a pane), are exempt from `gc`'s

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -209,7 +209,8 @@ func (d *Daemon) handleRegisterAgent(a map[string]any) proto.Response {
 		Alias: alias, Role: str(a, "role"), ModelType: str(a, "model_type"),
 		SocketPath: str(a, "socket_path"), PaneID: str(a, "pane_id"), SessionName: str(a, "session_name"),
 		SessionID: str(a, "session_id"), SessionCreated: i64(a, "session_created"),
-		Project: str(a, "project"), Label: str(a, "label"), LabelManual: boolArg(a, "label_manual"),
+		HarnessSessionID: str(a, "harness_session_id"),
+		Project:          str(a, "project"), Label: str(a, "label"), LabelManual: boolArg(a, "label_manual"),
 	}
 
 	var mu *sync.Mutex

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -603,9 +603,12 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 		d.logEvent(store.Event{Kind: "read", Agent: alias, Detail: detail})
 		return ok(threads)
 	case "session_aliases":
+		// socket_path may be empty: a paneless session's tuple is ("",
+		// harness session UUID) — see internal/harnessenv. Only a missing
+		// session_id leaves no tuple to key on.
 		socketPath, sessionID := str(a, "socket_path"), str(a, "session_id")
-		if socketPath == "" || sessionID == "" {
-			return fail(fmt.Errorf("session_aliases: socket_path and session_id are required"))
+		if sessionID == "" {
+			return fail(fmt.Errorf("session_aliases: session_id is required"))
 		}
 		agents, err := d.s.ListAgents()
 		if err != nil {
@@ -625,9 +628,10 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 		// unlike setSessionBadge, this neither mutates the tmux badge nor
 		// journals anything, so there is nothing for the session lock to
 		// serialize against.
+		// socket_path may be empty — the paneless tuple, as in session_aliases.
 		socketPath, sessionID := str(a, "socket_path"), str(a, "session_id")
-		if socketPath == "" || sessionID == "" {
-			return fail(fmt.Errorf("session_unread: socket_path and session_id are required"))
+		if sessionID == "" {
+			return fail(fmt.Errorf("session_unread: session_id is required"))
 		}
 		total, action, err := d.s.SessionUnread(socketPath, sessionID)
 		if err != nil {

--- a/internal/daemon/wake_wiring_test.go
+++ b/internal/daemon/wake_wiring_test.go
@@ -618,20 +618,44 @@ func TestNotifyDrainInterleaving(t *testing.T) {
 	}
 }
 
-// TestSessionAliasesRejectsEmptyTuple: session_aliases requires BOTH
-// socket_path and session_id non-empty (spec §3), and on success returns the
-// session's aliases sorted.
+// TestSessionAliasesRejectsEmptyTuple: session_aliases requires a non-empty
+// session_id (spec §3) — socket_path may be empty, the PANELESS tuple ("",
+// harness session UUID), which must match only paneless rows — and on
+// success returns the session's aliases sorted.
 func TestSessionAliasesRejectsEmptyTuple(t *testing.T) {
 	n := &fakeNotifier{}
 	sock := startWithNotifier(t, n)
 	call(t, sock, "register_agent", map[string]any{"alias": "solo", "role": "peer", "model_type": "claude", "socket_path": "/s", "session_id": "$9"})
 	call(t, sock, "register_agent", map[string]any{"alias": "twin", "role": "peer", "model_type": "claude", "socket_path": "/s", "session_id": "$9"})
 
-	if resp := call(t, sock, "session_aliases", map[string]any{"socket_path": "", "session_id": "$9"}); resp.OK {
-		t.Fatal("session_aliases must reject an empty socket_path")
-	}
 	if resp := call(t, sock, "session_aliases", map[string]any{"socket_path": "/s", "session_id": ""}); resp.OK {
 		t.Fatal("session_aliases must reject an empty session_id")
+	}
+
+	// The paneless tuple ("", uuid) is valid and matches only paneless rows —
+	// never tmux rows, even ones whose session_id coincides.
+	call(t, sock, "register_agent", map[string]any{"alias": "paneless-1", "role": "peer", "model_type": "claude", "socket_path": "", "session_id": "hs-uuid"})
+	respPaneless := call(t, sock, "session_aliases", map[string]any{"socket_path": "", "session_id": "hs-uuid"})
+	if !respPaneless.OK {
+		t.Fatalf("session_aliases must accept the paneless tuple: %+v", respPaneless)
+	}
+	var panelessOut struct {
+		Aliases []string `json:"aliases"`
+	}
+	decode(t, respPaneless, &panelessOut)
+	if !slices.Equal(panelessOut.Aliases, []string{"paneless-1"}) {
+		t.Fatalf("paneless aliases = %v, want [paneless-1]", panelessOut.Aliases)
+	}
+	respEmpty := call(t, sock, "session_aliases", map[string]any{"socket_path": "", "session_id": "$9"})
+	if !respEmpty.OK {
+		t.Fatalf("session_aliases with empty socket must be accepted: %+v", respEmpty)
+	}
+	var emptyOut struct {
+		Aliases []string `json:"aliases"`
+	}
+	decode(t, respEmpty, &emptyOut)
+	if len(emptyOut.Aliases) != 0 {
+		t.Fatalf("(\"\", $9) must not match tmux rows on socket /s, got %v", emptyOut.Aliases)
 	}
 
 	resp := call(t, sock, "session_aliases", map[string]any{"socket_path": "/s", "session_id": "$9"})
@@ -650,16 +674,17 @@ func TestSessionAliasesRejectsEmptyTuple(t *testing.T) {
 
 // TestSessionUnreadOpRejectsEmptyTupleAndReturnsCounts: the session_unread op
 // (spec §3/§4, added for the Stop hook's multi-alias drain wording) requires
-// both fields non-empty like session_aliases, and on success returns the
-// store's {total, action} pair as-is.
+// a non-empty session_id like session_aliases (socket_path may be empty —
+// the paneless tuple), and on success returns the store's {total, action}
+// pair as-is.
 func TestSessionUnreadOpRejectsEmptyTupleAndReturnsCounts(t *testing.T) {
 	sock := startWithNotifier(t, &fakeNotifier{})
 	call(t, sock, "register_agent", map[string]any{"alias": "worker", "role": "peer", "model_type": "claude", "socket_path": "/s", "session_id": "$9"})
 	call(t, sock, "register_agent", map[string]any{"alias": "other", "role": "peer", "model_type": "claude", "socket_path": "/p", "session_id": "$2"})
 	call(t, sock, "send_message", map[string]any{"from": "other", "to_kind": "agent", "to_target": "worker", "subject": "s", "body": "b", "intent": "action-requested"})
 
-	if resp := call(t, sock, "session_unread", map[string]any{"socket_path": "", "session_id": "$9"}); resp.OK {
-		t.Fatal("session_unread must reject an empty socket_path")
+	if resp := call(t, sock, "session_unread", map[string]any{"socket_path": "", "session_id": "$9"}); !resp.OK {
+		t.Fatalf("session_unread must accept an empty socket_path (paneless tuple): %+v", resp)
 	}
 	if resp := call(t, sock, "session_unread", map[string]any{"socket_path": "/s", "session_id": ""}); resp.OK {
 		t.Fatal("session_unread must reject an empty session_id")

--- a/internal/harnessenv/harnessenv.go
+++ b/internal/harnessenv/harnessenv.go
@@ -1,0 +1,114 @@
+// Package harnessenv captures a coding-agent harness session's identity —
+// the paneless counterpart to tmuxenv. Harness runtimes that host sessions
+// in a daemon (Claude Code's daemon-hosted sessions, background jobs) run
+// them outside any tmux pane: $TMUX/$TMUX_PANE never reach the process even
+// when the operator launched from a pane, so tmuxenv.CaptureEnv comes back
+// empty. Identity then comes from what the harness DOES provide: every hook's
+// stdin payload carries session_id and cwd, and the process environment
+// carries $CLAUDE_CODE_SESSION_ID and a working directory. Like tmuxenv,
+// this package is the single canonical capture path for that identity —
+// callers must not read those variables directly.
+package harnessenv
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Capture holds the identity fields available to a paneless session. A
+// paneless registration stores SessionID in the roster row's session_id with
+// an empty socket_path — the tuple ("", SessionID) groups sibling aliases and
+// scopes hook ownership exactly as (socket, tmux session id) does for panes.
+type Capture struct {
+	// SessionID is the harness's session UUID — stable for the session's
+	// lifetime, present in every hook payload and in the session's own
+	// process environment. "" when not running under a known harness.
+	SessionID string
+	// CWD is the session's working directory, the raw material for Alias and
+	// Project derivation.
+	CWD string
+}
+
+// FromEnv captures identity from the process environment: the harness
+// session UUID and the working directory.
+func FromEnv() Capture {
+	cwd, _ := os.Getwd()
+	return Capture{SessionID: os.Getenv("CLAUDE_CODE_SESSION_ID"), CWD: cwd}
+}
+
+// FromHookPayload captures identity from a hook's stdin payload (Claude Code
+// and Codex both send {"session_id": ..., "cwd": ..., ...}), falling back to
+// FromEnv for any field the payload doesn't carry. Invalid or empty JSON is
+// tolerated — hooks must never fail on input shape.
+func FromHookPayload(payload []byte) Capture {
+	var p struct {
+		SessionID string `json:"session_id"`
+		CWD       string `json:"cwd"`
+	}
+	_ = json.Unmarshal(payload, &p)
+	c := FromEnv()
+	if p.SessionID != "" {
+		c.SessionID = p.SessionID
+	}
+	if p.CWD != "" {
+		c.CWD = p.CWD
+	}
+	return c
+}
+
+// Alias derives the fallback agent alias from the working directory — its
+// basename, mirroring how the operator's per-project tmux sessions are named
+// after their directory. "" when there is no usable directory ($MUSTER_ALIAS
+// and explicit arguments always take precedence over this in callers).
+func (c Capture) Alias() string {
+	base := filepath.Base(c.CWD)
+	if base == "." || base == string(filepath.Separator) || base == "" {
+		return ""
+	}
+	return base
+}
+
+// Project derives the project name by walking up from CWD to the enclosing
+// git checkout. For a linked worktree (.git is a pointer file, "gitdir:
+// <main>/.git/worktrees/<name>"), the project is the MAIN checkout's
+// directory name, so every worktree of one repo shares its project — the
+// same grouping the per-project tmux sockets ("proj-<project>") give
+// pane-anchored agents. "" when CWD is not inside a git checkout.
+func (c Capture) Project() string {
+	dir := c.CWD
+	for dir != "" {
+		gitPath := filepath.Join(dir, ".git")
+		if fi, err := os.Stat(gitPath); err == nil {
+			if !fi.IsDir() {
+				if main := mainCheckoutFromGitFile(gitPath); main != "" {
+					return filepath.Base(main)
+				}
+			}
+			return filepath.Base(dir)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
+}
+
+// mainCheckoutFromGitFile resolves a linked worktree's .git pointer file to
+// the main checkout's path: "gitdir: /main/.git/worktrees/<name>" → "/main".
+// "" when the file doesn't parse as a worktree pointer.
+func mainCheckoutFromGitFile(gitPath string) string {
+	b, err := os.ReadFile(gitPath)
+	if err != nil {
+		return ""
+	}
+	gd := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(b)), "gitdir:"))
+	sep := string(filepath.Separator)
+	if i := strings.Index(gd, sep+".git"+sep); i > 0 {
+		return gd[:i]
+	}
+	return ""
+}

--- a/internal/harnessenv/harnessenv_test.go
+++ b/internal/harnessenv/harnessenv_test.go
@@ -1,0 +1,72 @@
+package harnessenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFromHookPayloadPrecedence(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "env-uuid")
+	c := FromHookPayload([]byte(`{"session_id":"payload-uuid","cwd":"/tmp/payload-dir"}`))
+	if c.SessionID != "payload-uuid" || c.CWD != "/tmp/payload-dir" {
+		t.Fatalf("payload must win over env, got %+v", c)
+	}
+}
+
+func TestFromHookPayloadFallsBackToEnv(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "env-uuid")
+	for _, payload := range []string{"", "not json", "{}"} {
+		c := FromHookPayload([]byte(payload))
+		if c.SessionID != "env-uuid" {
+			t.Fatalf("payload %q: expected env fallback, got %+v", payload, c)
+		}
+	}
+}
+
+func TestAlias(t *testing.T) {
+	for _, tc := range []struct{ cwd, want string }{
+		{"/Users/x/GitHub/muster", "muster"},
+		{"/Users/x/repo/.claude/worktrees/paneless-agents", "paneless-agents"},
+		{"/", ""},
+		{"", ""},
+	} {
+		if got := (Capture{CWD: tc.cwd}).Alias(); got != tc.want {
+			t.Fatalf("Alias(%q) = %q, want %q", tc.cwd, got, tc.want)
+		}
+	}
+}
+
+func TestProjectMainCheckout(t *testing.T) {
+	root := t.TempDir()
+	main := filepath.Join(root, "myproj")
+	sub := filepath.Join(main, "internal", "deep")
+	if err := os.MkdirAll(filepath.Join(main, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := (Capture{CWD: sub}).Project(); got != "myproj" {
+		t.Fatalf("Project from subdir = %q, want myproj", got)
+	}
+	if got := (Capture{CWD: root}).Project(); got != "" {
+		t.Fatalf("Project outside any checkout = %q, want empty", got)
+	}
+}
+
+func TestProjectLinkedWorktree(t *testing.T) {
+	root := t.TempDir()
+	main := filepath.Join(root, "myproj")
+	wt := filepath.Join(main, ".claude", "worktrees", "feat-x")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitdir := "gitdir: " + filepath.Join(main, ".git", "worktrees", "feat-x") + "\n"
+	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte(gitdir), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := (Capture{CWD: wt}).Project(); got != "myproj" {
+		t.Fatalf("Project from linked worktree = %q, want myproj", got)
+	}
+}

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -78,8 +78,18 @@ func hookSessionStartPaneless(h harnessenv.Capture, model string) {
 	if h.SessionID == "" && h.Alias() == "" {
 		return // no resolvable identity: never dial the daemon from an identity-less hook
 	}
-	if owned := panelessOwnedAliases(h.SessionID); len(owned) > 0 {
-		_ = regFn(owned[0], false) // resume: revive/refresh this session's own identity
+	if owned := harnessOwnedRows(h.SessionID); len(owned) > 0 {
+		// This session already has an identity — the pane-side launch
+		// handshake pre-registered a tmux-anchored row, or a prior life of
+		// this session (resume) left one. A live row needs nothing from
+		// this hook; if every owned row is a tombstone, revive the first
+		// with its stored identity intact.
+		for _, ag := range owned {
+			if !ag.Departed {
+				return
+			}
+		}
+		reviveRow(owned[0], model)
 		return
 	}
 	_, _ = allocPanelessAlias(h.Alias(), h.SessionID, regFn)
@@ -182,21 +192,13 @@ func hookSessionEnd(c tmuxenv.Capture, h harnessenv.Capture) {
 	}
 }
 
-// hookSessionEndPaneless tombstones every alias the dying paneless session
-// owns — rows whose tuple is ("", this harness session UUID). Rows holding a
-// tmux socket, another session's UUID, or no UUID at all (a pre-harnessenv
-// paneless registration) are never this session's to tombstone.
+// hookSessionEndPaneless tombstones every row the dying harness session owns
+// — handshake-registered tmux rows and paneless rows alike (harnessOwnedRows'
+// two match shapes). Rows of other sessions, or with no harness link at all
+// (pre-handshake registrations), are never this session's to tombstone.
 func hookSessionEndPaneless(h harnessenv.Capture) {
-	raw, err := callData("list_agents", nil)
-	if err != nil {
-		return // hooks never block a session on a dead daemon
-	}
-	var rows []agentRow
-	if json.Unmarshal(raw, &rows) != nil {
-		return
-	}
-	for _, ag := range rows {
-		if ag.Departed || ag.SocketPath != "" || ag.SessionID != h.SessionID {
+	for _, ag := range harnessOwnedRows(h.SessionID) {
+		if ag.Departed {
 			continue
 		}
 		_ = cmdDeregister([]string{ag.Alias}, io.Discard)
@@ -299,33 +301,51 @@ func hookStop(payload []byte, out io.Writer) {
 }
 
 // hookStopPaneless is the Stop-hook inbox check for sessions with no tmux in
-// their environment (harness daemon-hosted sessions). A paneless session has
-// no @muster_inbox tmux option to serve as the cheap firing gate, so this
-// dials the daemon directly on every Stop — two ops over a local unix
-// socket, the price of paneless mail. Aliases and unread both come from the
-// paneless tuple ("", harness session UUID); an unregistered session (no
-// aliases on that tuple) prints nothing, and unlike the tmux path there is
-// no session-name fallback to address — a paneless identity either resolved
-// from the roster or doesn't exist.
+// their environment (harness daemon-hosted sessions). Such a session has no
+// @muster_inbox tmux option to serve as the cheap firing gate, so this dials
+// the daemon directly on every Stop — two ops over a local unix socket, the
+// price of daemon-hosted mail. Identity resolves by harness session UUID
+// (harnessOwnedRows): handshake-registered tmux rows and paneless rows
+// alike. An unregistered session prints nothing, and unlike the tmux path
+// there is no session-name fallback to address — a harness identity either
+// resolved from the roster or doesn't exist.
 func hookStopPaneless(h harnessenv.Capture, out io.Writer) {
 	if h.SessionID == "" {
 		return
 	}
-	raw, err := callData("session_aliases", map[string]any{"socket_path": "", "session_id": h.SessionID})
-	if err != nil {
+	var aliases []string
+	var label string
+	var tup *agentRow
+	owned := harnessOwnedRows(h.SessionID)
+	for i, ag := range owned {
+		if ag.Departed {
+			continue
+		}
+		aliases = append(aliases, ag.Alias)
+		if label == "" && ag.LabelManual {
+			label = ag.Label
+		}
+		if tup == nil && ag.SocketPath != "" && ag.SessionID != "" {
+			tup = &owned[i]
+		}
+	}
+	if len(aliases) == 0 {
 		return
 	}
-	var res struct {
-		Aliases []string `json:"aliases"`
+	// Unread comes from ONE tuple: the handshake row's tmux tuple when the
+	// session has one (its mail lives there), else the paneless tuple. A
+	// split identity spanning both would need two queries whose overlapping
+	// threads can't be deduplicated client-side — the aliases list still
+	// names every identity, so nothing goes undrained.
+	sock, sid := "", h.SessionID
+	if tup != nil {
+		sock, sid = tup.SocketPath, tup.SessionID
 	}
-	if json.Unmarshal(raw, &res) != nil || len(res.Aliases) == 0 {
-		return
-	}
-	total, action, ok := sessionUnreadForHook("", h.SessionID)
+	total, action, ok := sessionUnreadForHook(sock, sid)
 	if !ok || total <= 0 {
 		return
 	}
-	b, err := json.Marshal(stopReason{Decision: "block", Reason: hookReason(total, action, res.Aliases, "")})
+	b, err := json.Marshal(stopReason{Decision: "block", Reason: hookReason(total, action, aliases, label)})
 	if err != nil {
 		return
 	}

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/schuettc/muster/internal/harnessenv"
 	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
@@ -15,6 +16,12 @@ import (
 // the single entry point an agent harness's hook config points at directly
 // (in place of a copied contrib/muster-session-hook.sh). model defaults to
 // "claude" when omitted.
+//
+// The stdin payload is read once here and handed to every branch: harnesses
+// that host sessions outside tmux (daemon-hosted sessions — see harnessenv)
+// leave tmuxenv.CaptureEnv empty, and the payload's session_id/cwd are then
+// the ONLY identity a hook has, for SessionStart's register just as much as
+// for Stop's inbox check.
 //
 // A hook must never block a session, so cmdHook always returns nil: every
 // internal error is swallowed, and on any input other than a recognized
@@ -30,17 +37,51 @@ func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
 	if len(args) > 1 && args[1] != "" {
 		model = args[1]
 	}
+	payload, _ := io.ReadAll(io.LimitReader(stdin, 1<<20)) // a hook payload is small; the cap only guards a pathological writer
 	switch args[0] {
 	case "SessionStart":
-		if hookMayClaimIdentity(tmuxenv.CaptureEnv()) {
-			_ = cmdRegister([]string{"--model", model}, io.Discard)
+		c := tmuxenv.CaptureEnv()
+		if c.SocketPath != "" && c.PaneID != "" {
+			if hookMayClaimIdentity(c) {
+				_ = cmdRegister([]string{"--model", model}, io.Discard)
+			}
+		} else {
+			hookSessionStartPaneless(harnessenv.FromHookPayload(payload), model)
 		}
 	case "SessionEnd":
-		hookSessionEnd(tmuxenv.CaptureEnv())
+		hookSessionEnd(tmuxenv.CaptureEnv(), harnessenv.FromHookPayload(payload))
 	case "Stop":
-		hookStop(stdin, out)
+		hookStop(payload, out)
 	}
 	return nil
+}
+
+// hookSessionStartPaneless auto-registers a session that has no tmux pane in
+// its environment (harness daemon-hosted sessions): alias from $MUSTER_ALIAS
+// or the payload cwd's basename, identity tuple ("", harness session UUID).
+// The claim gate mirrors hookMayClaimIdentity's philosophy — a departed row
+// or one from another session is reclaimed (paneless rows have no liveness,
+// so a stale row from a crashed session must not squat the alias forever);
+// only an alias whose registered tmux pane is provably still alive is left
+// alone, since a live pane-anchored owner CAN be verified.
+func hookSessionStartPaneless(h harnessenv.Capture, model string) {
+	alias := os.Getenv("MUSTER_ALIAS")
+	if alias == "" {
+		alias = h.Alias()
+	}
+	if alias == "" {
+		return // no resolvable identity: never dial the daemon from an identity-less hook
+	}
+	if ag, found := hookGetAgent(alias); found && !ag.Departed &&
+		ag.SocketPath != "" && ag.PaneID != "" && tmuxenv.IsPaneAlive(ag.SocketPath, ag.PaneID) {
+		return // a live tmux pane owns this alias: not ours to steal
+	}
+	_, _ = callData("register_agent", map[string]any{
+		"alias": alias, "role": "", "model_type": model,
+		"session_name": "", "session_id": h.SessionID, "session_created": 0,
+		"socket_path": "", "pane_id": "",
+		"project": h.Project(), "label": "", "label_manual": false,
+	})
 }
 
 // hookAlias resolves the identity a hook event acts on, mirroring
@@ -106,10 +147,16 @@ func hookMayClaimIdentity(c tmuxenv.Capture) bool {
 // same predicate hookOwnsIdentity applies to one: same (socket_path,
 // session_id) tuple, not departed, and the row's pane is unset or this pane
 // — so a dying sibling (subagent) pane still cannot tombstone the primary's
-// registrations. Outside tmux there is no tuple to enumerate; the
-// single-identity gate is all there is, exactly as before.
-func hookSessionEnd(c tmuxenv.Capture) {
+// registrations. Outside tmux the paneless tuple ("", harness session UUID)
+// is enumerated the same way — every alias this harness session registered is
+// tombstoned; with no harness identity either, the single-identity gate is
+// all there is, exactly as before.
+func hookSessionEnd(c tmuxenv.Capture, h harnessenv.Capture) {
 	if c.SocketPath == "" || c.SessionID == "" {
+		if h.SessionID != "" {
+			hookSessionEndPaneless(h)
+			return
+		}
 		if hookOwnsIdentity(c) {
 			_ = cmdDeregister(nil, io.Discard)
 		}
@@ -129,6 +176,27 @@ func hookSessionEnd(c tmuxenv.Capture) {
 		}
 		if ag.PaneID != "" && ag.PaneID != c.PaneID {
 			continue // a sibling pane's identity: not ours to tombstone
+		}
+		_ = cmdDeregister([]string{ag.Alias}, io.Discard)
+	}
+}
+
+// hookSessionEndPaneless tombstones every alias the dying paneless session
+// owns — rows whose tuple is ("", this harness session UUID). Rows holding a
+// tmux socket, another session's UUID, or no UUID at all (a pre-harnessenv
+// paneless registration) are never this session's to tombstone.
+func hookSessionEndPaneless(h harnessenv.Capture) {
+	raw, err := callData("list_agents", nil)
+	if err != nil {
+		return // hooks never block a session on a dead daemon
+	}
+	var rows []agentRow
+	if json.Unmarshal(raw, &rows) != nil {
+		return
+	}
+	for _, ag := range rows {
+		if ag.Departed || ag.SocketPath != "" || ag.SessionID != h.SessionID {
+			continue
 		}
 		_ = cmdDeregister([]string{ag.Alias}, io.Discard)
 	}
@@ -189,15 +257,14 @@ type stopReason struct {
 // happened to read the option from. Either call's failure (or an empty
 // alias list) falls back to today's single session-name behavior so the
 // hook never goes silent because of a daemon hiccup.
-func hookStop(stdin io.Reader, out io.Writer) {
+func hookStop(payload []byte, out io.Writer) {
 	var in stopInput
-	if b, err := io.ReadAll(stdin); err == nil {
-		_ = json.Unmarshal(b, &in) // invalid/empty JSON -> zero value (false)
-	}
+	_ = json.Unmarshal(payload, &in) // invalid/empty JSON -> zero value (false)
 	if in.StopHookActive {
 		return // loop guard: we already triggered a continuation this cycle
 	}
 	if os.Getenv("TMUX") == "" {
+		hookStopPaneless(harnessenv.FromHookPayload(payload), out)
 		return
 	}
 	optCount, err := strconv.Atoi(tmuxenv.CurrentSessionOption("@muster_inbox"))
@@ -224,6 +291,40 @@ func hookStop(stdin io.Reader, out io.Writer) {
 	label := tmuxenv.CurrentSessionOption(tmuxenv.LabelOption())
 	reason := hookReason(total, action, aliases, label)
 	b, err := json.Marshal(stopReason{Decision: "block", Reason: reason})
+	if err != nil {
+		return
+	}
+	_, _ = fmt.Fprintln(out, string(b)) // best-effort: a hook's stdout write failing has nowhere to report to
+}
+
+// hookStopPaneless is the Stop-hook inbox check for sessions with no tmux in
+// their environment (harness daemon-hosted sessions). A paneless session has
+// no @muster_inbox tmux option to serve as the cheap firing gate, so this
+// dials the daemon directly on every Stop — two ops over a local unix
+// socket, the price of paneless mail. Aliases and unread both come from the
+// paneless tuple ("", harness session UUID); an unregistered session (no
+// aliases on that tuple) prints nothing, and unlike the tmux path there is
+// no session-name fallback to address — a paneless identity either resolved
+// from the roster or doesn't exist.
+func hookStopPaneless(h harnessenv.Capture, out io.Writer) {
+	if h.SessionID == "" {
+		return
+	}
+	raw, err := callData("session_aliases", map[string]any{"socket_path": "", "session_id": h.SessionID})
+	if err != nil {
+		return
+	}
+	var res struct {
+		Aliases []string `json:"aliases"`
+	}
+	if json.Unmarshal(raw, &res) != nil || len(res.Aliases) == 0 {
+		return
+	}
+	total, action, ok := sessionUnreadForHook("", h.SessionID)
+	if !ok || total <= 0 {
+		return
+	}
+	b, err := json.Marshal(stopReason{Decision: "block", Reason: hookReason(total, action, res.Aliases, "")})
 	if err != nil {
 		return
 	}

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -57,31 +57,32 @@ func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
 }
 
 // hookSessionStartPaneless auto-registers a session that has no tmux pane in
-// its environment (harness daemon-hosted sessions): alias from $MUSTER_ALIAS
-// or the payload cwd's basename, identity tuple ("", harness session UUID).
-// The claim gate mirrors hookMayClaimIdentity's philosophy — a departed row
-// or one from another session is reclaimed (paneless rows have no liveness,
-// so a stale row from a crashed session must not squat the alias forever);
-// only an alias whose registered tmux pane is provably still alive is left
-// alone, since a live pane-anchored owner CAN be verified.
+// its environment (harness daemon-hosted sessions) on the paneless tuple
+// ("", harness session UUID). $MUSTER_ALIAS is explicit operator intent and
+// registers exactly (plain upsert). Otherwise the alias is ALLOCATED from
+// the payload cwd's basename via allocPanelessAlias — every session in a
+// directory derives the same base, so uniqueness (dotfiles, dotfiles-2, …)
+// must be allocated, never taken over: the takeover this replaces let a
+// second session in the same directory silently steal the first one's
+// identity and inbox. A session that already owns aliases on its tuple
+// (resume) refreshes the first instead of allocating a new one.
 func hookSessionStartPaneless(h harnessenv.Capture, model string) {
-	alias := os.Getenv("MUSTER_ALIAS")
-	if alias == "" {
-		alias = h.Alias()
+	regFn := func(alias string, ifAbsent bool) error {
+		_, err := callData("register_agent", registerPanelessArgs(alias, "", model, h, ifAbsent))
+		return err
 	}
-	if alias == "" {
+	if alias := os.Getenv("MUSTER_ALIAS"); alias != "" {
+		_ = regFn(alias, false)
+		return
+	}
+	if h.SessionID == "" && h.Alias() == "" {
 		return // no resolvable identity: never dial the daemon from an identity-less hook
 	}
-	if ag, found := hookGetAgent(alias); found && !ag.Departed &&
-		ag.SocketPath != "" && ag.PaneID != "" && tmuxenv.IsPaneAlive(ag.SocketPath, ag.PaneID) {
-		return // a live tmux pane owns this alias: not ours to steal
+	if owned := panelessOwnedAliases(h.SessionID); len(owned) > 0 {
+		_ = regFn(owned[0], false) // resume: revive/refresh this session's own identity
+		return
 	}
-	_, _ = callData("register_agent", map[string]any{
-		"alias": alias, "role": "", "model_type": model,
-		"session_name": "", "session_id": h.SessionID, "session_created": 0,
-		"socket_path": "", "pane_id": "",
-		"project": h.Project(), "label": "", "label_manual": false,
-	})
+	_, _ = allocPanelessAlias(h.Alias(), h.SessionID, regFn)
 }
 
 // hookAlias resolves the identity a hook event acts on, mirroring

--- a/internal/humancli/hook_test.go
+++ b/internal/humancli/hook_test.go
@@ -24,6 +24,10 @@ func TestHookStopLoopGuard(t *testing.T) {
 
 func TestHookStopNoTmux(t *testing.T) {
 	t.Setenv("TMUX", "")
+	// Pin the harness identity away: on a dev machine `go test` itself runs
+	// inside a Claude session whose CLAUDE_CODE_SESSION_ID would otherwise
+	// give this "no identity" scenario a paneless identity and a daemon dial.
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
 	var buf bytes.Buffer
 	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{}`), &buf); err != nil {
 		t.Fatal(err)
@@ -741,6 +745,7 @@ func TestHookSessionStartBestEffortWhenDaemonUnreachable(t *testing.T) {
 	t.Setenv("TMUX", "")
 	t.Setenv("TMUX_PANE", "")
 	t.Setenv("MUSTER_ALIAS", "")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "") // pin: a dev machine's own Claude session must not lend this test an identity
 	var buf bytes.Buffer
 	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(""), &buf); err != nil {
 		t.Fatalf("hook must never return an error, got %v", err)
@@ -856,6 +861,11 @@ func TestHookSessionEndUnresolvableIdentityNeverDialsDaemon(t *testing.T) {
 	t.Setenv("TMUX", "")
 	t.Setenv("TMUX_PANE", "")
 	t.Setenv("MUSTER_ALIAS", "")
+	// Pin the harness identity away: with a CLAUDE_CODE_SESSION_ID leaking in
+	// from a dev machine's own Claude session, SessionEnd legitimately HAS an
+	// identity (the paneless tuple) and dialing would be correct — this test
+	// is specifically about the no-identity-at-all branch.
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
 
 	done := make(chan error, 1)
 	go func() {

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -48,12 +48,16 @@ type agentRow struct {
 	SessionID string `json:"session_id"`
 	// SessionCreated feeds tmuxenv.IsSessionAlive's recycled-session-ID
 	// discrimination (see store.Agent.SessionCreated).
-	SessionCreated int64  `json:"session_created"`
-	SessionName    string `json:"session_name"`
-	Project        string `json:"project"`
-	Label          string `json:"label"`
-	LabelManual    bool   `json:"label_manual"`
-	LastSeen       int64  `json:"last_seen"`
+	SessionCreated int64 `json:"session_created"`
+	// HarnessSessionID links a row to its harness session (see
+	// store.Agent.HarnessSessionID) — how a daemon-hosted session's hooks,
+	// which see no tmux, find their own rows.
+	HarnessSessionID string `json:"harness_session_id"`
+	SessionName      string `json:"session_name"`
+	Project          string `json:"project"`
+	Label            string `json:"label"`
+	LabelManual      bool   `json:"label_manual"`
+	LastSeen         int64  `json:"last_seen"`
 	// Departed is true once the agent has been deregistered (tombstoned, not
 	// deleted — see store.Store.DepartAgent): gc's default reap and
 	// --purge-agents both key off this to decide whether a row still needs

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -155,8 +155,14 @@ func cmdAgents(out io.Writer) error {
 			label = "(" + label + ")" // auto-topic: shown but not addressable
 		}
 		live := "✗"
-		if a.Live {
+		switch {
+		case a.Live:
 			live = "●"
+		case a.SocketPath == "" && !a.Departed:
+			// Paneless agents (harness daemon-hosted sessions) have no tmux
+			// session to probe: liveness is unknowable here, and rendering ✗
+			// would read as "dead" for what is usually a live session.
+			live = "◌"
 		}
 		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", proj, a.Alias, label, a.ModelType, live); err != nil {
 			return err

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -64,7 +64,32 @@ func cmdRegister(args []string, out io.Writer) error {
 	case c.SessionName != "":
 		alias = c.SessionName
 	default:
-		alias = h.Alias()
+		// Paneless cwd fallback: every session in a directory derives the
+		// same base, so the alias must be ALLOCATED unique (base, base-2, …)
+		// — never taken over from another live session. An explicit arg,
+		// $MUSTER_ALIAS, or a tmux session name (unique by construction)
+		// registers exactly, above.
+		if h.Alias() == "" && h.SessionID == "" {
+			return fmt.Errorf("cannot determine alias: no tmux session and no usable working directory; pass one explicitly or set $MUSTER_ALIAS")
+		}
+		regFn := func(a string, ifAbsent bool) error {
+			args := registerPanelessArgs(a, *role, *model, h, ifAbsent)
+			_, err := callData("register_agent", args)
+			return err
+		}
+		if owned := panelessOwnedAliases(h.SessionID); len(owned) > 0 {
+			alias = owned[0] // this session already has an identity: refresh it
+			if err := regFn(alias, false); err != nil {
+				return err
+			}
+		} else {
+			var err error
+			if alias, err = allocPanelessAlias(h.Alias(), h.SessionID, regFn); err != nil {
+				return err
+			}
+		}
+		_, err := fmt.Fprintf(out, "registered %s (paneless, project %q, model %s)\n", alias, h.Project(), *model)
+		return err
 	}
 	if alias == "" {
 		return fmt.Errorf("cannot determine alias: no tmux session and no usable working directory; pass one explicitly or set $MUSTER_ALIAS")
@@ -114,7 +139,15 @@ func cmdDeregister(args []string, out io.Writer) error {
 	default:
 		alias = tmuxenv.CaptureEnv().SessionName
 		if alias == "" {
-			alias = harnessenv.FromEnv().Alias()
+			// Paneless: this session's ALLOCATED alias may carry a suffix
+			// (dotfiles-2), so resolve through the roster by session UUID
+			// first; the raw cwd basename is only a last resort.
+			h := harnessenv.FromEnv()
+			if owned := panelessOwnedAliases(h.SessionID); len(owned) > 0 {
+				alias = owned[0]
+			} else {
+				alias = h.Alias()
+			}
 		}
 	}
 	if alias == "" {

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -18,18 +18,19 @@ import (
 // newRegisterFlagsWithVals declares register's flags and returns typed
 // access to their values — shared by cmdRegister (real parsing) and
 // newRegisterFlags (registry help/man rendering).
-func newRegisterFlagsWithVals() (fs *flag.FlagSet, role, model *string) {
+func newRegisterFlagsWithVals() (fs *flag.FlagSet, role, model, harness *string) {
 	fs = flag.NewFlagSet("register", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	role = fs.String("role", "", "this agent's role")
 	model = fs.String("model", "claude", "model backing this agent: claude or codex")
-	return fs, role, model
+	harness = fs.String("harness-session", "", "harness session UUID this registration belongs to — the pane-side launch handshake passes the UUID it then hands to `claude --session-id`, so the session's own hooks (which see no tmux) can find this row")
+	return fs, role, model, harness
 }
 
 // newRegisterFlags builds register's flag.FlagSet for registry-driven
 // help/man rendering.
 func newRegisterFlags() *flag.FlagSet {
-	fs, _, _ := newRegisterFlagsWithVals()
+	fs, _, _, _ := newRegisterFlagsWithVals()
 	return fs
 }
 
@@ -41,7 +42,7 @@ func newRegisterFlags() *flag.FlagSet {
 // harness session UUID, so hook ownership and sibling grouping still have an
 // identity tuple, ("", uuid), to key on.
 func cmdRegister(args []string, out io.Writer) error {
-	fs, role, model := newRegisterFlagsWithVals()
+	fs, role, model, harness := newRegisterFlagsWithVals()
 	// register has no boolean flags: --role and --model both take values, so
 	// pass an empty bool-flags set (an implicit default would wrongly reuse
 	// send's --role, which IS boolean there).
@@ -77,18 +78,20 @@ func cmdRegister(args []string, out io.Writer) error {
 			_, err := callData("register_agent", args)
 			return err
 		}
-		if owned := panelessOwnedAliases(h.SessionID); len(owned) > 0 {
-			alias = owned[0] // this session already has an identity: refresh it
-			if err := regFn(alias, false); err != nil {
-				return err
-			}
-		} else {
-			var err error
-			if alias, err = allocPanelessAlias(h.Alias(), h.SessionID, regFn); err != nil {
-				return err
-			}
+		if owned := harnessOwnedRows(h.SessionID); len(owned) > 0 {
+			// This session already has an identity (a handshake tmux row or a
+			// prior paneless one): refresh/revive it with its stored shape
+			// intact rather than allocating another.
+			alias = owned[0].Alias
+			reviveRow(owned[0], *model)
+			_, err := fmt.Fprintf(out, "registered %s (existing identity, project %q, model %s)\n", alias, owned[0].Project, *model)
+			return err
 		}
-		_, err := fmt.Fprintf(out, "registered %s (paneless, project %q, model %s)\n", alias, h.Project(), *model)
+		var err error
+		if alias, err = allocPanelessAlias(h.Alias(), h.SessionID, regFn); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(out, "registered %s (paneless, project %q, model %s)\n", alias, h.Project(), *model)
 		return err
 	}
 	if alias == "" {
@@ -106,11 +109,19 @@ func cmdRegister(args []string, out io.Writer) error {
 		sessionID = h.SessionID
 		project = h.Project()
 	}
+	// The harness link: --harness-session (the pane-side launch handshake,
+	// which mints the UUID before the session exists), else the ambient
+	// harness UUID when this process runs inside a session.
+	harnessID := *harness
+	if harnessID == "" {
+		harnessID = h.SessionID
+	}
 	if _, err := callData("register_agent", map[string]any{
 		"alias": alias, "role": *role, "model_type": *model,
 		"session_name": sessionName, "session_id": sessionID,
-		"session_created": created,
-		"socket_path":     socketPath, "pane_id": paneID,
+		"session_created":    created,
+		"harness_session_id": harnessID,
+		"socket_path":        socketPath, "pane_id": paneID,
 		"project": project, "label": c.Label, "label_manual": c.LabelManual,
 	}); err != nil {
 		return err
@@ -139,12 +150,12 @@ func cmdDeregister(args []string, out io.Writer) error {
 	default:
 		alias = tmuxenv.CaptureEnv().SessionName
 		if alias == "" {
-			// Paneless: this session's ALLOCATED alias may carry a suffix
-			// (dotfiles-2), so resolve through the roster by session UUID
-			// first; the raw cwd basename is only a last resort.
+			// No tmux: this session's alias may be handshake- or
+			// suffix-allocated, so resolve through the roster by harness
+			// session UUID first; the raw cwd basename is only a last resort.
 			h := harnessenv.FromEnv()
-			if owned := panelessOwnedAliases(h.SessionID); len(owned) > 0 {
-				alias = owned[0]
+			if owned := harnessOwnedRows(h.SessionID); len(owned) > 0 {
+				alias = owned[0].Alias
 			} else {
 				alias = h.Alias()
 			}

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/schuettc/muster/internal/clock"
+	"github.com/schuettc/muster/internal/harnessenv"
 	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
@@ -32,8 +33,13 @@ func newRegisterFlags() *flag.FlagSet {
 	return fs
 }
 
-// cmdRegister registers the current tmux session as an agent. Alias precedence:
-// explicit positional arg → $MUSTER_ALIAS → tmux session name.
+// cmdRegister registers the current session as an agent. Alias precedence:
+// explicit positional arg → $MUSTER_ALIAS → tmux session name → the working
+// directory's basename (paneless fallback). A session with no tmux pane in
+// its process environment (harness daemon-hosted sessions — see harnessenv)
+// registers PANELESS: socket_path/pane_id empty, session_id carrying the
+// harness session UUID, so hook ownership and sibling grouping still have an
+// identity tuple, ("", uuid), to key on.
 func cmdRegister(args []string, out io.Writer) error {
 	fs, role, model := newRegisterFlagsWithVals()
 	// register has no boolean flags: --role and --model both take values, so
@@ -47,33 +53,54 @@ func cmdRegister(args []string, out io.Writer) error {
 		return err
 	}
 	c := tmuxenv.CaptureEnv()
+	h := harnessenv.FromEnv()
+	paneless := c.SocketPath == "" || c.PaneID == ""
 	alias := ""
 	switch {
 	case len(rest) > 0:
 		alias = rest[0]
 	case os.Getenv("MUSTER_ALIAS") != "":
 		alias = os.Getenv("MUSTER_ALIAS")
-	default:
+	case c.SessionName != "":
 		alias = c.SessionName
+	default:
+		alias = h.Alias()
 	}
 	if alias == "" {
-		return fmt.Errorf("cannot determine alias: not in a named tmux session; pass one explicitly or set $MUSTER_ALIAS")
+		return fmt.Errorf("cannot determine alias: no tmux session and no usable working directory; pass one explicitly or set $MUSTER_ALIAS")
+	}
+	socketPath, paneID := c.SocketPath, c.PaneID
+	sessionID, sessionName, created := c.SessionID, c.SessionName, c.SessionCreated
+	project := c.Project
+	if paneless {
+		// A half-captured tmux identity (socket without a pane — run-shell
+		// contexts) must not be stored: a tuple mixing a real socket with a
+		// non-tmux session ID would read as a dead session to every liveness
+		// check. Store the clean paneless shape instead.
+		socketPath, paneID, sessionName, created = "", "", "", 0
+		sessionID = h.SessionID
+		project = h.Project()
 	}
 	if _, err := callData("register_agent", map[string]any{
 		"alias": alias, "role": *role, "model_type": *model,
-		"session_name": c.SessionName, "session_id": c.SessionID,
-		"session_created": c.SessionCreated,
-		"socket_path":     c.SocketPath, "pane_id": c.PaneID,
-		"project": c.Project, "label": c.Label, "label_manual": c.LabelManual,
+		"session_name": sessionName, "session_id": sessionID,
+		"session_created": created,
+		"socket_path":     socketPath, "pane_id": paneID,
+		"project": project, "label": c.Label, "label_manual": c.LabelManual,
 	}); err != nil {
 		return err
 	}
-	_, err := fmt.Fprintf(out, "registered %s (project %q, model %s)\n", alias, c.Project, *model)
+	shape := ""
+	if paneless {
+		shape = "paneless, "
+	}
+	_, err := fmt.Fprintf(out, "registered %s (%sproject %q, model %s)\n", alias, shape, project, *model)
 	return err
 }
 
 // cmdDeregister removes an agent's registration. Alias precedence mirrors
-// register: explicit arg → $MUSTER_ALIAS → tmux session name.
+// register: explicit arg → $MUSTER_ALIAS → tmux session name → working
+// directory basename (paneless fallback).
 func cmdDeregister(args []string, out io.Writer) error {
 	if helpRequested(args) {
 		return HelpFor("deregister", out)
@@ -86,6 +113,9 @@ func cmdDeregister(args []string, out io.Writer) error {
 		alias = os.Getenv("MUSTER_ALIAS")
 	default:
 		alias = tmuxenv.CaptureEnv().SessionName
+		if alias == "" {
+			alias = harnessenv.FromEnv().Alias()
+		}
 	}
 	if alias == "" {
 		return fmt.Errorf("cannot determine alias to deregister")
@@ -104,7 +134,7 @@ func newGCFlagsWithVals() (fs *flag.FlagSet, eventsKeep *time.Duration, purgeAge
 	fs = flag.NewFlagSet("gc", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	eventsKeep = fs.Duration("events-keep", 720*time.Hour, "prune journal events older than this")
-	purgeAgents = fs.Bool("purge-agents", false, "hard-delete departed and tmux-dead agent rows instead of tombstoning them (irreversible: identity, project, label, and read-state are all gone)")
+	purgeAgents = fs.Bool("purge-agents", false, "hard-delete departed and tmux-dead agent rows instead of tombstoning them (irreversible: identity, project, label, and read-state are all gone; paneless rows — no tmux identity — are only reaped once departed)")
 	return fs, eventsKeep, purgeAgents
 }
 
@@ -120,7 +150,11 @@ func newGCFlags() *flag.FlagSet {
 // as history), then prunes journal events older than --events-keep (default
 // 720h = 30 days). --purge-agents instead hard-deletes every departed OR
 // currently-dead agent row (the pre-tombstone behavior, now explicit and
-// irreversible). The agent phase and the event-prune phase are independent: a
+// irreversible). Paneless rows (empty socket_path — harness daemon-hosted
+// sessions, see harnessenv) are exempt from BOTH liveness judgments: they
+// have no tmux session to be dead in, so gc would otherwise reap every live
+// one; their lifecycle belongs to the SessionEnd hook and explicit
+// deregister. The agent phase and the event-prune phase are independent: a
 // prune error is reported on the same writer but never masks the agent-phase
 // summary already printed.
 func cmdGC(args []string, out io.Writer) error {
@@ -147,8 +181,11 @@ func cmdGC(args []string, out io.Writer) error {
 	if *purgeAgents {
 		purged := 0
 		for _, a := range agents {
-			if !a.Departed && tmuxenv.IsSessionAlive(a.SocketPath, a.SessionID, a.SessionCreated) {
-				continue // still live and never departed: nothing to purge
+			// A paneless row (no socket) has no tmux session to be dead in, so
+			// liveness cannot condemn it — only its own departure (the
+			// SessionEnd hook, or an explicit deregister) makes it purgeable.
+			if !a.Departed && (a.SocketPath == "" || tmuxenv.IsSessionAlive(a.SocketPath, a.SessionID, a.SessionCreated)) {
+				continue // still live (or liveness-unknowable) and never departed: nothing to purge
 			}
 			if _, err := callData("purge_agent", map[string]any{"alias": a.Alias}); err != nil {
 				return err
@@ -164,6 +201,9 @@ func cmdGC(args []string, out io.Writer) error {
 	} else {
 		tombstoned := 0
 		for _, a := range agents {
+			if a.SocketPath == "" {
+				continue // paneless: no tmux session to judge dead — lifecycle belongs to the SessionEnd hook
+			}
 			if a.Departed || tmuxenv.IsSessionAlive(a.SocketPath, a.SessionID, a.SessionCreated) {
 				continue // already history, or still alive: nothing to do
 			}

--- a/internal/humancli/paneless.go
+++ b/internal/humancli/paneless.go
@@ -1,0 +1,111 @@
+package humancli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/schuettc/muster/internal/harnessenv"
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// panelessAliasCap bounds the suffix probe. Fifty sessions in one directory
+// mirrors proj's own session-numbering cap; hitting it means something is
+// leaking registrations, and failing loudly beats alias -51.
+const panelessAliasCap = 50
+
+// panelessOwnedAliases returns the aliases already registered on this
+// session's paneless tuple ("", uuid) — including tombstones, so a resumed
+// session revives its own departed identity rather than allocating a fresh
+// suffix. Empty on any daemon failure.
+func panelessOwnedAliases(sessionID string) []string {
+	if sessionID == "" {
+		return nil
+	}
+	raw, err := callData("session_aliases", map[string]any{"socket_path": "", "session_id": sessionID})
+	if err != nil {
+		return nil
+	}
+	var res struct {
+		Aliases []string `json:"aliases"`
+	}
+	if json.Unmarshal(raw, &res) != nil {
+		return nil
+	}
+	return res.Aliases
+}
+
+// allocPanelessAlias claims a UNIQUE alias for a paneless session: base, then
+// base-2, base-3, … (proj's session-numbering vocabulary). Every session in a
+// directory derives the same base — the tmux model got uniqueness for free
+// from numbered session names, so the paneless model must allocate it.
+// Per-candidate rules:
+//
+//   - my own row (same paneless tuple), departed or not → reuse it (resume)
+//   - a tombstone → revive-takeover (a departed row never owns a name)
+//   - a tmux row whose pane is provably dead → takeover (the existing
+//     cross-session-reclaim philosophy; liveness IS checkable there)
+//   - a live tmux owner, or another session's paneless row → next suffix.
+//     A paneless row's liveness is unknowable, so it is presumed live and
+//     never stolen — that presumption is exactly what keeps two sessions in
+//     one directory from silently trading an identity (and its inbox) back
+//     and forth. A crashed session's stale row squats its name until
+//     `muster deregister <alias>` or `gc --purge-agents`; suffixing past it
+//     costs one integer.
+//
+// Free candidates are claimed with if_absent=true — the daemon's CAS — so two
+// sessions launching in one directory at the same instant cannot both win a
+// name; the loser just moves to the next suffix. register is the caller's
+// actual registration op (hook vs CLI carry different flags); ifAbsent is
+// forwarded to it. Returns the claimed alias.
+func allocPanelessAlias(base, sessionID string, register func(alias string, ifAbsent bool) error) (string, error) {
+	if base == "" {
+		return "", fmt.Errorf("no alias base to allocate from")
+	}
+	for i := 1; i <= panelessAliasCap; i++ {
+		cand := base
+		if i > 1 {
+			cand = fmt.Sprintf("%s-%d", base, i)
+		}
+		ag, found := hookGetAgent(cand)
+		switch {
+		case !found:
+			if err := register(cand, true); err != nil {
+				continue // lost the CAS race (or transient failure): next suffix
+			}
+			return cand, nil
+		case ag.SocketPath == "" && ag.SessionID != "" && ag.SessionID == sessionID:
+			// Mine already (resume/refresh) — plain upsert, tuple unchanged.
+			if err := register(cand, false); err != nil {
+				return "", err
+			}
+			return cand, nil
+		case ag.Departed:
+			if err := register(cand, false); err != nil {
+				return "", err
+			}
+			return cand, nil
+		case ag.SocketPath != "" && ag.PaneID != "" && !tmuxenv.IsPaneAlive(ag.SocketPath, ag.PaneID):
+			// A tmux row whose pane is provably gone: reclaim.
+			if err := register(cand, false); err != nil {
+				return "", err
+			}
+			return cand, nil
+		default:
+			continue // live tmux owner, or another session's paneless row
+		}
+	}
+	return "", fmt.Errorf("no free paneless alias within %s..%s-%d", base, base, panelessAliasCap)
+}
+
+// registerPanelessArgs builds the register_agent payload for a paneless
+// registration — the one canonical shape: empty socket/pane, the harness
+// session UUID as session_id, project from the enclosing checkout.
+func registerPanelessArgs(alias, role, model string, h harnessenv.Capture, ifAbsent bool) map[string]any {
+	return map[string]any{
+		"alias": alias, "role": role, "model_type": model,
+		"session_name": "", "session_id": h.SessionID, "session_created": 0,
+		"socket_path": "", "pane_id": "",
+		"project": h.Project(), "label": "", "label_manual": false,
+		"if_absent": ifAbsent,
+	}
+}

--- a/internal/humancli/paneless.go
+++ b/internal/humancli/paneless.go
@@ -13,27 +13,6 @@ import (
 // leaking registrations, and failing loudly beats alias -51.
 const panelessAliasCap = 50
 
-// panelessOwnedAliases returns the aliases already registered on this
-// session's paneless tuple ("", uuid) — including tombstones, so a resumed
-// session revives its own departed identity rather than allocating a fresh
-// suffix. Empty on any daemon failure.
-func panelessOwnedAliases(sessionID string) []string {
-	if sessionID == "" {
-		return nil
-	}
-	raw, err := callData("session_aliases", map[string]any{"socket_path": "", "session_id": sessionID})
-	if err != nil {
-		return nil
-	}
-	var res struct {
-		Aliases []string `json:"aliases"`
-	}
-	if json.Unmarshal(raw, &res) != nil {
-		return nil
-	}
-	return res.Aliases
-}
-
 // allocPanelessAlias claims a UNIQUE alias for a paneless session: base, then
 // base-2, base-3, … (proj's session-numbering vocabulary). Every session in a
 // directory derives the same base — the tmux model got uniqueness for free
@@ -99,13 +78,58 @@ func allocPanelessAlias(base, sessionID string, register func(alias string, ifAb
 
 // registerPanelessArgs builds the register_agent payload for a paneless
 // registration — the one canonical shape: empty socket/pane, the harness
-// session UUID as session_id, project from the enclosing checkout.
+// session UUID as both session_id (the tuple) and harness_session_id (the
+// uniform lookup key shared with handshake-launched tmux rows), project from
+// the enclosing checkout.
 func registerPanelessArgs(alias, role, model string, h harnessenv.Capture, ifAbsent bool) map[string]any {
 	return map[string]any{
 		"alias": alias, "role": role, "model_type": model,
 		"session_name": "", "session_id": h.SessionID, "session_created": 0,
-		"socket_path": "", "pane_id": "",
+		"harness_session_id": h.SessionID,
+		"socket_path":        "", "pane_id": "",
 		"project": h.Project(), "label": "", "label_manual": false,
 		"if_absent": ifAbsent,
 	}
+}
+
+// harnessOwnedRows returns every roster row belonging to harness session
+// uuid — handshake-registered tmux rows (harness_session_id) and paneless
+// rows (tuple ("", uuid)) alike, tombstones included so resume can revive.
+// Empty on any daemon failure.
+func harnessOwnedRows(uuid string) []agentRow {
+	if uuid == "" {
+		return nil
+	}
+	raw, err := callData("list_agents", nil)
+	if err != nil {
+		return nil
+	}
+	var rows []agentRow
+	if json.Unmarshal(raw, &rows) != nil {
+		return nil
+	}
+	var mine []agentRow
+	for _, ag := range rows {
+		if ag.HarnessSessionID == uuid || (ag.SocketPath == "" && ag.SessionID == uuid) {
+			mine = append(mine, ag)
+		}
+	}
+	return mine
+}
+
+// reviveRow re-registers a tombstoned row echoing back its own stored
+// identity — tuple, harness link, project, label — so revival never rewrites
+// what the row already knows about itself.
+func reviveRow(ag agentRow, model string) {
+	if model == "" {
+		model = ag.ModelType
+	}
+	_, _ = callData("register_agent", map[string]any{
+		"alias": ag.Alias, "role": ag.Role, "model_type": model,
+		"session_name": ag.SessionName, "session_id": ag.SessionID,
+		"session_created":    ag.SessionCreated,
+		"harness_session_id": ag.HarnessSessionID,
+		"socket_path":        ag.SocketPath, "pane_id": ag.PaneID,
+		"project": ag.Project, "label": ag.Label, "label_manual": ag.LabelManual,
+	})
 }

--- a/internal/humancli/paneless_test.go
+++ b/internal/humancli/paneless_test.go
@@ -1,0 +1,226 @@
+package humancli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// panelessEnv pins the process into a paneless shape: no tmux, a known
+// harness session UUID, and a working directory whose basename is the
+// expected fallback alias. CLAUDE_CODE_SESSION_ID must be pinned in every
+// paneless test — on a dev machine `go test` itself runs inside a Claude
+// session whose UUID would otherwise leak in.
+func panelessEnv(t *testing.T, uuid, dirName string) string {
+	t.Helper()
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("MUSTER_ALIAS", "")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", uuid)
+	dir := filepath.Join(t.TempDir(), dirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	return dir
+}
+
+func TestRegisterPanelessFallsBackToCwdAlias(t *testing.T) {
+	startTestDaemon(t)
+	panelessEnv(t, "hs-reg-1", "wt-alpha")
+
+	var buf bytes.Buffer
+	if err := cmdRegister(nil, &buf); err != nil {
+		t.Fatalf("paneless register must succeed on the cwd fallback, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "registered wt-alpha (paneless") {
+		t.Fatalf("output must name the alias and the paneless shape, got %q", buf.String())
+	}
+	agents := listAgentsForTest(t, "")
+	if len(agents) != 1 {
+		t.Fatalf("expected one registration, got %+v", agents)
+	}
+	a := agents[0]
+	if a.Alias != "wt-alpha" || a.SocketPath != "" || a.PaneID != "" || a.SessionID != "hs-reg-1" {
+		t.Fatalf("paneless row shape wrong: %+v", a)
+	}
+}
+
+func TestRegisterPanelessWithoutAnyIdentityStillErrors(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("MUSTER_ALIAS", "")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Chdir("/") // basename "/" derives no alias
+	var buf bytes.Buffer
+	err := cmdRegister(nil, &buf)
+	if err == nil || !strings.Contains(err.Error(), "cannot determine alias") {
+		t.Fatalf("expected the no-identity error, got %v", err)
+	}
+}
+
+func TestHookSessionStartPanelessRegistersFromPayload(t *testing.T) {
+	startTestDaemon(t)
+	panelessEnv(t, "", "env-dir") // env UUID empty: the payload must carry identity
+
+	payload := `{"session_id":"hs-hook-1","cwd":"/tmp/somewhere/payload-dir"}`
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart", "codex"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatalf("SessionStart: %v", err)
+	}
+	agents := listAgentsForTest(t, "")
+	if len(agents) != 1 {
+		t.Fatalf("expected one paneless registration, got %+v", agents)
+	}
+	a := agents[0]
+	if a.Alias != "payload-dir" || a.SessionID != "hs-hook-1" || a.SocketPath != "" || a.ModelType != "codex" {
+		t.Fatalf("paneless hook registration shape wrong: %+v", a)
+	}
+}
+
+func TestHookSessionStartPanelessDefersToLiveTmuxOwner(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "owner-dir", "socket_path": "/tmp/sockOwn", "session_id": "$1", "pane_id": "%1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	panelessEnv(t, "hs-thief", "owner-dir")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{"#{pane_id}": "%1"}) // the tmux owner's pane is alive
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"session_id":"hs-thief","cwd":"`+"/x/owner-dir"+`"}`), &buf); err != nil {
+		t.Fatalf("SessionStart: %v", err)
+	}
+	ag, found := hookGetAgent("owner-dir")
+	if !found || ag.SessionID != "$1" || ag.SocketPath != "/tmp/sockOwn" {
+		t.Fatalf("a live tmux owner must keep the alias, got %+v found=%v", ag, found)
+	}
+}
+
+func TestHookSessionEndPanelessReapsOnlyOwnAliases(t *testing.T) {
+	startTestDaemon(t)
+	reg := func(alias, socket, session string) {
+		t.Helper()
+		if _, err := callData("register_agent", map[string]any{
+			"alias": alias, "socket_path": socket, "session_id": session,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reg("mine-a", "", "hs-end-1")
+	reg("mine-b", "", "hs-end-1")
+	reg("other-paneless", "", "hs-other")
+	reg("tmux-agent", "/s", "hs-end-1") // a tmux row whose session_id coincides: not paneless, not ours
+
+	panelessEnv(t, "", "end-dir")
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionEnd"}, strings.NewReader(`{"session_id":"hs-end-1"}`), &buf); err != nil {
+		t.Fatalf("SessionEnd: %v", err)
+	}
+	departed := map[string]bool{}
+	for _, a := range listAgentsForTest(t, "") {
+		departed[a.Alias] = a.Departed
+	}
+	if !departed["mine-a"] || !departed["mine-b"] {
+		t.Fatalf("both of the dying session's aliases must be tombstoned, got %+v", departed)
+	}
+	if departed["other-paneless"] || departed["tmux-agent"] {
+		t.Fatalf("another session's rows must survive, got %+v", departed)
+	}
+}
+
+func TestHookStopPanelessBlocksOnUnread(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "wt-mail", "socket_path": "", "session_id": "hs-stop-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/p", "session_id": "$2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	panelessEnv(t, "", "stop-dir")
+
+	// No mail yet: the hook must stay silent.
+	var quiet bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{"session_id":"hs-stop-1"}`), &quiet); err != nil {
+		t.Fatal(err)
+	}
+	if quiet.Len() != 0 {
+		t.Fatalf("expected silence with no unread mail, got %q", quiet.String())
+	}
+
+	if _, err := callData("send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "wt-mail", "subject": "s", "body": "b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{"session_id":"hs-stop-1"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"decision":"block"`) || !strings.Contains(buf.String(), "alias 'wt-mail'") {
+		t.Fatalf("expected a block decision addressing wt-mail, got %q", buf.String())
+	}
+
+	// An unregistered paneless session (unknown UUID) must stay silent.
+	var other bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{"session_id":"hs-unknown"}`), &other); err != nil {
+		t.Fatal(err)
+	}
+	if other.Len() != 0 {
+		t.Fatalf("an unregistered session must print nothing, got %q", other.String())
+	}
+}
+
+func TestGCSparesLivePanelessRows(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "paneless-live", "socket_path": "", "session_id": "hs-gc-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(_ ...string) (string, error) { return "", fmt.Errorf("dead") } // every tmux probe answers dead
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdGC(nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "gc: tombstoned 0 agent(s)") {
+		t.Fatalf("gc must not judge a paneless row by tmux liveness, got %q", buf.String())
+	}
+
+	buf.Reset()
+	if err := cmdGC([]string{"--purge-agents"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "gc: purged 0 agent(s)") {
+		t.Fatalf("--purge-agents must spare a live paneless row, got %q", buf.String())
+	}
+
+	// Once departed, the row is purgeable exactly like any other tombstone.
+	if err := cmdDeregister([]string{"paneless-live"}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	if err := cmdGC([]string{"--purge-agents"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "gc: purged 1 agent(s)") {
+		t.Fatalf("a departed paneless row must purge, got %q", buf.String())
+	}
+}

--- a/internal/humancli/paneless_test.go
+++ b/internal/humancli/paneless_test.go
@@ -281,3 +281,73 @@ func TestGCSparesLivePanelessRows(t *testing.T) {
 		t.Fatalf("a departed paneless row must purge, got %q", buf.String())
 	}
 }
+
+// TestLaunchHandshakeLifecycle drives the pane-side launch handshake end to
+// end: the pane registers the tmux session name with --harness-session (the
+// UUID it will hand to `claude --session-id`), then the SESSION's hooks —
+// which see no tmux — resolve that row by UUID: SessionStart leaves the live
+// row alone (no cwd-derived duplicate), Stop drains mail via the row's tmux
+// tuple with the label leading the reason, SessionEnd tombstones it.
+func TestLaunchHandshakeLifecycle(t *testing.T) {
+	startTestDaemon(t)
+
+	// Pane side: tmux env present, handshake registration.
+	t.Setenv("TMUX", "/tmp/sockHS,1,0")
+	t.Setenv("TMUX_PANE", "%3")
+	t.Setenv("MUSTER_ALIAS", "")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$7", "#{session_name}": "bh-workspace-4", "#{session_created}": "1784000123",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	var buf bytes.Buffer
+	if err := cmdRegister([]string{"--harness-session", "hs-shake"}, &buf); err != nil {
+		t.Fatalf("handshake register: %v", err)
+	}
+	ag, found := hookGetAgent("bh-workspace-4")
+	if !found {
+		t.Fatal("handshake row missing")
+	}
+
+	// Session side: no tmux at all.
+	panelessEnv(t, "", "some-worktree-dir")
+	payload := `{"session_id":"hs-shake","cwd":"/x/some-worktree-dir"}`
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, found := hookGetAgent("some-worktree-dir"); found {
+		t.Fatal("SessionStart must not allocate a cwd alias when the handshake row exists")
+	}
+
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/p", "session_id": "$9",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "bh-workspace-4", "subject": "s", "body": "b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("set_label", map[string]any{
+		"socket_path": "/tmp/sockHS", "session_id": "$7", "label": "debug alarms", "label_manual": true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var stop bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{"session_id":"hs-shake"}`), &stop); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stop.String(), "alias 'bh-workspace-4'") || !strings.Contains(stop.String(), "You are 'debug alarms'") {
+		t.Fatalf("Stop must address the handshake alias and lead with its label, got %q", stop.String())
+	}
+
+	if err := cmdHook([]string{"SessionEnd"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+	ag, found = hookGetAgent("bh-workspace-4")
+	if !found || !ag.Departed {
+		t.Fatalf("SessionEnd must tombstone the handshake row, got %+v found=%v", ag, found)
+	}
+}

--- a/internal/humancli/paneless_test.go
+++ b/internal/humancli/paneless_test.go
@@ -84,7 +84,7 @@ func TestHookSessionStartPanelessRegistersFromPayload(t *testing.T) {
 	}
 }
 
-func TestHookSessionStartPanelessDefersToLiveTmuxOwner(t *testing.T) {
+func TestHookSessionStartPanelessSuffixesPastLiveTmuxOwner(t *testing.T) {
 	startTestDaemon(t)
 	if _, err := callData("register_agent", map[string]any{
 		"alias": "owner-dir", "socket_path": "/tmp/sockOwn", "session_id": "$1", "pane_id": "%1",
@@ -103,6 +103,63 @@ func TestHookSessionStartPanelessDefersToLiveTmuxOwner(t *testing.T) {
 	ag, found := hookGetAgent("owner-dir")
 	if !found || ag.SessionID != "$1" || ag.SocketPath != "/tmp/sockOwn" {
 		t.Fatalf("a live tmux owner must keep the alias, got %+v found=%v", ag, found)
+	}
+	suf, found := hookGetAgent("owner-dir-2")
+	if !found || suf.SessionID != "hs-thief" || suf.SocketPath != "" {
+		t.Fatalf("the paneless session must allocate the next suffix, got %+v found=%v", suf, found)
+	}
+}
+
+func TestHookSessionStartPanelessAllocatesUniqueAliases(t *testing.T) {
+	startTestDaemon(t)
+	panelessEnv(t, "", "shared-dir")
+	start := func(uuid string) {
+		t.Helper()
+		var buf bytes.Buffer
+		if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"session_id":"`+uuid+`","cwd":"/x/shared-dir"}`), &buf); err != nil {
+			t.Fatalf("SessionStart(%s): %v", uuid, err)
+		}
+	}
+	start("hs-one")
+	start("hs-two")   // same directory, different session: must NOT steal
+	start("hs-three") // third session: next suffix again
+	start("hs-two")   // resume: must refresh its own alias, not allocate a fourth
+
+	want := map[string]string{"shared-dir": "hs-one", "shared-dir-2": "hs-two", "shared-dir-3": "hs-three"}
+	for alias, uuid := range want {
+		ag, found := hookGetAgent(alias)
+		if !found || ag.SessionID != uuid || ag.SocketPath != "" || ag.Departed {
+			t.Fatalf("%s: want live paneless row for %s, got %+v found=%v", alias, uuid, ag, found)
+		}
+	}
+	if _, found := hookGetAgent("shared-dir-4"); found {
+		t.Fatal("a resumed session must reuse its alias, not allocate shared-dir-4")
+	}
+}
+
+func TestHookSessionStartPanelessRevivesOwnTombstoneOnResume(t *testing.T) {
+	startTestDaemon(t)
+	panelessEnv(t, "", "revive-dir")
+	payload := `{"session_id":"hs-rev","cwd":"/x/revive-dir"}`
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdHook([]string{"SessionEnd"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if ag, _ := hookGetAgent("revive-dir"); !ag.Departed {
+		t.Fatalf("setup: expected tombstone after SessionEnd, got %+v", ag)
+	}
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+	ag, found := hookGetAgent("revive-dir")
+	if !found || ag.Departed || ag.SessionID != "hs-rev" {
+		t.Fatalf("resume must revive the session's own tombstone, got %+v found=%v", ag, found)
+	}
+	if _, found := hookGetAgent("revive-dir-2"); found {
+		t.Fatal("revival must not allocate a suffix")
 	}
 }
 

--- a/internal/mcpserver/tools_registry.go
+++ b/internal/mcpserver/tools_registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/schuettc/muster/internal/harnessenv"
 	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
@@ -47,16 +48,30 @@ func registerAgentHandler(_ context.Context, _ *mcp.CallToolRequest, in Register
 	if sessionName == "" {
 		sessionName = c.SessionName
 	}
+	socketPath, paneID := c.SocketPath, c.PaneID
+	sessionID, project := c.SessionID, c.Project
+	if c.SocketPath == "" || c.PaneID == "" {
+		// Paneless session (harness daemon-hosted — the MCP server inherits
+		// the session's env, which has no tmux): register under the paneless
+		// tuple ("", harness session UUID) so the SessionEnd hook can reap
+		// this alias and gc knows not to judge it by tmux liveness. A
+		// half-captured socket (run-shell contexts) is dropped too — a tuple
+		// mixing a real socket with a non-tmux session ID would read as dead
+		// to every liveness check.
+		h := harnessenv.FromEnv()
+		socketPath, paneID = "", ""
+		sessionID, project = h.SessionID, h.Project()
+	}
 	_, err := callDaemon("register_agent", map[string]any{
 		"alias":           in.Alias,
 		"role":            in.Role,
 		"model_type":      in.ModelType,
 		"session_name":    sessionName,
-		"session_id":      c.SessionID,
+		"session_id":      sessionID,
 		"session_created": c.SessionCreated,
-		"socket_path":     c.SocketPath,
-		"pane_id":         c.PaneID,
-		"project":         c.Project,
+		"socket_path":     socketPath,
+		"pane_id":         paneID,
+		"project":         project,
 		"label":           c.Label,
 		"label_manual":    c.LabelManual,
 	})

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -229,14 +229,17 @@ func (s *Store) MarkRead(alias string) error {
 // session — so a session's own writes under either alias never make its own
 // threads unread, and a broadcast concerning two sibling aliases counts once,
 // never twice (no summing of per-alias counts). action is the subset whose
-// effective intent (effectiveIntent) is action-requested. An empty
-// socketPath or sessionID never groups: it matches no agents, so both
-// results are 0 (per-alias identity is UnreadCount's job for such agents,
-// e.g. one registered without a live tmux pane).
+// effective intent (effectiveIntent) is action-requested. An empty sessionID
+// never groups: it matches no agents, so both results are 0 (per-alias
+// identity is UnreadCount's job for such agents). socketPath MAY be empty —
+// ("", harness session UUID) is the paneless tuple (see internal/harnessenv),
+// a real session identity whose sibling aliases group exactly like a tmux
+// session's; the sessionID guard alone keeps pre-harnessenv no-tmux rows
+// (both fields empty) from ever grouping with each other.
 func (s *Store) SessionUnread(socketPath, sessionID string) (total, action int, err error) {
 	err = s.db.QueryRow(`
 WITH sess AS (SELECT alias, last_read_entry_id FROM agents
-              WHERE socket_path = ?1 AND session_id = ?2 AND ?1 != '' AND ?2 != '')
+              WHERE socket_path = ?1 AND session_id = ?2 AND ?2 != '')
 SELECT
   COUNT(DISTINCT threads.id),
   COUNT(DISTINCT CASE WHEN `+effectiveIntent+` = 'action-requested' THEN threads.id END)

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -16,8 +16,8 @@ import (
 func (s *Store) RegisterAgent(a Agent) error {
 	now := clock.NowMillis()
 	_, err := s.db.Exec(`
-INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, project, label, label_manual, departed, registered_at, last_seen)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, departed, registered_at, last_seen)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
 ON CONFLICT(alias) DO UPDATE SET
     role=excluded.role,
     model_type=excluded.model_type,
@@ -26,13 +26,14 @@ ON CONFLICT(alias) DO UPDATE SET
     session_name=excluded.session_name,
     session_id=excluded.session_id,
     session_created=excluded.session_created,
+    harness_session_id=excluded.harness_session_id,
     project=excluded.project,
     label=excluded.label,
     label_manual=excluded.label_manual,
     departed=0,
     last_seen=excluded.last_seen`,
 		a.Alias, a.Role, a.ModelType, a.SocketPath, a.PaneID, a.SessionName, a.SessionID, a.SessionCreated,
-		a.Project, a.Label, a.LabelManual, now, now)
+		a.HarnessSessionID, a.Project, a.Label, a.LabelManual, now, now)
 	return err
 }
 
@@ -40,7 +41,7 @@ ON CONFLICT(alias) DO UPDATE SET
 // agents included: their rows are history, not gone (see DepartAgent).
 func (s *Store) ListAgents() ([]Agent, error) {
 	rows, err := s.db.Query(`
-SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed
+SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed
 FROM agents ORDER BY alias`)
 	if err != nil {
 		return nil, err
@@ -49,7 +50,7 @@ FROM agents ORDER BY alias`)
 	var out []Agent
 	for rows.Next() {
 		var a Agent
-		if err := rows.Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed); err != nil {
+		if err := rows.Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.HarnessSessionID, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed); err != nil {
 			return nil, err
 		}
 		out = append(out, a)
@@ -63,9 +64,9 @@ FROM agents ORDER BY alias`)
 func (s *Store) GetAgent(alias string) (Agent, bool, error) {
 	var a Agent
 	err := s.db.QueryRow(`
-SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed
+SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed
 FROM agents WHERE alias=?`, alias).
-		Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed)
+		Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.HarnessSessionID, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Agent{}, false, nil
 	}

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -27,12 +27,21 @@ type Agent struct {
 	// (registered outside tmux, or before this column existed) — liveness
 	// then falls back to bare session existence. See tmuxenv.IsSessionAlive
 	// and Store.DepartStaleSiblings.
-	SessionCreated int64  `json:"session_created"`
-	Project        string `json:"project"`
-	Label          string `json:"label"`
-	LabelManual    bool   `json:"label_manual"`
-	RegisteredAt   int64  `json:"registered_at"`
-	LastSeen       int64  `json:"last_seen"`
+	SessionCreated int64 `json:"session_created"`
+	// HarnessSessionID is the agent-harness session UUID (e.g. Claude Code's
+	// session id) when known — the deterministic link between a roster row
+	// and the harness session it belongs to. The pane-side launch handshake
+	// (`muster register <name> --harness-session <uuid>` before
+	// `claude --session-id <uuid>`) sets it on tmux-anchored rows so the
+	// session's own hooks — which run with no tmux in their environment on
+	// daemon-hosted harnesses — can still find their rows; paneless
+	// registrations carry it too. "" = unknown (pre-handshake rows).
+	HarnessSessionID string `json:"harness_session_id"`
+	Project          string `json:"project"`
+	Label            string `json:"label"`
+	LabelManual      bool   `json:"label_manual"`
+	RegisteredAt     int64  `json:"registered_at"`
+	LastSeen         int64  `json:"last_seen"`
 	// LastReadEntryID is the entry-ID read watermark (see MarkRead/UnreadCount
 	// in agents.go): the highest entries.id visible the last time this
 	// agent's inbox was read. Supersedes the wall-clock last_read_at for

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,6 +50,7 @@ func migrate(db *sql.DB) error {
 		`ALTER TABLE threads ADD COLUMN origin_project TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE agents ADD COLUMN departed INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE agents ADD COLUMN session_created INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE agents ADD COLUMN harness_session_id TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, ddl := range alters {
 		if _, err := db.Exec(ddl); err != nil && !strings.Contains(err.Error(), "duplicate column name") {


### PR DESCRIPTION
## Why

Claude Code now hosts sessions in daemon-forked processes (pre-warmed spares under `claude daemon`, parented to launchd) — even for a plain interactive `claude` launched from a tmux pane. `$TMUX`/`$TMUX_PANE` never reach the session, so every muster identity path failed:

- `muster register` → `cannot determine alias: not in a named tmux session`
- SessionStart hook silently couldn't auto-register
- Stop hook (self-resolving inbox) bailed on the missing `@muster_inbox` tmux badge
- `muster gc` read any empty-socket registration as a dead session and tombstoned it

## What

**`internal/harnessenv`** — the paneless counterpart to `tmuxenv`, the one canonical capture path for harness identity: `session_id`/`cwd` from the hook stdin payload, `$CLAUDE_CODE_SESSION_ID` + cwd in-process. Alias = cwd basename; project = enclosing git checkout's dir name (linked-worktree-aware, so all worktrees of a repo share a project).

A paneless registration stores the tuple **`("", harness session UUID)`** — sibling-alias grouping and hook ownership work exactly like a tmux tuple, with no schema change.

- **register/deregister**: alias precedence gains a cwd-basename fallback; a half-captured socket (run-shell contexts) is never mixed into the stored tuple
- **SessionStart hook**: auto-registers paneless; defers only to an alias whose registered tmux pane is provably alive (stale rows from crashed sessions are reclaimed, matching the existing cross-session-takeover philosophy)
- **SessionEnd hook**: tombstones every alias on the dying session's paneless tuple
- **Stop hook**: no tmux badge exists as the cheap firing gate, so it dials the daemon directly (`session_aliases` + `session_unread` on the paneless tuple) each Stop — two ops on a local unix socket
- **daemon/store**: `session_aliases`/`session_unread` accept an empty `socket_path`; `session_id` stays required so legacy no-tmux rows (both fields empty) never group
- **gc**: paneless rows exempt from tmux-liveness reaping (lifecycle = SessionEnd hook); `--purge-agents` takes them only once departed
- **`muster agents`**: LIVE renders `◌` for paneless rows — liveness is unknowable without a pane, and `✗` read as dead
- **MCP `register_agent`**: captures the same paneless identity, so tool-registered agents are hook-reapable too

Known limitation: `muster nudge` can't reach a paneless agent (no pane to type into) — mail waits in the inbox for the next Stop.

## Verification

- `just verify` green (gofmt, golangci-lint, `go test -race`, build matrix)
- New tests: harnessenv derivation (incl. linked worktrees), paneless register/hooks/Stop/gc in `internal/humancli/paneless_test.go`, paneless-tuple acceptance in the daemon op tests; hook tests now pin `CLAUDE_CODE_SESSION_ID` so a dev machine's own Claude session can't leak identity into no-identity scenarios
- Live smoke test from the daemon-hosted Claude session that hit the original bug: `muster register` → `registered dotfiles (paneless, project \"dotfiles\", model claude)` against the running daemon