### PR TITLE
feat(reply): fyi replies close threads without waking anyone — kill the ack-loop

### DIFF
--- a/.claude/skills/muster-coordination/SKILL.md
+++ b/.claude/skills/muster-coordination/SKILL.md
@@ -54,8 +54,9 @@ usual reason.
   path that types into a pane.
 - If **your** session has a self-resolving Stop hook, you'll be told at turn-end when
   you have unread muster mail. **When that happens: call `get_inbox`, read each new
-  thread with `get_thread`, handle the request, and `reply` — autonomously.** Don't
-  ask the human to relay; acting on your own is the entire point of the bus.
+  thread with `get_thread`, handle the request, and `reply` if the sender needs
+  something from you — autonomously.** Don't ask the human to relay; acting on your
+  own is the entire point of the bus.
 - If the muster MCP tools are unavailable (e.g. the stdio connection died
   mid-session), the CLI is the same loop from your shell: `muster inbox <alias>`,
   `muster thread <id>`, `muster reply <id> "…" --from <alias>`. Never treat a dead
@@ -65,4 +66,24 @@ usual reason.
 
 - Reply on the thread you were addressed on — keeps the exchange in one place.
 - Be concise: the bus carries pointers and short asks, not essays.
-- When you finish handling a request, `reply` so the sender knows it's done.
+- When you finish handling a request, `reply` so the sender knows it's done — and
+  make that closing reply `fyi=true` (CLI: `--fyi`) so it lands on the thread
+  without waking the sender.
+
+### The last word is free (hanging up)
+
+Ack-loops are the bus's failure mode: A closes with a long acknowledgment, B's
+badge lights, B wakes into "handle and reply", B acknowledges the
+acknowledgment, and neither side hangs up first. Measured on a live bus, 14% of
+all traffic was acks averaging 1KB each. The rules:
+
+- **Never reply just to acknowledge.** An ack, a thanks, a "received" — none of
+  these need a response. If the latest entry asks you for nothing, you are done
+  with the thread.
+- **"No response needed" is binding.** When a peer says it, believe them —
+  replying anyway is a defect, not politeness.
+- **Close with `fyi=true`.** A wrap-up or final status is welcome *content*, but
+  send it as an fyi reply: the entry lands on the thread, the peer sees it on
+  their next natural inbox check, and nobody is woken into one more goodbye.
+- **Fold the closing summary into your last substantive reply** instead of
+  sending a separate ceremony message after the work message.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -579,7 +579,14 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			return fail(err)
 		}
 		d.logEvent(store.Event{Kind: "reply", Agent: str(a, "from"), ThreadID: i64(a, "thread_id"), Detail: display.Sanitize(str(a, "body"), replyPreviewWidth)})
-		d.notifyForThread(i64(a, "thread_id"), str(a, "from"))
+		// An fyi reply is a closer: the entry lands on the thread and shows
+		// as unread on the recipients' next natural inbox check, but nobody's
+		// badge lights — no wake means no reflexive ack back, which is what
+		// breaks the ack-loop (each closing ack waking the peer into one more
+		// closing ack).
+		if !boolArg(a, "fyi") {
+			d.notifyForThread(i64(a, "thread_id"), str(a, "from"))
+		}
 		return ok(map[string]any{"entry_id": id})
 	case "get_inbox":
 		alias := str(a, "alias")

--- a/internal/daemon/fyi_reply_test.go
+++ b/internal/daemon/fyi_reply_test.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"testing"
+)
+
+// An fyi reply appends its entry like any reply but must not push a badge to
+// anyone: no Notify calls beyond those already caused by earlier activity.
+func TestFYIReplySuppressesNotify(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "backend", "role": "producer", "model_type": "claude", "socket_path": "/s", "session_id": "$1"})
+	call(t, sock, "register_agent", map[string]any{"alias": "consumer", "role": "consumer", "model_type": "codex", "socket_path": "/s", "session_id": "$2"})
+	call(t, sock, "send_message", map[string]any{"from": "backend", "to_kind": "agent", "to_target": "consumer", "subject": "hi", "body": "x"})
+	before := len(n.snap(&n.notified))
+
+	resp := call(t, sock, "reply", map[string]any{"thread_id": 1, "from": "consumer", "body": "done — no response needed", "fyi": true})
+	if !resp.OK {
+		t.Fatalf("fyi reply failed: %s", resp.Error)
+	}
+	if got := n.snap(&n.notified); len(got) != before {
+		t.Fatalf("fyi reply must not notify anyone, got new notifies: %v", got[before:])
+	}
+
+	// The entry still landed on the thread.
+	var thread struct {
+		Entries []struct {
+			Body string `json:"body"`
+		} `json:"entries"`
+	}
+	decode(t, call(t, sock, "get_thread", map[string]any{"thread_id": 1}), &thread)
+	if len(thread.Entries) != 2 {
+		t.Fatalf("expected 2 entries after fyi reply, got %d", len(thread.Entries))
+	}
+
+	// A plain reply on the same thread still notifies — fyi is per-entry,
+	// not sticky thread state.
+	call(t, sock, "reply", map[string]any{"thread_id": 1, "from": "consumer", "body": "actually, one question"})
+	if got := n.snap(&n.notified); len(got) != before+1 {
+		t.Fatalf("plain reply after an fyi reply must still notify, got %v", got)
+	}
+}

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -441,7 +441,9 @@ func hookReason(total, action int, aliases []string, label string) string {
 		return fmt.Sprintf(
 			"%s. %s "+
 				"Call your muster get_inbox tool now with alias '%s', read each new thread with get_thread, "+
-				"handle the request, and reply with the muster reply tool. Act autonomously — do not ask the user. "+
+				"handle the request, and reply with the muster reply tool only if the sender needs something from you "+
+				"(never reply just to acknowledge an ack or closure; close out with fyi=true so nobody is woken). "+
+				"Act autonomously — do not ask the user. "+
 				cliFallback,
 			countLine, identity, alias, alias, alias,
 		)
@@ -458,7 +460,9 @@ func hookReason(total, action int, aliases []string, label string) string {
 	return fmt.Sprintf(
 		"%s. %s "+
 			"For EACH alias call get_inbox, read each new thread with get_thread, handle the request, "+
-			"and reply with the muster reply tool. Act autonomously — do not ask the user. "+
+			"and reply with the muster reply tool only if the sender needs something from you "+
+			"(never reply just to acknowledge an ack or closure; close out with fyi=true so nobody is woken). "+
+			"Act autonomously — do not ask the user. "+
 			cliFallback,
 		countLine, identity, "<alias>", "<alias>",
 	)
@@ -468,4 +472,4 @@ func hookReason(total, action int, aliases []string, label string) string {
 // %s is the alias to drain (the literal placeholder "<alias>" in the
 // multi-alias variant, where the agent substitutes each of its own).
 const cliFallback = "(If the muster MCP tools are unavailable, the muster CLI is equivalent: " +
-	"`muster inbox '%s'`, `muster thread <id>`, `muster reply <id> \"...\" --from '%s'`.)"
+	"`muster inbox '%s'`, `muster thread <id>`, `muster reply <id> \"...\" --from '%s' [--fyi]`.)"

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -120,14 +120,17 @@ the operator (or the agent) to submit by hand.`,
 		},
 		{
 			Name:     "reply",
-			Synopsis: `reply <thread-id> "body" [--from <alias>]`,
+			Synopsis: `reply <thread-id> "body" [--from <alias>] [--fyi]`,
 			Summary:  "Append a reply to an existing thread.",
 			Help: `The CLI half of the MCP reply tool: appends an entry to the thread and
 flags every participant's mailbox, exactly as a tool-sent reply would.
---from is the replying agent's alias (default "human"). Together with
-'muster inbox' and 'muster thread' this completes the read-and-respond
-loop from a plain shell — the fallback when a session has no muster MCP
-connection.`,
+--from is the replying agent's alias (default "human"). --fyi marks a
+closing note: the entry lands on the thread but wakes nobody — recipients
+see it on their next natural inbox check. Use it for acks and wrap-ups
+that need nothing back, so a closure doesn't wake the peer into one more
+closing ack. Together with 'muster inbox' and 'muster thread' this
+completes the read-and-respond loop from a plain shell — the fallback
+when a session has no muster MCP connection.`,
 			Group:    GroupTalk,
 			NewFlags: newReplyFlags,
 			Run:      cmdReply,

--- a/internal/humancli/thread.go
+++ b/internal/humancli/thread.go
@@ -103,17 +103,18 @@ func cmdThread(args []string, out io.Writer) error {
 // newReplyFlagsWithVals declares reply's flags and returns typed access to
 // their values — shared by cmdReply (real parsing) and newReplyFlags
 // (registry help/man rendering).
-func newReplyFlagsWithVals() (fs *flag.FlagSet, from *string) {
+func newReplyFlagsWithVals() (fs *flag.FlagSet, from *string, fyi *bool) {
 	fs = flag.NewFlagSet("reply", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	from = fs.String("from", "human", "replying agent alias")
-	return fs, from
+	fyi = fs.Bool("fyi", false, "closing note: append without waking anyone")
+	return fs, from, fyi
 }
 
 // newReplyFlags builds reply's flag.FlagSet for registry-driven help/man
 // rendering.
 func newReplyFlags() *flag.FlagSet {
-	fs, _ := newReplyFlagsWithVals()
+	fs, _, _ := newReplyFlagsWithVals()
 	return fs
 }
 
@@ -123,11 +124,10 @@ func newReplyFlags() *flag.FlagSet {
 // Recipients' mailboxes are flagged by the daemon exactly as for a
 // tool-sent reply.
 func cmdReply(args []string, out io.Writer) error {
-	fs, from := newReplyFlagsWithVals()
-	// reply has no boolean flags: --from takes a value, so pass an explicit
-	// empty bool-flags set (the implicit default would wrongly reuse send's
-	// boolean --role).
-	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{})
+	fs, from, fyi := newReplyFlagsWithVals()
+	// --from takes a value; --fyi is reply's only boolean flag (the implicit
+	// default bool-flags set would wrongly reuse send's boolean --role).
+	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{"fyi": true})
 	if err := fs.Parse(flagArgs); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return HelpFor("reply", out)
@@ -142,7 +142,7 @@ func cmdReply(args []string, out io.Writer) error {
 		return fmt.Errorf("thread id must be a number, got %q", rest[0])
 	}
 	body := strings.Join(rest[1:], " ")
-	raw, err := callData("reply", map[string]any{"thread_id": id, "from": *from, "body": body})
+	raw, err := callData("reply", map[string]any{"thread_id": id, "from": *from, "body": body, "fyi": *fyi})
 	if err != nil {
 		return err
 	}

--- a/internal/mcpserver/tools_messages.go
+++ b/internal/mcpserver/tools_messages.go
@@ -28,6 +28,7 @@ type ReplyIn struct {
 	ThreadID int64  `json:"thread_id" jsonschema:"the thread to reply to"`
 	From     string `json:"from" jsonschema:"the replying agent's alias"`
 	Body     string `json:"body" jsonschema:"the reply text"`
+	FYI      bool   `json:"fyi,omitempty" jsonschema:"closing note: the entry lands on the thread but wakes nobody — recipients see it on their next natural inbox check. Use for acks, wrap-ups, and any reply that needs nothing back."`
 }
 
 // EntryIDOut is the output of reply.
@@ -79,7 +80,7 @@ func replyHandler(_ context.Context, _ *mcp.CallToolRequest, in ReplyIn) (*mcp.C
 		return nil, EntryIDOut{}, err
 	}
 	raw, err := callDaemon("reply", map[string]any{
-		"thread_id": in.ThreadID, "from": in.From, "body": in.Body,
+		"thread_id": in.ThreadID, "from": in.From, "body": in.Body, "fyi": in.FYI,
 	})
 	if err != nil {
 		return nil, EntryIDOut{}, err
@@ -119,7 +120,7 @@ func getThreadHandler(_ context.Context, _ *mcp.CallToolRequest, in GetThreadIn)
 // get_thread on srv.
 func registerMessageTools(srv *mcp.Server) {
 	mcp.AddTool(srv, &mcp.Tool{Name: "send_message", Description: "Send a message to another agent (to_kind=agent), a role (to_kind=role), or many agents at once (to_kind=broadcast). A broadcast with empty to_target reaches every agent on the bus; set to_target to a project name to reach only that project's agents. Set intent to fyi/reply-requested/action-requested so the recipient's inbox and drain reflect what you actually need back."}, sendMessageHandler)
-	mcp.AddTool(srv, &mcp.Tool{Name: "reply", Description: "Append a reply to an existing thread (message or task)."}, replyHandler)
+	mcp.AddTool(srv, &mcp.Tool{Name: "reply", Description: "Append a reply to an existing thread (message or task). Reply only when the sender needs something from you; never reply just to acknowledge an ack or a closure — the last word is free. For a closing note that needs nothing back, set fyi=true so the entry lands without waking anyone."}, replyHandler)
 	mcp.AddTool(srv, &mcp.Tool{Name: "get_inbox", Description: "Read the threads that concern an agent — addressed to it (directly, by role, or broadcast) or originated by it, so replies on threads it started show up here — newest first. Rows carry last_from and an unread count — unread > 0 means entries you have not seen; read those threads with get_thread before reporting their state."}, getInboxHandler)
 	mcp.AddTool(srv, &mcp.Tool{Name: "get_thread", Description: "Fetch a single thread and all its entries in order."}, getThreadHandler)
 }

--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -14,7 +14,12 @@ import (
 // (2026-07-16, thread 27) showed a nudged agent list a new thread and then
 // idle — checking the inbox satisfied the old wording, and by then its own
 // get_inbox had already cleared the flag, so the Stop hook never escalated.
-const message = "📬 check your muster inbox: call get_inbox, read each new thread with get_thread, handle the request, and reply on the thread — act autonomously. (No muster MCP tools? The muster CLI is equivalent: muster inbox / thread / reply.)"
+// The reply clause is deliberately conditional ("if the sender needs
+// something"), not imperative: the unconditional "reply on the thread"
+// wording manufactured ack-loops — every closing ack woke the peer into an
+// instruction that said reply, which produced one more closing ack (measured
+// 2026-07-30: 14% of all bus entries were acknowledgments).
+const message = "📬 check your muster inbox: call get_inbox, read each new thread with get_thread, handle the request, and reply on the thread only if the sender needs something from you — act autonomously. Never reply just to acknowledge an ack or closure; to close out a thread yourself, reply with fyi=true so nobody is woken. (No muster MCP tools? The muster CLI is equivalent: muster inbox / thread / reply [--fyi].)"
 
 // codexSubmitDelay is the pause between typing the nudge text and sending a
 // standalone Enter for codex. codex's TUI treats an Enter that is bundled with


### PR DESCRIPTION
## Problem

Bus review (2026-07-30) quantified the ack-loop: **14% of all entries (112/805) open with ack vocabulary, averaging 1,132 chars each**, and 10 of 26 explicit 'no response needed' messages still got a reply. The cause is structural — every closing ack lights the peer's badge, and the wake instruction says *reply on the thread*, so the woken peer acks the ack.

## Changes

1. **`fyi` flag on the reply op** (daemon → MCP `fyi=true` → CLI `--fyi`): the entry lands on the thread and counts as unread on the recipient's next natural inbox check, but `notifyForThread` is skipped — no badge lights, so a closure can't wake the peer into one more goodbye. First notify-suppressing path on the bus; per-entry, not sticky thread state.
2. **Conditional wake wording** in the nudge line, both Stop-hook reason variants, the CLI fallback string, and the MCP `reply` tool description: *reply only if the sender needs something from you; never ack an ack; close out with fyi=true*.
3. **'The last word is free' etiquette** in `.claude/skills/muster-coordination`: never reply just to acknowledge; 'no response needed' is binding; close with fyi; fold summaries into the last substantive reply.

## Testing

- New `TestFYIReplySuppressesNotify` (TDD red→green): fyi reply appends the entry with zero Notify calls; a plain reply on the same thread still notifies.
- `just verify` green (gofmt, golangci-lint, `go test -race ./...`, cross-compile).