### PR TITLE
feat: durable alias identity — register-on-resume reclaim

### DIFF
--- a/.claude/skills/muster-coordination/SKILL.md
+++ b/.claude/skills/muster-coordination/SKILL.md
@@ -9,12 +9,23 @@ muster lets independent agent sessions (each in its own tmux tab) message and ha
 tasks to each other with no copy/paste. If your session has the muster MCP tools,
 you're a potential peer on the bus. This skill is the etiquette.
 
-## Register once, at the start
+## Register at the start — and on resume
 
-Call `register_agent(alias, role, model_type)` a single time when your session
-begins. The bus captures your tmux pane automatically; your **alias** is how peers
-address you (default: your tmux session name). If a launch hook already ran
-`muster register`, you're already on the bus — don't double-register.
+Call `register_agent(alias, role, model_type)` once when your session begins.
+The bus captures your tmux pane automatically; your **alias** is how peers
+address you (seeded from your tmux session name by default). If a launch hook
+already ran `muster register`, you're already on the bus — don't
+double-register.
+
+Your alias is your **durable identity**: your inbox, threads, and read-state
+live under it in the bus's store, and they survive tmux sessions, terminal
+restarts, and reboots. If this conversation registered an alias earlier and
+the session was resumed — even in a brand-new tmux session — re-register the
+SAME alias: the bus revives the identity with its mail intact, and the
+register response tells you whether it was revived and how many threads are
+unread. (Under Claude Code the SessionStart hook does this reclaim for you
+and tells you your alias and backlog; re-registering by name is the fallback
+every harness has.)
 
 Codex peers register on their **first turn**, not at launch: a freshly opened
 Codex session is not addressable until someone says something to it ("hi" is
@@ -37,7 +48,10 @@ usual reason.
 
 ## Addressing
 
-- **alias** — a peer's tmux session name, globally unique: `send to "backend-2"`.
+- **alias** — a peer's durable bus identity, globally unique: `send to
+  "backend-2"`. It is usually seeded from the tmux session name at first
+  registration, but it belongs to the conversation, not the terminal — it
+  keeps its inbox across tmux sessions.
 - **label** — a peer's manually-pinned tmux label, resolved **within your project**:
   `send to "frontend"`. A bare label never silently crosses a project boundary.
 - **proj:label** — cross projects explicitly: `send to "timewalk:frontend"`.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ auto-submit; other values are typed without submitting).
 Any command that takes a target — `send`, `nudge`, `inbox`, `tasks` —
 accepts a target of the form `<alias|label|proj:label>`:
 
-- an **alias** (the tmux session name, globally unique): `muster nudge muster-2`
+- an **alias** (globally unique): seeded from your tmux session name at first
+  registration; thereafter it is the session's durable identity — re-registering
+  the same alias from anywhere (including after a resume in a new tmux
+  session) revives it with its inbox intact: `muster nudge muster-2`
 - a **label**, resolved within your current project: `muster send frontend "…"`
 - a **qualified label** to cross projects: `muster send timewalk:frontend "…"`
 
@@ -278,7 +281,9 @@ of typed by hand:
 - **SessionStart** → `muster register` — the session joins the bus on start.
   Claude Code fires this at launch; Codex fires it on the session's first turn,
   so say anything to a fresh Codex session ("hi" is enough) before addressing
-  mail to it.
+  mail to it. On `SessionStart` with `source:"resume"`, the hook reclaims
+  every alias the resumed conversation owns onto the new tmux session and
+  reports the unread backlog into the session's context.
 - **Stop** (turn end) → if the session has unread muster mail, the hook tells the
   agent to drain its inbox and reply, autonomously.
 - **SessionEnd** (Claude Code) → `muster deregister`; `muster gc` covers the rest.

--- a/docs/superpowers/plans/2026-08-01-durable-alias-identity.md
+++ b/docs/superpowers/plans/2026-08-01-durable-alias-identity.md
@@ -1,0 +1,1228 @@
+# Durable Alias Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A resumed harness conversation (claude --resume into a brand-new tmux session) automatically reclaims its alias — inbox, threads, read-state — with the register response, hooks, and docs all teaching alias-as-durable-identity.
+
+**Architecture:** The alias is already the durable key and `harness_session_id` already exists end-to-end (column, migration, store round-trip, CLI `--harness-session` flag, `harnessOwnedRows` lookup — all landed with paneless agents, PR #74). This feature adds: (1) a classified register response (new/refreshed/revived + unread count), (2) a lightweight stamp op so hooks can attach the harness session ID to already-registered aliases, (3) hook-driven reclaim on SessionStart `source:"resume"` with a summary printed to stdout (which Claude Code injects into the session's context), and (4) vocabulary fixes in skill/README. Spec: `docs/superpowers/specs/2026-08-01-durable-alias-identity-design.md`.
+
+**Tech Stack:** Go, pure-Go SQLite (`modernc.org/sqlite`), newline-JSON daemon protocol (`internal/proto`), MCP go-sdk.
+
+## Global Constraints
+
+- **Work in a git worktree cut from `origin/dev`** (NEVER local `dev` — the primary clone lags): `git fetch origin && git worktree add ~/GitHub/worktrees/muster-durable-alias -b feat/durable-alias-identity origin/dev`. First commit: copy `docs/superpowers/specs/2026-08-01-durable-alias-identity-design.md` and this plan file from the primary clone into the worktree (they exist only in the primary clone's working tree).
+- **`just verify` is the gate** (gofmt, golangci-lint, `go test -race`, build) — run before every commit claim of done.
+- **cgo-free**: no new dependencies; `CGO_ENABLED=0` must keep building.
+- **stdout is sacred in mcp mode** — all new diagnostics in mcpserver paths go to stderr or the tool result, never `fmt.Println`.
+- **Daemon stays tmux- and harness-agnostic**: `internal/daemon`/`internal/store` treat `harness_session_id` as an opaque string; no `tmuxenv`/`harnessenv` imports there.
+- **Hooks never block a session**: every new hook path swallows errors and degrades to today's behavior (`cmdHook` always returns nil).
+- macOS tests: daemon-socket tests must use the existing `startTestDaemon`/`startWithNotifier` helpers (they use `mustertest.ShortHome()` for the sun_path limit) — never `t.TempDir()` for a socket dir.
+- House style: doc comments are full-sentence, rationale-carrying (see any function in `hook.go`); Go doc comments in this repo deliberately render empty-string as `''` (U+2019 pair) — don't "fix" existing ones.
+
+## Interfaces established by this plan (cross-task contract)
+
+- Daemon `register_agent` response `Data`: `{"outcome": "new"|"refreshed"|"revived", "unread": <int>}`.
+- New daemon op `stamp_harness_session`, args `{"alias": string, "harness_session_id": string}` → `ok(nil)`.
+- New store method: `func (s *Store) SetHarnessSessionID(alias, id string) error`.
+- humancli: `type registerAck struct { Outcome string `+"`json:\"outcome\"`"+`; Unread int `+"`json:\"unread\"`"+` }` and `func decodeRegisterAck(raw json.RawMessage) registerAck` (zero value on any decode failure).
+- humancli: `reviveRow(ag agentRow, model string) registerAck` (signature gains the return; existing callers may discard it).
+- humancli: `func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model string, out io.Writer) bool` — reclaims owned rows onto the current tmux tuple; true when ≥1 alias was reclaimed (caller then skips the default register).
+
+---
+
+### Task 1: Daemon — classified register response with unread count
+
+**Files:**
+- Modify: `internal/daemon/daemon.go` (handleRegisterAgent, ~line 205)
+- Test: `internal/daemon/register_outcome_test.go` (new)
+
+**Interfaces:**
+- Consumes: existing `d.s.GetAgent` / `d.s.RegisterAgent` / `d.s.UnreadCount` / `d.logEvent`.
+- Produces: `register_agent` response Data `{"outcome": ..., "unread": ...}`; journal event `Kind:"register", Agent:<alias>, Detail:"revived"` on revival only.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package daemon
+
+import "testing"
+
+// TestRegisterAgentOutcomeClassification covers the three register outcomes
+// the durable-alias spec defines: a first-sight alias is "new", an upsert
+// over a live row is "refreshed", and an upsert over a tombstone is
+// "revived" — with the response carrying the alias's unread count so a
+// resuming session learns its backlog in the same call.
+func TestRegisterAgentOutcomeClassification(t *testing.T) {
+	sock := startWithNotifier(t, &fakeNotifier{})
+
+	resp := call(t, sock, "register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/s", "session_id": "$1",
+	})
+	if !resp.OK {
+		t.Fatalf("register: %+v", resp)
+	}
+	data, _ := resp.Data.(map[string]any)
+	if data["outcome"] != "new" {
+		t.Fatalf("first register outcome = %v, want new", data["outcome"])
+	}
+
+	resp = call(t, sock, "register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/s", "session_id": "$1",
+	})
+	data, _ = resp.Data.(map[string]any)
+	if data["outcome"] != "refreshed" {
+		t.Fatalf("re-register outcome = %v, want refreshed", data["outcome"])
+	}
+
+	// Mail lands while the agent is departed; revival must report it.
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/s", "session_id": "$2",
+	})
+	call(t, sock, "send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "backend",
+		"subject": "while you were away", "body": "ping",
+	})
+	call(t, sock, "deregister_agent", map[string]any{"alias": "backend"})
+
+	resp = call(t, sock, "register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/s3", "session_id": "$9",
+	})
+	data, _ = resp.Data.(map[string]any)
+	if data["outcome"] != "revived" {
+		t.Fatalf("revival outcome = %v, want revived", data["outcome"])
+	}
+	if n, _ := data["unread"].(float64); n < 1 {
+		t.Fatalf("revival unread = %v, want >= 1", data["unread"])
+	}
+
+	// Revival is journaled so watch/station show a returning agent.
+	ev := call(t, sock, "list_events", map[string]any{"agent": "backend"})
+	if !containsEventDetail(t, ev, "register", "revived") {
+		t.Fatalf("no register/revived journal event after revival: %+v", ev.Data)
+	}
+}
+```
+
+Add the small helper in the same file (decode `ev.Data` — a `[]any` of `map[string]any` over the wire — and return whether any row has `kind=="register"` and `detail=="revived"`):
+
+```go
+func containsEventDetail(t *testing.T, resp proto.Response, kind, detail string) bool {
+	t.Helper()
+	rows, _ := resp.Data.([]any)
+	for _, r := range rows {
+		m, _ := r.(map[string]any)
+		if m["kind"] == kind && m["detail"] == detail {
+			return true
+		}
+	}
+	return false
+}
+```
+
+(Import `github.com/schuettc/muster/internal/proto`. Check `list_events`' arg names against `internal/daemon/daemon.go` case `"list_events"` — the concern filter arg is `agent`; mirror whatever `internal/humancli/events.go` sends. If the events op requires more args, seed exactly what `events_test.go` does.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/daemon/ -run TestRegisterAgentOutcomeClassification -race`
+Expected: FAIL — `data["outcome"]` is nil (register currently returns `ok(nil)`).
+
+- [ ] **Step 3: Implement in handleRegisterAgent**
+
+In `internal/daemon/daemon.go`, replace the final `return ok(nil)` of `handleRegisterAgent` and classify from the already-fetched pre-mutation row:
+
+```go
+	// Outcome classification (durable-alias spec change 1): the pre-mutation
+	// row read above already tells this apart for free — no prior row is a
+	// first sight, a live prior row is a tuple refresh, and a tombstone is a
+	// returning session (RegisterAgent's upsert just revived it). The unread
+	// count rides along so a resuming session learns its backlog in the same
+	// call; a count failure degrades to 0 rather than failing a register that
+	// already succeeded.
+	outcome := "new"
+	switch {
+	case hadOld && old.Departed:
+		outcome = "revived"
+		d.logEvent(store.Event{Kind: "register", Agent: alias, Detail: "revived"})
+	case hadOld:
+		outcome = "refreshed"
+	}
+	unread, err := d.s.UnreadCount(alias)
+	if err != nil {
+		unread = 0
+	}
+	return ok(map[string]any{"outcome": outcome, "unread": unread})
+```
+
+- [ ] **Step 4: Run the package tests**
+
+Run: `go test ./internal/daemon/ -race`
+Expected: PASS — including all existing register/CAS/badge tests (they ignore response Data, so nothing else should move).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/daemon/daemon.go internal/daemon/register_outcome_test.go
+git commit -m "feat(daemon): register_agent classifies new/refreshed/revived and returns unread"
+```
+
+---
+
+### Task 2: Store + daemon — stamp_harness_session op
+
+**Files:**
+- Modify: `internal/store/agents.go`, `internal/daemon/daemon.go` (dispatch switch)
+- Test: `internal/store/agents_test.go` (append), `internal/daemon/daemon_test.go` (append)
+
+**Interfaces:**
+- Produces: `Store.SetHarnessSessionID(alias, id string) error`; daemon op `stamp_harness_session` `{"alias", "harness_session_id"}` → `ok(nil)`.
+
+- [ ] **Step 1: Write the failing store test** (append to `internal/store/agents_test.go`, mirroring its existing open-store helper — reuse whatever `TestRegisterAgent*` there uses to get a `*Store`):
+
+```go
+// TestSetHarnessSessionID covers the hook-repair path of the durable-alias
+// spec: an alias registered without a harness link (e.g. via the MCP tool in
+// an env with no harness UUID) gets one stamped later by the Stop hook.
+func TestSetHarnessSessionID(t *testing.T) {
+	s := openTestStore(t) // use this file's existing store-opening helper name
+	if err := s.RegisterAgent(Agent{Alias: "backend"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetHarnessSessionID("backend", "uuid-1"); err != nil {
+		t.Fatal(err)
+	}
+	ag, ok, err := s.GetAgent("backend")
+	if err != nil || !ok {
+		t.Fatalf("get: %v %v", ok, err)
+	}
+	if ag.HarnessSessionID != "uuid-1" {
+		t.Fatalf("harness_session_id = %q, want uuid-1", ag.HarnessSessionID)
+	}
+	// Unknown alias is a no-op, mirroring TouchAgent's contract.
+	if err := s.SetHarnessSessionID("ghost", "uuid-2"); err != nil {
+		t.Fatal(err)
+	}
+}
+```
+
+- [ ] **Step 2: Run it** — `go test ./internal/store/ -run TestSetHarnessSessionID -race` — expect FAIL (method undefined).
+
+- [ ] **Step 3: Implement the store method** (in `internal/store/agents.go`, next to `TouchAgent`):
+
+```go
+// SetHarnessSessionID stamps the harness session UUID onto an existing row —
+// the repair half of the durable-alias spec: an alias registered without a
+// harness link (an MCP register in an env carrying no harness UUID) gets one
+// attached later by a hook that DOES see the UUID (every hook payload carries
+// it). Identity, tuple, and read-state are untouched; unknown alias is a
+// no-op, mirroring TouchAgent's contract.
+func (s *Store) SetHarnessSessionID(alias, id string) error {
+	_, err := s.db.Exec(`UPDATE agents SET harness_session_id=? WHERE alias=?`, id, alias)
+	return err
+}
+```
+
+- [ ] **Step 4: Write the failing daemon test** (append to `internal/daemon/daemon_test.go`):
+
+```go
+// TestStampHarnessSession covers the stamp op end to end: register without a
+// harness link, stamp, and see the link in list_agents.
+func TestStampHarnessSession(t *testing.T) {
+	sock := startWithNotifier(t, &fakeNotifier{})
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/s", "session_id": "$1",
+	})
+	resp := call(t, sock, "stamp_harness_session", map[string]any{
+		"alias": "backend", "harness_session_id": "uuid-1",
+	})
+	if !resp.OK {
+		t.Fatalf("stamp: %+v", resp)
+	}
+	list := call(t, sock, "list_agents", nil)
+	rows, _ := list.Data.([]any)
+	m, _ := rows[0].(map[string]any)
+	if m["harness_session_id"] != "uuid-1" {
+		t.Fatalf("harness_session_id = %v, want uuid-1", m["harness_session_id"])
+	}
+}
+```
+
+- [ ] **Step 5: Run it** — expect FAIL (unknown op). Then add the dispatch case in `internal/daemon/daemon.go`, next to `case "set_label"`:
+
+```go
+	case "stamp_harness_session":
+		if err := d.s.SetHarnessSessionID(str(a, "alias"), str(a, "harness_session_id")); err != nil {
+			return fail(err)
+		}
+		return ok(nil)
+```
+
+- [ ] **Step 6: Run both packages** — `go test ./internal/store/ ./internal/daemon/ -race` — expect PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/store/agents.go internal/store/agents_test.go internal/daemon/daemon.go internal/daemon/daemon_test.go
+git commit -m "feat(store,daemon): stamp_harness_session op attaches a harness link to an existing alias"
+```
+
+---
+
+### Task 3: CLI — register prints outcome + unread
+
+**Files:**
+- Modify: `internal/humancli/identity.go` (cmdRegister), `internal/humancli/paneless.go` (reviveRow)
+- Create: `internal/humancli/register_ack.go`
+- Test: `internal/humancli/identity_test.go` (append)
+
+**Interfaces:**
+- Consumes: Task 1's response Data.
+- Produces: `registerAck`, `decodeRegisterAck(raw json.RawMessage) registerAck`, `func (a registerAck) line(alias string) string`, `reviveRow(...) registerAck`.
+
+- [ ] **Step 1: Write the failing test** (append to `identity_test.go`; the file's existing tests show how to run `cmdRegister` against `startTestDaemon(t)` with `t.Setenv("TMUX", ...)` + a `tmuxenv.Run` stub — mirror one):
+
+```go
+// TestRegisterPrintsRevivalAndUnread covers the resume loop's CLI surface:
+// re-registering a departed alias that accrued mail must say so, so the
+// operator (or a resumed agent using the CLI) learns the backlog in the
+// same command.
+func TestRegisterPrintsRevivalAndUnread(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("MUSTER_ALIAS", "")
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{"alias": "backend", "socket_path": "/s", "session_id": "$1"})
+	seed("register_agent", map[string]any{"alias": "sender", "socket_path": "/s", "session_id": "$2"})
+	seed("send_message", map[string]any{"from": "sender", "to_kind": "agent", "to_target": "backend", "subject": "hi", "body": "b"})
+	seed("deregister_agent", map[string]any{"alias": "backend"})
+
+	var buf bytes.Buffer
+	if err := cmdRegister([]string{"backend"}, &buf); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "revived") || !strings.Contains(out, "1 unread") {
+		t.Fatalf("register output missing revival/unread notice:\n%s", out)
+	}
+}
+```
+
+(Note: with `TMUX` empty and an explicit positional alias, cmdRegister takes the tmux-anchored code path with empty capture → the `paneless` half-capture guard stores the clean paneless shape; the daemon response decode is what's under test. If the empty-env path errors in practice, set `TMUX`/`TMUX_PANE` and stub `tmuxenv.Run` exactly as `TestHookStopUnreadEmitsBlockDecision` does instead.)
+
+- [ ] **Step 2: Run it** — `go test ./internal/humancli/ -run TestRegisterPrintsRevivalAndUnread -race` — expect FAIL (no such output).
+
+- [ ] **Step 3: Implement.** New file `internal/humancli/register_ack.go`:
+
+```go
+package humancli
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// registerAck decodes register_agent's response data (durable-alias spec
+// change 1): how the daemon classified this registration, and the alias's
+// unread-thread count at that moment.
+type registerAck struct {
+	Outcome string `json:"outcome"`
+	Unread  int    `json:"unread"`
+}
+
+// decodeRegisterAck tolerantly decodes a register_agent response. A daemon
+// predating the outcome field (or any decode failure) yields the zero value,
+// whose line() renders nothing — callers degrade to today's output.
+func decodeRegisterAck(raw json.RawMessage) registerAck {
+	var a registerAck
+	_ = json.Unmarshal(raw, &a)
+	return a
+}
+
+// line renders the human-facing follow-up for a registration worth
+// remarking on: a revival, or pending mail. "" for an unremarkable new or
+// refreshed registration with an empty inbox — the existing "registered X"
+// line already says everything.
+func (a registerAck) line(alias string) string {
+	if a.Outcome != "revived" && a.Unread == 0 {
+		return ""
+	}
+	msg := fmt.Sprintf("reconnected: identity '%s' %s", alias, a.Outcome)
+	if a.Unread > 0 {
+		msg += fmt.Sprintf(" — %d unread thread(s); run `muster inbox '%s'`", a.Unread, alias)
+	}
+	return msg + "\n"
+}
+```
+
+In `cmdRegister` (identity.go), capture and print on the main path — change:
+
+```go
+	if _, err := callData("register_agent", map[string]any{
+```
+
+to:
+
+```go
+	raw, err := callData("register_agent", map[string]any{
+```
+
+adjust the error check to `if err != nil { return err }` and after the existing `registered %s ...` Fprintf add:
+
+```go
+	if s := decodeRegisterAck(raw).line(alias); s != "" {
+		if _, err := fmt.Fprint(out, s); err != nil {
+			return err
+		}
+	}
+```
+
+In `paneless.go`, `reviveRow` returns the ack (existing callers compile unchanged only if they ignore returns — `hookSessionStartPaneless` and cmdRegister's paneless branch call it as a statement today; a statement call of a value-returning function is legal Go, so nothing else changes):
+
+```go
+func reviveRow(ag agentRow, model string) registerAck {
+	if model == "" {
+		model = ag.ModelType
+	}
+	raw, _ := callData("register_agent", map[string]any{ /* ...unchanged args... */ })
+	return decodeRegisterAck(raw)
+}
+```
+
+In cmdRegister's paneless owned-rows branch, print the ack line after the existing `registered %s (existing identity...)` Fprintf:
+
+```go
+			if s := reviveRow(owned[0], *model).line(alias); s != "" {
+				_, _ = fmt.Fprint(out, s)
+			}
+```
+
+(replacing the bare `reviveRow(owned[0], *model)` statement).
+
+- [ ] **Step 4: Run the package** — `go test ./internal/humancli/ -race` — expect PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/humancli/register_ack.go internal/humancli/identity.go internal/humancli/paneless.go internal/humancli/identity_test.go
+git commit -m "feat(cli): register reports revival and unread backlog"
+```
+
+---
+
+### Task 4: MCP — register stamps the harness link and reports the outcome
+
+**Files:**
+- Modify: `internal/mcpserver/tools_registry.go`
+- Test: `internal/mcpserver/tools_registry_test.go` (append)
+
+**Interfaces:**
+- Consumes: Task 1's response Data; existing `harnessenv.FromEnv()`.
+- Produces: `register_agent` MCP Detail carrying outcome + unread; `harness_session_id` in the daemon args.
+
+- [ ] **Step 1: Write the failing test** (append; mirror `TestRegisterAgentCapturesTmuxEnv`'s `callDaemon` stub):
+
+```go
+// TestRegisterAgentStampsHarnessLinkAndReportsRevival covers the durable-alias
+// spec's MCP surface: the handler forwards the ambient harness session UUID
+// (so hook reclaim can find this row after a resume), and folds the daemon's
+// outcome/unread into the Detail so a re-registering agent learns its backlog.
+func TestRegisterAgentStampsHarnessLinkAndReportsRevival(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%6")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "uuid-7")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_id}":
+			return "$5", nil
+		case "#{session_name}":
+			return "muster-2", nil
+		default:
+			return "", nil
+		}
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var got map[string]any
+	prevDaemon := callDaemon
+	callDaemon = func(op string, args map[string]any) (json.RawMessage, error) {
+		if op == "register_agent" {
+			got = args
+			return []byte(`{"outcome":"revived","unread":3}`), nil
+		}
+		return []byte(`[]`), nil // paneRegistration's list_agents probe
+	}
+	t.Cleanup(func() { callDaemon = prevDaemon })
+
+	_, out, err := registerAgentHandler(context.TODO(), nil, RegisterAgentIn{Alias: "backend", Role: "peer", ModelType: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["harness_session_id"] != "uuid-7" {
+		t.Fatalf("harness_session_id = %v, want uuid-7", got["harness_session_id"])
+	}
+	if !strings.Contains(out.Detail, "revived") || !strings.Contains(out.Detail, "3 unread") {
+		t.Fatalf("Detail = %q, want revival + unread notice", out.Detail)
+	}
+}
+```
+
+(Verify how `paneRegistration` fetches the roster — read `internal/mcpserver/validate.go` on the worktree; adjust the stub's non-register return to whatever shape it decodes.)
+
+- [ ] **Step 2: Run it** — `go test ./internal/mcpserver/ -run TestRegisterAgentStampsHarness -race` — expect FAIL.
+
+- [ ] **Step 3: Implement.** In `registerAgentHandler`: hoist `h := harnessenv.FromEnv()` above the paneless branch (the branch currently declares its own `h` — reuse the hoisted one), add `"harness_session_id": h.SessionID` to the `callDaemon` args map, capture the response, and build the Detail:
+
+```go
+	raw, err := callDaemon("register_agent", map[string]any{ /* existing args + harness_session_id */ })
+	if err != nil {
+		return nil, OKOut{}, err
+	}
+	var ack struct {
+		Outcome string `json:"outcome"`
+		Unread  int    `json:"unread"`
+	}
+	_ = json.Unmarshal(raw, &ack)
+	detail := "registered " + in.Alias
+	if ack.Outcome == "revived" {
+		detail = fmt.Sprintf("reconnected as '%s' — revived a previous registration", in.Alias)
+	}
+	if ack.Unread > 0 {
+		detail += fmt.Sprintf("; %d unread thread(s): call get_inbox with alias '%s'", ack.Unread, in.Alias)
+	}
+	return nil, OKOut{OK: true, Detail: detail}, nil
+```
+
+- [ ] **Step 4: Run the package** — `go test ./internal/mcpserver/ -race` — expect PASS (existing capture test still passes: it asserts specific keys, not the absence of others; if it asserts the full map, add the new key to its expectation).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mcpserver/tools_registry.go internal/mcpserver/tools_registry_test.go
+git commit -m "feat(mcp): register_agent stamps the harness link and reports revival/unread"
+```
+
+---
+
+### Task 5: tmuxenv — ancestry-based pane capture + `muster whereami`
+
+**Context (verified on thread 149 with the dotfiles session):** harnesses spawn
+hooks with a STRIPPED environment — `$TMUX`/`$TMUX_PANE` unset — so
+`tmuxenv.CaptureEnv()` comes back empty inside a hook even when the session
+lives in a pane. The proven fix (shipped in dotfiles
+`config/claude/claude-notify.sh`) is to walk the hook's process ancestry
+(hook → claude → pane shell) until a PID matches a tmux pane's
+`#{pane_pid}`. Muster builds its own copy in tmuxenv; dotfiles keeps theirs
+(independent installability — settled on thread 149, entry 878). The two are
+aligned by a four-point CONTRACT, quoted in the spec: walk outward; match
+across the `proj-*` sockets (the notify script's default-socket-only query
+is NOT enough — this machine runs one tmux server per project); first match
+wins; fail-safe empty, never a cwd guess or broadcast. Read
+`~/dotfiles/config/claude/claude-notify.sh` before implementing and lift its
+matching behavior — it is the version with real mileage. `muster whereami`
+is for muster's own hooks and operator convenience only; do not pitch it as
+a dotfiles dependency anywhere in help text or docs.
+
+**Files:**
+- Create: `internal/tmuxenv/ancestry.go`
+- Test: `internal/tmuxenv/ancestry_test.go`
+- Modify: `internal/humancli/registry.go` (+ whichever file pattern the registry uses for a new command — mirror how `cmdNudge` or `cmdLabel` is wired), new `internal/humancli/whereami.go`
+- Test: `internal/humancli/whereami_test.go`
+
+**Interfaces:**
+- Produces: `tmuxenv.CaptureFromAncestry() Capture` — same `Capture` struct `CaptureEnv` returns, zero value when no pane matches.
+- Produces (injectable for tests, mirroring the existing `tmuxenv.Run` var pattern): `tmuxenv.AncestorPIDs func() []int` and `tmuxenv.SocketDir func() string`.
+- Produces: CLI verb `muster whereami` — prints `socket=<path> session_id=<id> session_name=<name> pane=<id> created=<ts>` (one line), `--json` for a JSON object, empty stdout + exit 1 when no pane matches.
+
+- [ ] **Step 1: Write the failing tmuxenv test:**
+
+```go
+package tmuxenv
+
+import "testing"
+
+// TestCaptureFromAncestryMatchesPanePID: the walk must find the pane whose
+// #{pane_pid} is one of this process's ancestors, capture the full tuple
+// from THAT socket, and come back empty (fail-safe) when no pane matches —
+// never a guess.
+func TestCaptureFromAncestryMatchesPanePID(t *testing.T) {
+	prevRun, prevAnc, prevDir := Run, AncestorPIDs, SocketDir
+	t.Cleanup(func() { Run, AncestorPIDs, SocketDir = prevRun, prevAnc, prevDir })
+
+	AncestorPIDs = func() []int { return []int{999, 4242, 1} }
+
+	Run = func(args ...string) (string, error) {
+		// list-panes across sockets: only the proj-muster socket has our pane.
+		switch {
+		case contains(args, "list-panes") && containsSuffix(args, "proj-muster"):
+			return "4242\t%7\t$3\tmuster-2\t555", nil
+		case contains(args, "list-panes"):
+			return "100\t%1\t$1\tother\t111", nil
+		default:
+			return "", nil
+		}
+	}
+	// Socket enumeration: SocketDir points at a temp dir holding two fake
+	// socket files so CaptureFromAncestry's glob finds both "servers".
+	dir := t.TempDir()
+	for _, name := range []string{"proj-other", "proj-muster"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	SocketDir = func() string { return dir }
+
+	c := CaptureFromAncestry()
+	if c.SocketPath == "" || c.PaneID != "%7" || c.SessionID != "$3" || c.SessionCreated != 555 {
+		t.Fatalf("capture = %+v, want pane %%7 on $3 created 555", c)
+	}
+
+	AncestorPIDs = func() []int { return []int{999, 1} } // no pane pid in chain
+	if c := CaptureFromAncestry(); c.SocketPath != "" || c.PaneID != "" {
+		t.Fatalf("no-match capture = %+v, want zero value (fail-safe)", c)
+	}
+}
+```
+
+(Write `contains(args []string, want string) bool` and
+`containsSuffix(args []string, suffix string) bool` as small helpers —
+`containsSuffix` matches the `-S <path>` socket argument by its basename.
+Imports: `os`, `path/filepath`, `testing`. The test's CONTRACT is fixed:
+ancestor-pid match selects the socket and pane; no match yields the zero
+Capture. If `Run`'s real call shape targets sockets differently than a
+leading `-S` — check `tmuxenv.go`'s `query` helper — adjust the stub's
+match to the real arg shape, keeping both assertions.)
+
+- [ ] **Step 2: Run it** — `go test ./internal/tmuxenv/ -run TestCaptureFromAncestry -race` — expect FAIL (function undefined).
+
+- [ ] **Step 3: Implement `internal/tmuxenv/ancestry.go`:**
+
+```go
+package tmuxenv
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// ancestryGuard bounds the parent-chain walk; 30 generations is far beyond
+// any real hook → claude → shell nesting (mirrors claude-notify.sh's guard).
+const ancestryGuard = 30
+
+// AncestorPIDs returns this process's parent chain, nearest first, stopping
+// at pid 0/1. Injectable for tests. The real implementation shells out to
+// `ps -o ppid= -p <pid>` per hop — portable across macOS/Linux without cgo.
+var AncestorPIDs = func() []int {
+	pids := []int{os.Getpid()}
+	pid := os.Getpid()
+	for i := 0; i < ancestryGuard; i++ {
+		out, err := exec.Command("ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+		if err != nil {
+			break
+		}
+		next, err := strconv.Atoi(strings.TrimSpace(string(out)))
+		if err != nil || next <= 1 {
+			break
+		}
+		pids = append(pids, next)
+		pid = next
+	}
+	return pids
+}
+
+// SocketDir returns the directory holding this user's tmux server sockets:
+// $TMUX_TMPDIR if set (tmux's own knob — our operator-tunable too), else
+// /tmp/tmux-<uid>, tmux's default. Injectable for tests.
+var SocketDir = func() string {
+	if d := os.Getenv("TMUX_TMPDIR"); d != "" {
+		return filepath.Join(d, "tmux-"+strconv.Itoa(os.Getuid()))
+	}
+	return filepath.Join("/tmp", "tmux-"+strconv.Itoa(os.Getuid()))
+}
+
+// CaptureFromAncestry locates the tmux pane this PROCESS runs under by
+// walking its parent chain and matching pane PIDs across every tmux server
+// socket on the machine, then captures the same identity CaptureEnv reads
+// from $TMUX/$TMUX_PANE. Hooks need this: harnesses spawn them with a
+// stripped environment (no $TMUX), but the hook is still a descendant of the
+// pane's shell, so the ancestry names the pane even when the env can't
+// (the claude-notify.sh technique, generalized across per-project sockets).
+// Requires the hook to run synchronously — an async hook is reparented and
+// the chain breaks. Fail-safe: no match returns the zero Capture (paneless
+// behavior), NEVER a cwd-derived guess — two sessions in one directory is
+// normal, and mis-anchoring an identity is worse than not anchoring it.
+func CaptureFromAncestry() Capture {
+	ancestors := AncestorPIDs()
+	sockets, _ := filepath.Glob(filepath.Join(SocketDir(), "*"))
+	for _, sock := range sockets {
+		out, err := Run("-S", sock, "list-panes", "-aF",
+			"#{pane_pid}\t#{pane_id}\t#{session_id}\t#{session_name}\t#{session_created}")
+		if err != nil || out == "" {
+			continue
+		}
+		byPID := map[int][]string{}
+		for _, line := range strings.Split(out, "\n") {
+			f := strings.Split(line, "\t")
+			if len(f) != 5 {
+				continue
+			}
+			if pid, err := strconv.Atoi(f[0]); err == nil {
+				byPID[pid] = f
+			}
+		}
+		for _, pid := range ancestors {
+			if f, hit := byPID[pid]; hit {
+				created, _ := strconv.ParseInt(f[4], 10, 64)
+				return capturePane(sock, f[1], f[2], f[3], created)
+			}
+		}
+	}
+	return Capture{}
+}
+```
+
+with `capturePane` assembling a `Capture` the way `CaptureEnv` does for its
+fields — socket, pane, session id/name/created directly from the match, and
+Project/Label via the SAME queries CaptureEnv uses given a socket + pane
+(read `tmuxenv.go`'s `CaptureEnv`/`query` and reuse those helpers verbatim;
+if `Run` doesn't already accept a leading `-S`, mirror however `query`
+targets a socket).
+
+Adjust the Step 1 test mechanics to these seams (fake socket files in
+`SocketDir()`'s dir so the glob finds them).
+
+- [ ] **Step 4: Run it** — expect PASS. Also `go test ./internal/tmuxenv/ -race` for the package.
+
+- [ ] **Step 5: Write the failing CLI test** (`internal/humancli/whereami_test.go`):
+
+```go
+package humancli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// TestWhereamiPrintsResolvedTuple: the verb is the walk's CLI face, for
+// muster's own hooks and operators (dotfiles keeps its own walk — the two
+// share a behavioral contract, not a binary; thread 149).
+func TestWhereamiPrintsResolvedTuple(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	prev := tmuxenv.AncestorPIDs
+	// ... stub AncestorPIDs/SocketDir/Run exactly as the tmuxenv test does,
+	// yielding pane %7 / $3 / muster-2 / created 555 on socket S ...
+	t.Cleanup(func() { tmuxenv.AncestorPIDs = prev })
+
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"whereami"}, &buf); err != nil {
+		t.Fatalf("whereami: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"session_id=$3", "pane=%7", "session_name=muster-2"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("whereami output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestWhereamiFailsWhenUnresolvable: no env, no ancestry match → empty
+// stdout and a non-nil error (the CLI maps it to a nonzero exit).
+func TestWhereamiFailsWhenUnresolvable(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	// stub AncestorPIDs to pids matching no pane; Run to return no panes
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"whereami"}, &buf); err == nil {
+		t.Fatalf("expected an error when no pane resolves, got output %q", buf.String())
+	}
+}
+```
+
+- [ ] **Step 6: Implement `cmdWhereami`** in `internal/humancli/whereami.go`: env capture first (`tmuxenv.CaptureEnv()`), ancestry walk as fallback, `--json` flag via the registry's flag pattern. Register it in `registry.go` mirroring an existing simple command (grouped under the identity/hooks group; help text: "print the tmux identity of the pane this process runs under — resolves via $TMUX when present, else by walking process ancestry (works inside env-stripped harness hooks)").
+
+- [ ] **Step 7: Run the package** — `go test ./internal/humancli/ ./internal/tmuxenv/ -race` — expect PASS. Run `just verify` (registry changes touch help/man goldens if any — fix them per their test output).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/tmuxenv/ancestry.go internal/tmuxenv/ancestry_test.go internal/humancli/whereami.go internal/humancli/whereami_test.go internal/humancli/registry.go
+git commit -m "feat(tmuxenv): ancestry-based pane capture + muster whereami"
+```
+
+---
+
+### Task 6: Hooks — SessionStart passes the payload's harness ID; Stop repairs missing links
+
+**Files:**
+- Modify: `internal/humancli/hook.go` (cmdHook SessionStart tmux branch; hookStop tmux path)
+- Test: `internal/humancli/hook_test.go` (append)
+
+**Interfaces:**
+- Consumes: `harnessenv.FromHookPayload`, CLI `--harness-session` flag (exists), Task 2's `stamp_harness_session` op.
+- Produces: tmux-anchored SessionStart registrations carry `harness_session_id`; Stop stamps owned, link-less aliases (only when the mail gate already opened — the cheap `@muster_inbox` gate stays the only thing that decides whether Stop dials the daemon at all).
+
+- [ ] **Step 1: Write the failing Stop-repair test** (append to `hook_test.go`; mirror `TestHookStopUnreadEmitsBlockDecision`'s daemon + `tmuxenv.Run` + env setup — that test registers aliases on tuple `("/tmp/sock", "$1")`, stubs `@muster_inbox` > 0, and runs `cmdHook([]string{"Stop"}, ...)`):
+
+```go
+// TestHookStopStampsHarnessLink covers the repair half of the durable-alias
+// spec: a custom alias registered via the MCP tool (no harness link) gets the
+// payload's session_id stamped when the Stop hook fires for real mail — so a
+// later resume can find the row. The stamp piggybacks on the mail gate: no
+// mail, no daemon dials, no stamp.
+func TestHookStopStampsHarnessLink(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/tmp/sock", "session_id": "$1", "pane_id": "%1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/tmp/sock", "session_id": "$2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "backend", "subject": "s", "body": "b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"@muster_inbox":    "1",
+		"#{session_id}":    "$1",
+		"#{session_name}":  "backend",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{"session_id":"uuid-9"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	ag, ok := hookGetAgent("backend")
+	if !ok || ag.HarnessSessionID != "uuid-9" {
+		t.Fatalf("harness link after Stop = %q (found=%v), want uuid-9", ag.HarnessSessionID, ok)
+	}
+}
+```
+
+(The `tmuxenv.Run` stub must also satisfy `tmuxenv.SocketFromEnv` — that reads `$TMUX`, not Run — and the label option lookup; `hookRun` returns "" for unknown keys, which is fine. If `SocketFromEnv` yields `/tmp/sock` from the TMUX env var, the registered tuple matches.)
+
+- [ ] **Step 2: Run it** — expect FAIL (link stays empty).
+
+- [ ] **Step 3: Implement both halves in `hook.go`.**
+
+First, the capture helper both hook tasks build on — hooks run env-stripped
+(verified, thread 149), so env capture alone lands every pane-launched
+session in the paneless branch; the ancestry walk (Task 5) is the fallback
+that recovers the pane:
+
+```go
+// hookCapture resolves the tmux identity a hook acts on: the environment
+// when the harness passed it through, else the process-ancestry walk —
+// hooks are spawned env-stripped, but a synchronous hook is still a
+// descendant of its pane's shell (see tmuxenv.CaptureFromAncestry). The
+// zero Capture (both paths empty) means genuinely paneless.
+func hookCapture() tmuxenv.Capture {
+	if c := tmuxenv.CaptureEnv(); c.SocketPath != "" && c.PaneID != "" {
+		return c
+	}
+	return tmuxenv.CaptureFromAncestry()
+}
+```
+
+SessionStart branch of `cmdHook` — use it, and thread the payload's harness
+ID into the register (the `--harness-session` flag already exists on
+cmdRegister; an empty value falls back to `FromEnv` inside it, so pass
+unconditionally). NOTE: `cmdRegister` itself reads `tmuxenv.CaptureEnv()`
+internally, which is empty in a stripped hook — so when the ancestry walk
+(not the env) produced the capture, register through a direct
+`register_agent` call with the walked tuple (the `reclaimRow`-style args
+shape from Task 7) rather than through cmdRegister. Structure the branch so
+both paths stamp the harness ID:
+
+```go
+	case "SessionStart":
+		c := hookCapture()
+		h := harnessenv.FromHookPayload(payload)
+		if c.SocketPath != "" && c.PaneID != "" {
+			if hookMayClaimIdentity(c) {
+				hookRegisterPane(c, h, model)
+			}
+		} else {
+			hookSessionStartPaneless(h, model)
+		}
+```
+
+with:
+
+```go
+// hookRegisterPane registers the session-name alias for a pane-anchored
+// SessionStart. It cannot delegate to cmdRegister: that reads the tmux
+// identity from the ENVIRONMENT, which a stripped hook doesn't have — the
+// capture c (env or ancestry walk) is the truth here.
+func hookRegisterPane(c tmuxenv.Capture, h harnessenv.Capture, model string) {
+	alias := hookAlias(c)
+	if alias == "" {
+		return
+	}
+	_, _ = callData("register_agent", map[string]any{
+		"alias": alias, "role": "", "model_type": model,
+		"session_name": c.SessionName, "session_id": c.SessionID,
+		"session_created":    c.SessionCreated,
+		"harness_session_id": h.SessionID,
+		"socket_path":        c.SocketPath, "pane_id": c.PaneID,
+		"project": c.Project, "label": c.Label, "label_manual": c.LabelManual,
+	})
+}
+```
+
+(`hookAlias` currently takes the env-derived Capture — it already accepts a
+`tmuxenv.Capture` parameter, so it composes with the walked capture as-is.)
+
+Stop repair — in `hookStop`, after the `aliases := sessionAliasesForHook(...)` line and the ownership gate, before building the reason:
+
+```go
+	// Repair missing harness links (durable-alias spec: the stamp's Stop
+	// half). An alias registered via the MCP tool in an env carrying no
+	// harness UUID has no link for a future resume to find; every Stop
+	// payload carries the UUID, so stamp it here. This runs only when the
+	// mail gate above already opened — the cheap @muster_inbox check stays
+	// the sole decider of whether Stop dials the daemon at all, so a
+	// mail-less session costs nothing (documented residual: a link-less
+	// alias that never receives mail is never auto-stamped and rides the
+	// re-register-by-transcript contract instead).
+	stampHarnessLinks(aliases, harnessenv.FromHookPayload(payload), socketPath, sessionID)
+```
+
+with, as a new function in `hook.go`:
+
+```go
+// stampHarnessLinks attaches h.SessionID to every alias of MY tuple that
+// lacks a harness link. Best-effort per alias: a failed get or stamp is
+// skipped — hooks never block a session.
+func stampHarnessLinks(aliases []string, h harnessenv.Capture, socketPath, sessionID string) {
+	if h.SessionID == "" {
+		return
+	}
+	for _, alias := range aliases {
+		ag, ok := hookGetAgent(alias)
+		if !ok || ag.Departed || ag.HarnessSessionID != "" ||
+			ag.SocketPath != socketPath || ag.SessionID != sessionID {
+			continue
+		}
+		_, _ = callData("stamp_harness_session", map[string]any{
+			"alias": alias, "harness_session_id": h.SessionID,
+		})
+	}
+}
+```
+
+- [ ] **Step 4: Run the package** — `go test ./internal/humancli/ -race` — expect PASS (existing SessionStart tests must still pass: the extra flag is inert when the payload has no session_id and the env fallback is empty).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/humancli/hook.go internal/humancli/hook_test.go
+git commit -m "feat(hook): SessionStart carries the harness link; Stop repairs link-less aliases"
+```
+
+---
+
+### Task 7: Hooks — reclaim on SessionStart source:resume, summary into context
+
+**Files:**
+- Modify: `internal/humancli/hook.go` (cmdHook SessionStart branch), `internal/humancli/paneless.go` (new reclaim helper next to reviveRow)
+- Test: `internal/humancli/hook_test.go` (append)
+
+**Interfaces:**
+- Consumes: `harnessOwnedRows`, `tmuxenv.IsSessionAlive`, Task 3's `decodeRegisterAck`/`line`.
+- Produces: `hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model string, out io.Writer) bool`.
+
+- [ ] **Step 1: Write the failing test:**
+
+```go
+// TestHookSessionStartResumeReclaimsAlias is the durable-alias spec's core
+// scenario end to end: a conversation's alias was registered in a now-dead
+// tmux session (tombstoned), mail arrived, and the conversation is resumed
+// in a brand-new tmux session. The SessionStart hook with source:"resume"
+// must re-register the alias onto the NEW tuple and print a summary line
+// (which Claude Code injects into the session's context) naming the alias
+// and the backlog — and must NOT additionally register a fresh
+// session-name alias.
+func TestHookSessionStartResumeReclaimsAlias(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{
+		"alias": "backend-2", "socket_path": "/tmp/sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42", "label": "lake", "label_manual": true,
+	})
+	seed("register_agent", map[string]any{"alias": "sender", "socket_path": "/tmp/sock", "session_id": "$2"})
+	seed("send_message", map[string]any{"from": "sender", "to_kind": "agent", "to_target": "backend-2", "subject": "s", "body": "b"})
+	seed("deregister_agent", map[string]any{"alias": "backend-2"})
+
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}":      "$NEW",
+		"#{session_name}":    "muster-3",
+		"#{session_created}": "222",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "backend-2") || !strings.Contains(out, "1 unread") {
+		t.Fatalf("resume summary missing alias/backlog:\n%s", out)
+	}
+	ag, ok := hookGetAgent("backend-2")
+	if !ok || ag.Departed || ag.SessionID != "$NEW" || ag.Label != "lake" {
+		t.Fatalf("reclaimed row = %+v (found=%v), want live on $NEW with label kept", ag, ok)
+	}
+	if _, exists := hookGetAgent("muster-3"); exists {
+		t.Fatalf("resume must not also register a fresh session-name alias")
+	}
+}
+```
+
+(Check `tmuxenv.CaptureEnv`'s Run queries on the worktree and extend the `hookRun` map so socket/pane/project/label capture succeed — `tmuxenv_test.go` shows the exact format strings, including the `\x1f`-joined label/option query. Every format CaptureEnv asks for must return something coherent or empty.)
+
+- [ ] **Step 2: Run it** — expect FAIL (no summary; a `muster-3` row registered instead).
+
+- [ ] **Step 3: Implement.** In `cmdHook`'s SessionStart branch (as restructured by Task 6 — `hookCapture()` + `hookRegisterPane`), decode the source and try resume first:
+
+```go
+	case "SessionStart":
+		c := hookCapture()
+		h := harnessenv.FromHookPayload(payload)
+		var start struct {
+			Source string `json:"source"`
+		}
+		_ = json.Unmarshal(payload, &start)
+		if c.SocketPath != "" && c.PaneID != "" {
+			if start.Source == "resume" && hookSessionStartResume(c, h, model, out) {
+				return nil
+			}
+			if hookMayClaimIdentity(c) {
+				hookRegisterPane(c, h, model)
+			}
+		} else {
+			hookSessionStartPaneless(h, model)
+		}
+```
+
+New function in `hook.go`:
+
+```go
+// hookSessionStartResume reclaims a resumed conversation's aliases onto the
+// tmux session it woke up in (durable-alias spec change 4). The harness
+// session UUID is the lookup key — resume keeps it (only fork mints a new
+// one) — and harnessOwnedRows returns every row this conversation ever
+// registered. Each row is re-registered onto the CURRENT tuple (the revive
+// path: read-state survives, the daemon reports outcome+unread), EXCEPT a
+// row still live in a different, provably-alive tmux session — that is a
+// real collision (the old side's SessionEnd reason:"resume" normally
+// tombstones first), reported rather than clobbered. Returns true when at
+// least one alias was reclaimed: the caller then skips the default
+// session-name register — the conversation's identity IS the reclaimed one,
+// and minting a second alias would split it. Output goes to stdout, which
+// the harness injects into the session's context: the agent wakes up
+// knowing who it is and what's waiting.
+func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model string, out io.Writer) bool {
+	if h.SessionID == "" {
+		return false
+	}
+	reclaimed := 0
+	for _, ag := range harnessOwnedRows(h.SessionID) {
+		sameTuple := ag.SocketPath == c.SocketPath && ag.SessionID == c.SessionID
+		if !ag.Departed && !sameTuple && ag.SocketPath != "" &&
+			tmuxenv.IsSessionAlive(ag.SocketPath, ag.SessionID, ag.SessionCreated) {
+			fmt.Fprintf(out, "muster: alias '%s' is still live in another tmux session — not reclaimed\n", ag.Alias)
+			continue
+		}
+		ack := reclaimRow(ag, c, h.SessionID, model)
+		fmt.Fprintf(out, "muster: reconnected as '%s' (%s) — %d unread thread(s); call get_inbox with alias '%s'\n",
+			ag.Alias, ack.Outcome, ack.Unread, ag.Alias)
+		reclaimed++
+	}
+	return reclaimed > 0
+}
+```
+
+New function in `paneless.go`, next to `reviveRow` (same shape, but the tuple is the CURRENT capture — a reclaim moves the row; label/role travel with the conversation, per the spec: identity belongs to the conversation, and a manually-pinned label is part of it):
+
+```go
+// reclaimRow re-registers a conversation's row onto the tmux session it
+// resumed in: role, model, label, and harness link are echoed from the row
+// (they belong to the conversation), while the tuple is the CURRENT
+// capture's (the conversation moved). Contrast reviveRow, which echoes the
+// stored tuple back for an in-place revival.
+func reclaimRow(ag agentRow, c tmuxenv.Capture, harnessID, model string) registerAck {
+	if model == "" {
+		model = ag.ModelType
+	}
+	raw, _ := callData("register_agent", map[string]any{
+		"alias": ag.Alias, "role": ag.Role, "model_type": model,
+		"session_name": c.SessionName, "session_id": c.SessionID,
+		"session_created":    c.SessionCreated,
+		"harness_session_id": harnessID,
+		"socket_path":        c.SocketPath, "pane_id": c.PaneID,
+		"project": c.Project, "label": ag.Label, "label_manual": ag.LabelManual,
+	})
+	return decodeRegisterAck(raw)
+}
+```
+
+- [ ] **Step 4: Also cover the collision-skip branch** — append a second test seeding the row NON-departed on a different tuple with the `IsSessionAlive` probe answering alive (stub `tmuxenv.Run` so the `#{session_created}` probe for the OLD socket returns the row's stored `session_created` — read `tmuxenv.IsSessionAlive` on the worktree for the exact args it passes; `hook_test.go`'s existing liveness-stubbing tests show the pattern):
+
+```go
+// TestHookSessionStartResumeSkipsLiveCollision: a row still provably live in
+// another tmux session is reported, never clobbered — and with nothing
+// reclaimed the hook falls through to the normal session-name register.
+func TestHookSessionStartResumeSkipsLiveCollision(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "backend-2", "socket_path": "/other-sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		// The liveness probe against /other-sock/$OLD must confirm alive.
+		for _, a := range args {
+			if a == "/other-sock" {
+				return "111", nil
+			}
+		}
+		return hookRun(map[string]string{
+			"#{session_id}": "$NEW", "#{session_name}": "muster-3", "#{session_created}": "222",
+		})(args...)
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "not reclaimed") {
+		t.Fatalf("expected a collision notice, got:\n%s", buf.String())
+	}
+	ag, _ := hookGetAgent("backend-2")
+	if ag.SessionID != "$OLD" {
+		t.Fatalf("collision row moved to %q — must stay on $OLD", ag.SessionID)
+	}
+}
+```
+
+- [ ] **Step 5: Run the package** — `go test ./internal/humancli/ -race` — expect PASS, including all pre-existing SessionStart/Stop/paneless tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/humancli/hook.go internal/humancli/paneless.go internal/humancli/hook_test.go
+git commit -m "feat(hook): SessionStart source:resume reclaims the conversation's aliases with a context summary"
+```
+
+---
+
+### Task 8: Docs — skill and README teach alias-as-durable-identity
+
+**Files:**
+- Modify: `.claude/skills/muster-coordination/SKILL.md`, `README.md`
+
+**Interfaces:** none (prose only). Full sentences; explain, don't sell; no assumed context.
+
+- [ ] **Step 1: SKILL.md — three edits.**
+
+Replace the "Register once, at the start" section (lines 12–17) with:
+
+```markdown
+## Register at the start — and on resume
+
+Call `register_agent(alias, role, model_type)` once when your session begins.
+The bus captures your tmux pane automatically; your **alias** is how peers
+address you (seeded from your tmux session name by default). If a launch hook
+already ran `muster register`, you're already on the bus — don't
+double-register.
+
+Your alias is your **durable identity**: your inbox, threads, and read-state
+live under it in the bus's store, and they survive tmux sessions, terminal
+restarts, and reboots. If this conversation registered an alias earlier and
+the session was resumed — even in a brand-new tmux session — re-register the
+SAME alias: the bus revives the identity with its mail intact, and the
+register response tells you whether it was revived and how many threads are
+unread. (Under Claude Code the SessionStart hook does this reclaim for you
+and tells you your alias and backlog; re-registering by name is the fallback
+every harness has.)
+```
+
+In the Addressing section, replace the alias bullet (line 40):
+
+```markdown
+- **alias** — a peer's durable bus identity, globally unique: `send to
+  "backend-2"`. It is usually seeded from the tmux session name at first
+  registration, but it belongs to the conversation, not the terminal — it
+  keeps its inbox across tmux sessions.
+```
+
+- [ ] **Step 2: README — vocabulary sweep.** Run `grep -n "session name" README.md` in the worktree. For each hit that *defines* the alias as the tmux session name (the register/identity sections), rephrase to the seed-then-own model, e.g. "your alias defaults to your tmux session name at first registration" → "your alias is seeded from your tmux session name at first registration; thereafter it is the session's durable identity — re-registering the same alias from anywhere (including after a resume in a new tmux session) revives it with its inbox intact." Do not touch hits that merely *display* the session name (nudge output, station columns). Also add one sentence to the README's hooks section: "On `SessionStart` with `source:"resume"`, the hook reclaims every alias the resumed conversation owns onto the new tmux session and reports the unread backlog into the session's context."
+
+- [ ] **Step 3: Verify prose renders** — `just verify` still passes (docs don't affect it, but the commit gate is uniform).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/muster-coordination/SKILL.md README.md
+git commit -m "docs: alias is the durable identity; register on resume"
+```
+
+---
+
+### Task 9: Gate, PR, and live verification checklist
+
+- [ ] **Step 1:** `just verify` in the worktree — all green (trust CI over local if a local-only dependency error appears; read the CI log on failure).
+- [ ] **Step 2:** Push and open a PR to `dev` titled `feat: durable alias identity — register-on-resume reclaim`. Body: link the spec file, summarize the four changes, and note the residuals (Stop-stamp piggybacks on the mail gate; Codex rides the contract; Cursor payload fields to be verified empirically).
+- [ ] **Step 3 (operator-gated, post-merge):** live verification with the real binary — register an alias in a tmux session, send it mail from another session, kill the tmux session, `claude --resume` the conversation in a NEW tmux session, and confirm: the old row was tombstoned (SessionEnd), the SessionStart hook printed the "reconnected as … unread" summary into context, and `muster agents` shows the alias live on the new tuple. Also capture what `cursor-agent` hook payloads actually contain (the spec's open Cursor question) and post the findings — plus the final `whereami` verb name/flags — as an fyi reply on bus thread 149, where the dotfiles session is waiting to fold them into its hooks.json writers.
+- [ ] **Step 4:** VERSION bump rides a separate `chore/bump-*` PR on dev when the operator decides to release (per house release model).
+
+---
+
+## Self-review notes (spec ↔ plan)
+
+- Spec change 1 (outcome + unread + journal event) → Task 1; CLI/MCP surfaces → Tasks 3–4.
+- Spec change 2 (skill rewrite) → Task 8.
+- Spec change 3 (CLI default kept, vocabulary fixed) → Task 8 (no code change, by design).
+- Spec change 4 (stamp / release / reclaim) → ancestry capture + whereami: Task 5; stamp: Tasks 2, 4, 6; release: already shipped (v0.7.4 hookSessionEnd — no task); reclaim: Task 7.
+- Spec's ancestry-walk contract (4 invariants, shared with dotfiles by contract not by binary — thread 149) → Task 5; the fail-safe invariant is the tmuxenv test's second assertion.
+- Spec's "revival journal event" → Task 1 Step 3.
+- Spec's collision-skip rule → Task 7 Steps 3–4.
+- Hooks are env-stripped (verified, thread 149): both hook tasks route capture through `hookCapture()` (env, else ancestry walk), and Task 6's `hookRegisterPane` replaces the cmdRegister delegation, which would silently re-read the empty env. Hook tests that stub `$TMUX`/`tmuxenv.Run` exercise the env path; the walk path is covered in Task 5's tmuxenv tests.
+- Cursor payload verification + posting findings to bus thread 149 → Task 9 Step 3.
+- Paneless resume already revives via `hookSessionStartPaneless` (shipped in #74) — out of scope here except that `reviveRow` now returns an ack (Task 3), which paneless callers may ignore.

--- a/docs/superpowers/specs/2026-08-01-durable-alias-identity-design.md
+++ b/docs/superpowers/specs/2026-08-01-durable-alias-identity-design.md
@@ -1,0 +1,270 @@
+# Durable alias identity — design
+
+**Date:** 2026-08-01
+**Status:** proposed
+**Depends on:** label-first identity (v0.7.5), fyi replies / paneless agents (v0.7.7)
+
+## Problem
+
+An agent's inbox, threads, and read-state are keyed by **alias**, which is the
+right durable identity: it belongs to the *conversation* (the Claude Code /
+Codex / Cursor session), not to the terminal it happens to be running in. But
+two conventions currently bind the alias to the tmux session instead:
+
+1. The CLI's alias default is the tmux session name
+   (`internal/humancli/identity.go`: explicit arg → `$MUSTER_ALIAS` → tmux
+   session name), and
+2. the coordination skill *defines* alias as "a peer's tmux session name."
+
+The failure mode: an operator closes a tmux session, opens a new one, and
+resumes the same agent conversation (`claude --resume`, Codex resume, Cursor
+resume). The resumed session — the one that actually holds the context the
+inbox belongs to — arrives in a tmux session with a different name. If
+anything leans on the tmux-name default, the agent registers under a fresh
+alias and its inbox, threads, and unread cursor are orphaned under the old
+one.
+
+## Decision
+
+Make the **alias-first contract** explicit and self-reinforcing, with **no
+per-harness glue**. The durable identity anchor is the alias itself, reclaimed
+by re-registration; the mechanism every resumable harness already carries
+across a tmux swap is the conversation transcript, which contains "I
+registered as `backend-2`."
+
+Explicitly rejected: anchoring identity on a harness session ID as the
+*required* identity mechanism (Codex would require scraping
+`~/.codex/sessions`; Cursor exposes nothing dependable). That path builds a
+first-class experience for one harness and a permanently degraded one for the
+other two, and adds an adapter per future harness.
+
+What IS in scope (change 4): **hook-layer reclaim glue** where a harness hands
+us its session ID for free in a hook payload — Claude Code does, in every
+hook event. The glue is strictly additive: the contract (changes 1–3) is the
+identity mechanism on every harness; the glue automates it where the hooks
+allow. The daemon stays harness-agnostic — it stores the harness session ID
+as an opaque string it never interprets; only the hook layer
+(`internal/humancli`) reads or writes it.
+
+## What already works (no changes)
+
+- `store.RegisterAgent` upserts by alias and always resets `departed=0`, so
+  re-registering a tombstoned alias revives it. Read-state
+  (`last_read_entry_id`/`last_read_at`) is untouched by both branches, so the
+  unread cursor survives the roundtrip (`internal/store/agents.go`).
+- The tmux tuple (`socket_path`, `session_id`, `session_created`, `pane_id`,
+  `session_name`) is re-captured wholesale on every register — it is liveness
+  and wake plumbing, stamped per registration, never identity.
+- The MCP register path's pane guard (`tools_registry.go`) checks the *current
+  pane's* registration, so a resumed session in a brand-new pane re-registers
+  its old alias without conflict.
+- Ghost reaping and `muster gc` tombstone the old registration when the old
+  tmux session dies. Tombstoning is a soft delete precisely so revival works;
+  no change to those semantics.
+
+## Changes
+
+### 1. `register_agent` reports what happened (daemon + MCP + CLI)
+
+Today the register response is a bare "registered `<alias>`" regardless of
+whether the row was new, refreshed, or revived. `handleRegisterAgent` already
+reads the pre-mutation row (`old`, `hadOld`) for reconciliation, so it can
+classify the outcome without an extra query:
+
+- **new** — no prior row: `registered <alias>`.
+- **refreshed** — prior row, not departed: `re-registered <alias>` (tuple
+  refreshed).
+- **revived** — prior row with `departed=1`: `reconnected as <alias> — revived
+  departed registration`.
+
+On the *refreshed* and *revived* outcomes, the response also carries the
+agent's pending-inbox count, computed by the same query `get_inbox` uses. This
+closes the resume loop in one call: a resumed session re-registers and is told
+"you have 3 unread thread(s)" — a direct prompt to run `get_inbox` — instead
+of discovering its backlog only at the next Stop-hook wake. The daemon returns
+`{outcome, unread}` structured fields; the MCP tool folds them into
+`OKOut.Detail`; the CLI prints them after its existing "registered …" line.
+
+A revival also logs a journal event (existing `logEvent` path, the register
+kind with a "revived" detail) so `muster watch` and station surfaces show a
+returning agent as *returned*, not as a ghost that got lucky.
+
+### 2. The skill teaches the contract (`.claude/skills/muster-coordination`)
+
+Three edits, no new sections beyond one:
+
+- **"Register once, at the start" → "Register at the start — and on resume."**
+  The alias is the session's durable identity on the bus: it survives tmux
+  sessions, terminal restarts, and machine reboots, because the inbox and
+  read-state live under it in the daemon's store. If this conversation
+  previously registered an alias, re-register **the same alias** when the
+  session resumes — even (especially) if the tmux session around it is new.
+  The register response says whether the identity was revived and how much
+  mail is waiting.
+- **Addressing:** redefine the alias bullet from "a peer's tmux session name"
+  to "a peer's durable bus identity, globally unique — often *seeded from* the
+  tmux session name at first registration, but owned by the conversation
+  thereafter."
+- **Alias choice guidance:** pick an alias that names the *work*, not the
+  terminal (the default tmux-name seed is fine when the session name is
+  already meaningful).
+
+### 3. CLI default: keep the seed, fix the vocabulary
+
+The `muster register` fallback chain (explicit arg → `$MUSTER_ALIAS` → tmux
+session name) **stays**. It is a *seed* for first registration — operators
+name their tmux sessions meaningfully, and the human CLI's identity defaults
+elsewhere (hooks resolve aliases by tuple, not name, so a divergent alias
+already works). What changes is the documentation: README and help text stop
+*defining* the alias as the tmux session name and instead describe the
+seed-then-own model above. No behavior change, so nothing existing breaks.
+
+### 4. Hook-layer reclaim: register-on-resume, automated where possible
+
+Register-on-resume is the biggest driver of this design, so where the harness
+gives the hook layer enough signal, the reclaim happens without the model
+having to remember anything. Verified facts this leans on (Claude Code docs +
+live verification by the dotfiles session, thread 149, 2026-08-01):
+
+- Resume (`--resume`, `--continue`, `/resume`) reopens the session under the
+  **same `session_id`**; only fork (`--fork-session`, `/branch`) mints a new
+  one. So the harness session ID is a stable key for one conversation.
+- Every hook payload (SessionStart, Stop, SessionEnd) carries `session_id`.
+  SessionStart additionally carries `source`
+  (`startup|resume|clear|compact|fork`); SessionEnd carries `reason`, which is
+  `"resume"` when the session was resumed *somewhere else*.
+- SessionStart hook **stdout is added to the session's context** — the hook
+  can tell the resumed agent who it is directly.
+- Hooks run in a **stripped environment** — `$TMUX`/`$TMUX_PANE` are unset —
+  but the *session* process itself does see them on a pane launch (verified
+  live on claude 2.1.220; the dotfiles wrapper's "daemon-forks sessions"
+  comment is stale). A hook therefore cannot read its pane from env, but it
+  CAN locate it by walking its own process ancestry (hook → claude → pane
+  shell) until a PID matches a tmux pane's `#{pane_pid}` — the technique
+  dotfiles ships today in `config/claude/claude-notify.sh`. The walk requires
+  the hook to run synchronously (async reparents the hook and breaks the
+  chain) and fails safe: no match → behave paneless, never guess.
+- Rejected: a pane-side hint keyed by cwd (wrapper writes tuple to kv at
+  resume launch, hook consumes it). Two sessions in one directory is normal
+  on this machine (live counterexample: bettor-help-workspace-4 and -6 in the
+  same checkout), so a cwd key mis-delivers. No cwd fallbacks anywhere in
+  this design.
+
+The pane-side wrapper (dotfiles `04-aliases.zsh`) stays exactly as it is: on
+a fresh tmux launch it mints the UUID, pre-registers the tmux session's name
+with `--harness-session`, and passes `--session-id` — so fresh launches have
+the harness link from birth. It deliberately skips `--resume`/`--continue`:
+on an interactive resume the UUID is unknowable before exec, which is exactly
+why reclaim is the hook layer's job.
+
+**Ancestry capture: one implementation per product, aligned by contract.**
+Within muster, the walk joins `internal/tmuxenv` (the capture owner, per the
+one-canonical-module rule) — but that rule is intra-repo, not cross-product.
+Dotfiles keeps its own implementation (extracted from `claude-notify.sh`) so
+the two products stay independently installable: neither may become a hard
+runtime dependency of the other (settled on thread 149). What is shared is
+the **contract**, four invariants both implementations must hold:
+
+1. Walk the parent chain outward from the hook process.
+2. Match PIDs against `list-panes -aF '#{pane_pid} …'` across the
+   `proj-*` sockets — per-project tmux servers mean a single-socket lookup
+   silently misses.
+3. First match wins; stop there.
+4. Fail safe: no match → empty result and paneless behavior — never a
+   broadcast to all panes, never a cwd-derived guess (two sessions in one
+   directory is normal).
+
+Muster additionally exposes the walk as a CLI verb, working name
+**`muster whereami`** (tuple on stdout, `--json` for structure, empty +
+nonzero exit when no pane matches) — for muster's own hooks and as an
+operator convenience, NOT as a dependency dotfiles consumes.
+
+Mechanism, three parts, all in the hook layer:
+
+**Stamping.** A new opaque `harness_session_id` column on the agent row,
+written via `register_agent` (new optional field) and a small
+`stamp_harness_session` op. Two writers: (a) `muster hook SessionStart` —
+which today ignores stdin — now decodes the payload and passes the harness
+session ID through its auto-register; (b) the Stop hook, which already
+resolves the session's full alias list by tuple (`session_aliases`), stamps
+any owned alias that lacks the ID. Path (b) is what covers custom aliases
+registered through the MCP tool mid-session — the MCP server never sees the
+harness session ID, and doesn't need to; the next Stop event repairs the
+mapping. Stamp only when unset or changed: no write traffic in the steady
+state.
+
+**Release.** Already shipped, no change: SessionEnd (including
+`reason:"resume"` — the old side of a resume) tombstones every alias the
+dying pane owns via the existing ownership predicate (`hookSessionEnd`,
+v0.7.4). The old registration frees the alias at the exact moment the new
+side wants it.
+
+**Reclaim.** `muster hook SessionStart` with `source:"resume"`: resolve the
+CURRENT pane via env capture when present, else the tmuxenv ancestry walk
+(hooks are env-stripped, above); look up aliases by the payload's
+`session_id` (`harnessOwnedRows` — the client-side lookup shipped with
+paneless agents; no new daemon op needed), and for each one re-register it
+with the *current* tmux tuple. That's the existing revive
+path; change 1's outcome/unread response feeds the last step: the hook prints
+a plain-text summary — "reconnected as 'backend-2' (revived) — 3 unread
+thread(s); call get_inbox" — which SessionStart injects into the resumed
+conversation's context. The agent wakes up knowing who it is and what's
+waiting, with zero reliance on transcript memory. Safety: before stealing an
+alias, apply the same client-side liveness check the hooks already use — a
+row that is live under a *different* tuple and a different harness session ID
+is a real collision, so skip it and say so in the hook output rather than
+clobber (`hookMayClaimIdentity`'s cross-session takeover arm already encodes
+the precedent).
+
+Harness matrix:
+
+| Harness | Stamp | Release | Reclaim |
+|---|---|---|---|
+| Claude Code | SessionStart + Stop payloads | SessionEnd (incl. `reason:resume`) | SessionStart `source:resume`, output injected into context |
+| Cursor | verify: hook payload fields undocumented — build only what its payload carries | ditto | ditto, else contract |
+| Codex | none (no hook payload with a session ID) | first-turn register convention | contract only: re-register by transcript memory |
+
+Codex losing the glue is acceptable by design — the contract still works
+there, exactly as it does everywhere. The Cursor column is an empirical
+question (its harness support landed in v0.7.7; its hook payload fields are
+undocumented) — resolve it during implementation against the real
+`cursor-agent`, and if its payloads carry no stable session ID, Cursor rides
+the contract like Codex. Never scrape a harness's session store from a hook.
+
+## Non-goals
+
+- Harness session IDs as a *required* identity mechanism, or any scraping of
+  a harness's session store (`~/.codex/sessions`, Cursor internals). The only
+  sanctioned source is a hook payload that hands the ID over directly.
+- Daemon-side guessing: the daemon never decides a new registration "is" an
+  old agent. Reclaim is always an explicit re-register by alias — the hook
+  layer merely automates issuing it.
+- Changes to ghost reaping, gc, tombstone semantics, or the wake model.
+
+## Test surface
+
+- Daemon: register outcome classification (new / refreshed / revived) and the
+  unread count on refresh/revive; revival journal event emitted.
+- MCP: `OKOut.Detail` carries outcome + unread on revive.
+- CLI: register output prints outcome + unread; existing default-alias
+  precedence tests unchanged (behavior is unchanged).
+- Store: (existing) revival preserves read-state — already covered; extend if
+  the outcome classification moves any logic into the store. New:
+  `harness_session_id` column round-trip + `harness_aliases` lookup.
+- Hooks: SessionStart decodes payload (tolerant of empty/invalid stdin, as
+  hookStop already is); `source:resume` reclaims stamped aliases and prints
+  the context summary; `source:startup` stamps through register; Stop stamps
+  owned aliases lacking the ID; collision (live different-tuple,
+  different-harness-ID row) is skipped with a message, never clobbered.
+- Live verification during implementation: real `claude --resume` into a
+  fresh tmux session end-to-end (old side releases via SessionEnd
+  reason:resume, new side reclaims, unread summary lands in context), and an
+  empirical check of what `cursor-agent` hook payloads actually carry.
+
+## Implementation note
+
+Cut the feature worktree from **origin/dev** — the primary clone's dev lags
+(known trap; v0.7.7's fyi/paneless/Cursor work is on origin, and this
+document's file/line references were read against the stale local checkout;
+re-verify against origin/dev when building, especially `hook.go`, which
+gained a Cursor loop guard in the #78 back-merge).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -43,6 +43,7 @@ type storeAPI interface {
 	Threads(limit int) ([]store.Thread, error)
 	Inbox(alias string) ([]store.Thread, error)
 	MarkRead(alias string) error
+	UnreadCount(alias string) (int, error)
 	SessionUnread(socketPath, sessionID string) (total, action int, err error)
 	KVSet(key, value, updatedBy string) error
 	KVGet(key string) (store.KVPair, bool, error)
@@ -249,7 +250,26 @@ func (d *Daemon) handleRegisterAgent(a map[string]any) proto.Response {
 		d.reconcileBadge(old.SocketPath, old.SessionID)
 	}
 	d.reconcileBadge(newAgent.SocketPath, newAgent.SessionID)
-	return ok(nil)
+	// Outcome classification (durable-alias spec change 1): the pre-mutation
+	// row read above already tells this apart for free — no prior row is a
+	// first sight, a live prior row is a tuple refresh, and a tombstone is a
+	// returning session (RegisterAgent's upsert just revived it). The unread
+	// count rides along so a resuming session learns its backlog in the same
+	// call; a count failure degrades to 0 rather than failing a register that
+	// already succeeded.
+	outcome := "new"
+	switch {
+	case hadOld && old.Departed:
+		outcome = "revived"
+		d.logEvent(store.Event{Kind: "register", Agent: alias, Detail: "revived"})
+	case hadOld:
+		outcome = "refreshed"
+	}
+	unread, err := d.s.UnreadCount(alias)
+	if err != nil {
+		unread = 0
+	}
+	return ok(map[string]any{"outcome": outcome, "unread": unread})
 }
 
 // setSessionBadge is the ONE canonical {recompute, push} sequence for a

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -34,6 +34,7 @@ type storeAPI interface {
 	DepartAgent(alias string) error
 	DepartStaleSiblings(socketPath, sessionID string, created int64, keepAlias string) ([]string, error)
 	SetSessionLabel(socketPath, sessionID, label string, manual bool) (int64, error)
+	SetHarnessSessionID(alias, id string) error
 	DeleteAgent(alias string) error
 	CreateThread(t store.Thread, firstBody string) (int64, error)
 	AppendEntry(threadID int64, fromAgent, body, statusChange string) (int64, error)
@@ -754,6 +755,11 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			return fail(err)
 		}
 		return ok(map[string]any{"updated": n})
+	case "stamp_harness_session":
+		if err := d.s.SetHarnessSessionID(str(a, "alias"), str(a, "harness_session_id")); err != nil {
+			return fail(err)
+		}
+		return ok(nil)
 	case "purge_agent":
 		// The explicit, irreversible hard-delete: `muster gc --purge-agents`'s
 		// own op, distinct from deregister_agent's tombstone. Identity,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -458,3 +458,24 @@ func TestListEventsMaxIDAndFollow(t *testing.T) {
 		t.Fatalf("follow from 0: %+v", out)
 	}
 }
+
+// TestStampHarnessSession covers the stamp op end to end: register without a
+// harness link, stamp, and see the link in list_agents.
+func TestStampHarnessSession(t *testing.T) {
+	sock := startWithNotifier(t, &fakeNotifier{})
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/s", "session_id": "$1",
+	})
+	resp := call(t, sock, "stamp_harness_session", map[string]any{
+		"alias": "backend", "harness_session_id": "uuid-1",
+	})
+	if !resp.OK {
+		t.Fatalf("stamp: %+v", resp)
+	}
+	list := call(t, sock, "list_agents", nil)
+	rows, _ := list.Data.([]any)
+	m, _ := rows[0].(map[string]any)
+	if m["harness_session_id"] != "uuid-1" {
+		t.Fatalf("harness_session_id = %v, want uuid-1", m["harness_session_id"])
+	}
+}

--- a/internal/daemon/register_outcome_test.go
+++ b/internal/daemon/register_outcome_test.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/schuettc/muster/internal/proto"
+)
+
+// TestRegisterAgentOutcomeClassification covers the three register outcomes
+// the durable-alias spec defines: a first-sight alias is "new", an upsert
+// over a live row is "refreshed", and an upsert over a tombstone is
+// "revived" — with the response carrying the alias's unread count so a
+// resuming session learns its backlog in the same call.
+func TestRegisterAgentOutcomeClassification(t *testing.T) {
+	sock := startWithNotifier(t, &fakeNotifier{})
+
+	resp := call(t, sock, "register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/s", "session_id": "$1",
+	})
+	if !resp.OK {
+		t.Fatalf("register: %+v", resp)
+	}
+	data, _ := resp.Data.(map[string]any)
+	if data["outcome"] != "new" {
+		t.Fatalf("first register outcome = %v, want new", data["outcome"])
+	}
+
+	resp = call(t, sock, "register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/s", "session_id": "$1",
+	})
+	data, _ = resp.Data.(map[string]any)
+	if data["outcome"] != "refreshed" {
+		t.Fatalf("re-register outcome = %v, want refreshed", data["outcome"])
+	}
+
+	// Mail lands while the agent is departed; revival must report it.
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/s", "session_id": "$2",
+	})
+	call(t, sock, "send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "backend",
+		"subject": "while you were away", "body": "ping",
+	})
+	call(t, sock, "deregister_agent", map[string]any{"alias": "backend"})
+
+	resp = call(t, sock, "register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/s3", "session_id": "$9",
+	})
+	data, _ = resp.Data.(map[string]any)
+	if data["outcome"] != "revived" {
+		t.Fatalf("revival outcome = %v, want revived", data["outcome"])
+	}
+	if n, _ := data["unread"].(float64); n < 1 {
+		t.Fatalf("revival unread = %v, want >= 1", data["unread"])
+	}
+
+	// Revival is journaled so watch/station show a returning agent.
+	ev := call(t, sock, "list_events", map[string]any{"agent": "backend"})
+	if !containsEventDetail(t, ev, "register", "revived") {
+		t.Fatalf("no register/revived journal event after revival: %+v", ev.Data)
+	}
+}
+
+// containsEventDetail decodes list_events' response — {"events": [...],
+// "max_id": ...} over the wire, each event row a map[string]any — and
+// reports whether any row matches the given kind/detail pair.
+func containsEventDetail(t *testing.T, resp proto.Response, kind, detail string) bool {
+	t.Helper()
+	data, _ := resp.Data.(map[string]any)
+	rows, _ := data["events"].([]any)
+	for _, r := range rows {
+		m, _ := r.(map[string]any)
+		if m["kind"] == kind && m["detail"] == detail {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -42,7 +42,14 @@ func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
 	case "SessionStart":
 		c := hookCapture()
 		h := harnessenv.FromHookPayload(payload)
+		var start struct {
+			Source string `json:"source"`
+		}
+		_ = json.Unmarshal(payload, &start)
 		if c.SocketPath != "" && c.PaneID != "" {
+			if start.Source == "resume" && hookSessionStartResume(c, h, model, out) {
+				return nil
+			}
 			if hookMayClaimIdentity(c) {
 				hookRegisterPane(c, h, model)
 			}
@@ -86,6 +93,40 @@ func hookRegisterPane(c tmuxenv.Capture, h harnessenv.Capture, model string) {
 		"socket_path":        c.SocketPath, "pane_id": c.PaneID,
 		"project": c.Project, "label": c.Label, "label_manual": c.LabelManual,
 	})
+}
+
+// hookSessionStartResume reclaims a resumed conversation's aliases onto the
+// tmux session it woke up in (durable-alias spec change 4). The harness
+// session UUID is the lookup key — resume keeps it (only fork mints a new
+// one) — and harnessOwnedRows returns every row this conversation ever
+// registered. Each row is re-registered onto the CURRENT tuple (the revive
+// path: read-state survives, the daemon reports outcome+unread), EXCEPT a
+// row still live in a different, provably-alive tmux session — that is a
+// real collision (the old side's SessionEnd reason:"resume" normally
+// tombstones first), reported rather than clobbered. Returns true when at
+// least one alias was reclaimed: the caller then skips the default
+// session-name register — the conversation's identity IS the reclaimed one,
+// and minting a second alias would split it. Output goes to stdout, which
+// the harness injects into the session's context: the agent wakes up
+// knowing who it is and what's waiting.
+func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model string, out io.Writer) bool {
+	if h.SessionID == "" {
+		return false
+	}
+	reclaimed := 0
+	for _, ag := range harnessOwnedRows(h.SessionID) {
+		sameTuple := ag.SocketPath == c.SocketPath && ag.SessionID == c.SessionID
+		if !ag.Departed && !sameTuple && ag.SocketPath != "" &&
+			tmuxenv.IsSessionAlive(ag.SocketPath, ag.SessionID, ag.SessionCreated) {
+			_, _ = fmt.Fprintf(out, "muster: alias '%s' is still live in another tmux session — not reclaimed\n", ag.Alias)
+			continue
+		}
+		ack := reclaimRow(ag, c, h.SessionID, model)
+		_, _ = fmt.Fprintf(out, "muster: reconnected as '%s' (%s) — %d unread thread(s); call get_inbox with alias '%s'\n",
+			ag.Alias, ack.Outcome, ack.Unread, ag.Alias)
+		reclaimed++
+	}
+	return reclaimed > 0
 }
 
 // hookSessionStartPaneless auto-registers a session that has no tmux pane in

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -40,13 +40,14 @@ func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
 	payload, _ := io.ReadAll(io.LimitReader(stdin, 1<<20)) // a hook payload is small; the cap only guards a pathological writer
 	switch args[0] {
 	case "SessionStart":
-		c := tmuxenv.CaptureEnv()
+		c := hookCapture()
+		h := harnessenv.FromHookPayload(payload)
 		if c.SocketPath != "" && c.PaneID != "" {
 			if hookMayClaimIdentity(c) {
-				_ = cmdRegister([]string{"--model", model}, io.Discard)
+				hookRegisterPane(c, h, model)
 			}
 		} else {
-			hookSessionStartPaneless(harnessenv.FromHookPayload(payload), model)
+			hookSessionStartPaneless(h, model)
 		}
 	case "SessionEnd":
 		hookSessionEnd(tmuxenv.CaptureEnv(), harnessenv.FromHookPayload(payload))
@@ -54,6 +55,37 @@ func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
 		hookStop(payload, out)
 	}
 	return nil
+}
+
+// hookCapture resolves the tmux identity a hook acts on: the environment
+// when the harness passed it through, else the process-ancestry walk —
+// hooks are spawned env-stripped, but a synchronous hook is still a
+// descendant of its pane's shell (see tmuxenv.CaptureFromAncestry). The
+// zero Capture (both paths empty) means genuinely paneless.
+func hookCapture() tmuxenv.Capture {
+	if c := tmuxenv.CaptureEnv(); c.SocketPath != "" && c.PaneID != "" {
+		return c
+	}
+	return tmuxenv.CaptureFromAncestry()
+}
+
+// hookRegisterPane registers the session-name alias for a pane-anchored
+// SessionStart. It cannot delegate to cmdRegister: that reads the tmux
+// identity from the ENVIRONMENT, which a stripped hook doesn't have — the
+// capture c (env or ancestry walk) is the truth here.
+func hookRegisterPane(c tmuxenv.Capture, h harnessenv.Capture, model string) {
+	alias := hookAlias(c)
+	if alias == "" {
+		return
+	}
+	_, _ = callData("register_agent", map[string]any{
+		"alias": alias, "role": "", "model_type": model,
+		"session_name": c.SessionName, "session_id": c.SessionID,
+		"session_created":    c.SessionCreated,
+		"harness_session_id": h.SessionID,
+		"socket_path":        c.SocketPath, "pane_id": c.PaneID,
+		"project": c.Project, "label": c.Label, "label_manual": c.LabelManual,
+	})
 }
 
 // hookSessionStartPaneless auto-registers a session that has no tmux pane in
@@ -294,6 +326,17 @@ func hookStop(payload []byte, out io.Writer) {
 	}
 	aliases := sessionAliasesForHook(socketPath, sessionID)
 
+	// Repair missing harness links (durable-alias spec: the stamp's Stop
+	// half). An alias registered via the MCP tool in an env carrying no
+	// harness UUID has no link for a future resume to find; every Stop
+	// payload carries the UUID, so stamp it here. This runs only when the
+	// mail gate above already opened — the cheap @muster_inbox check stays
+	// the sole decider of whether Stop dials the daemon at all, so a
+	// mail-less session costs nothing (documented residual: a link-less
+	// alias that never receives mail is never auto-stamped and rides the
+	// re-register-by-transcript contract instead).
+	stampHarnessLinks(aliases, harnessenv.FromHookPayload(payload), socketPath, sessionID)
+
 	if !hookStopOwnsAnyAlias(aliases) {
 		return // roster names a live owner and it isn't me: don't drain a sibling's mail
 	}
@@ -357,6 +400,25 @@ func hookStopPaneless(h harnessenv.Capture, out io.Writer) {
 		return
 	}
 	_, _ = fmt.Fprintln(out, string(b)) // best-effort: a hook's stdout write failing has nowhere to report to
+}
+
+// stampHarnessLinks attaches h.SessionID to every alias of MY tuple that
+// lacks a harness link. Best-effort per alias: a failed get or stamp is
+// skipped — hooks never block a session.
+func stampHarnessLinks(aliases []string, h harnessenv.Capture, socketPath, sessionID string) {
+	if h.SessionID == "" {
+		return
+	}
+	for _, alias := range aliases {
+		ag, ok := hookGetAgent(alias)
+		if !ok || ag.Departed || ag.HarnessSessionID != "" ||
+			ag.SocketPath != socketPath || ag.SessionID != sessionID {
+			continue
+		}
+		_, _ = callData("stamp_harness_session", map[string]any{
+			"alias": alias, "harness_session_id": h.SessionID,
+		})
+	}
 }
 
 // sessionAliasesForHook calls the session_aliases op and returns the sorted,

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -57,7 +57,15 @@ func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
 			hookSessionStartPaneless(h, model)
 		}
 	case "SessionEnd":
-		hookSessionEnd(tmuxenv.CaptureEnv(), harnessenv.FromHookPayload(payload))
+		// hookCapture, not tmuxenv.CaptureEnv: SessionEnd hooks run
+		// env-stripped in production exactly like every other hook (see
+		// hookCapture's doc comment), so CaptureEnv alone always came back
+		// empty and every dying session took the paneless branch — the
+		// ancestry-walk fallback is what lets a pane-anchored dying session
+		// resolve ITS tuple, which is what scopes hookSessionEnd's tombstone
+		// sweep to that tuple instead of every alias the harness session
+		// ever registered (finding F2).
+		hookSessionEnd(hookCapture(), harnessenv.FromHookPayload(payload))
 	case "Stop":
 		hookStop(payload, out)
 	}
@@ -269,9 +277,22 @@ func hookSessionEnd(c tmuxenv.Capture, h harnessenv.Capture) {
 // — handshake-registered tmux rows and paneless rows alike (harnessOwnedRows'
 // two match shapes). Rows of other sessions, or with no harness link at all
 // (pre-handshake registrations), are never this session's to tombstone.
+//
+// Belt-and-suspenders (finding F2): harnessOwnedRows keys purely on the
+// harness session UUID, with no tuple discrimination. In the resume
+// coexistence window — SessionEnd(reason:"resume") fires for the OLD side
+// while the NEW side has already registered its row under the SAME UUID on
+// a NEW tuple — that lookup returns both, and an unqualified sweep would
+// tombstone the new side's live registration out from under it. A row still
+// provably alive on its own tmux tuple (mirroring the reclaim collision
+// check in hookSessionStartResume) is therefore skipped: it belongs to
+// someone else's still-running session, not this dying one.
 func hookSessionEndPaneless(h harnessenv.Capture) {
 	for _, ag := range harnessOwnedRows(h.SessionID) {
 		if ag.Departed {
+			continue
+		}
+		if ag.SocketPath != "" && tmuxenv.IsSessionAlive(ag.SocketPath, ag.SessionID, ag.SessionCreated) {
 			continue
 		}
 		_ = cmdDeregister([]string{ag.Alias}, io.Discard)
@@ -328,15 +349,15 @@ type stopReason struct {
 // read/decode failures, a missing tmux, or a missing/non-numeric/zero count
 // all fall through to "print nothing".
 //
-// The @muster_inbox option remains the cheap FIRING gate (spec §3): only when
-// it reads > 0 does the hook go on to call the daemon at all. From there it
-// captures the (socket_path, session_id) tuple and asks the daemon for the
-// session's full alias list (session_aliases) and its true unread/action
-// counts (session_unread) — a session with a split identity (a tmux-name
-// alias plus a chosen one) must drain both, not just the alias the hook
-// happened to read the option from. Either call's failure (or an empty
-// alias list) falls back to today's single session-name behavior so the
-// hook never goes silent because of a daemon hiccup.
+// Identity resolution mirrors hookCapture's env-else-walk (finding F1): a
+// harness that passed $TMUX through gets the exact ambient-query behavior
+// this hook has always had (hookStopTmuxEnv); a harness that stripped it
+// (the production case — every hook is spawned env-stripped) falls to the
+// process-ancestry walk (hookStopWalked), and only when BOTH come back empty
+// does the session count as genuinely paneless (hookStopPaneless). Before
+// this fix, hookStop gated on the literal $TMUX env var alone, so it ALWAYS
+// took the paneless branch in production and stampHarnessLinks (the resume
+// spec's repair path, below) never ran.
 func hookStop(payload []byte, out io.Writer) {
 	var in stopInput
 	_ = json.Unmarshal(payload, &in) // invalid/empty JSON -> zero value (false)
@@ -346,18 +367,62 @@ func hookStop(payload []byte, out io.Writer) {
 	if in.Status == "aborted" || in.Status == "error" {
 		return
 	}
-	if os.Getenv("TMUX") == "" {
-		hookStopPaneless(harnessenv.FromHookPayload(payload), out)
+
+	h := harnessenv.FromHookPayload(payload)
+
+	if os.Getenv("TMUX") != "" {
+		hookStopTmuxEnv(h, out)
 		return
 	}
+	if c := tmuxenv.CaptureFromAncestry(); c.SocketPath != "" && c.PaneID != "" {
+		hookStopWalked(c, h, out)
+		return
+	}
+	hookStopPaneless(h, out)
+}
+
+// hookStopTmuxEnv is hookStop's tmux path when the harness passed $TMUX
+// through — unchanged from before finding F1: the (socket_path, session_id)
+// tuple and the @muster_inbox cheap gate both read from the AMBIENT tmux
+// session (no -S/-t), relying on $TMUX/$TMUX_PANE in the process
+// environment.
+func hookStopTmuxEnv(h harnessenv.Capture, out io.Writer) {
 	optCount, err := strconv.Atoi(tmuxenv.CurrentSessionOption("@muster_inbox"))
 	if err != nil || optCount <= 0 {
 		return // cheap gate: no daemon calls unless the tmux option says there's mail
 	}
-
 	socketPath := tmuxenv.SocketFromEnv()
 	sessionID := tmuxenv.CurrentSessionID()
+	label := tmuxenv.CurrentSessionOption(tmuxenv.LabelOption())
+	hookStopDrain(socketPath, sessionID, os.Getenv("TMUX_PANE"), optCount, label, h, out)
+}
 
+// hookStopWalked is finding F1's new branch: the harness stripped $TMUX from
+// the hook's environment, but the process-ancestry walk (the same fallback
+// hookCapture uses) still located the pane. tmuxenv.CurrentSessionOption,
+// SocketFromEnv, and CurrentSessionID are all env-dependent and would read
+// nothing here — every tmux read instead goes through the socket-aware query
+// seam (tmuxenv.SessionOption / SessionLabel) against the WALKED capture's
+// own tuple, never the (absent) ambient environment.
+func hookStopWalked(c tmuxenv.Capture, h harnessenv.Capture, out io.Writer) {
+	optCount, err := strconv.Atoi(tmuxenv.SessionOption(c.SocketPath, c.PaneID, "@muster_inbox"))
+	if err != nil || optCount <= 0 {
+		return // cheap gate: no daemon calls unless the tmux option says there's mail
+	}
+	label, _ := tmuxenv.SessionLabel(c.SocketPath, c.PaneID)
+	hookStopDrain(c.SocketPath, c.SessionID, c.PaneID, optCount, label, h, out)
+}
+
+// hookStopDrain is the daemon-facing core shared by hookStopTmuxEnv and
+// hookStopWalked: given a resolved (socket_path, session_id, pane) tuple and
+// the cheap gate's option count, it asks the daemon for the session's full
+// alias list (session_aliases) and its true unread/action counts
+// (session_unread) — a session with a split identity (a tmux-name alias plus
+// a chosen one) must drain both, not just the alias the hook happened to
+// read the option from. Either call's failure (or an empty alias list) falls
+// back to today's single session-name behavior so the hook never goes silent
+// because of a daemon hiccup.
+func hookStopDrain(socketPath, sessionID, myPane string, optCount int, label string, h harnessenv.Capture, out io.Writer) {
 	total, action, ok := sessionUnreadForHook(socketPath, sessionID)
 	if !ok {
 		total, action = optCount, 0 // fall back to the tmux option value on op failure
@@ -376,13 +441,12 @@ func hookStop(payload []byte, out io.Writer) {
 	// mail-less session costs nothing (documented residual: a link-less
 	// alias that never receives mail is never auto-stamped and rides the
 	// re-register-by-transcript contract instead).
-	stampHarnessLinks(aliases, harnessenv.FromHookPayload(payload), socketPath, sessionID)
+	stampHarnessLinks(aliases, h, socketPath, sessionID, myPane)
 
-	if !hookStopOwnsAnyAlias(aliases) {
+	if !hookStopOwnsAnyAlias(aliases, myPane) {
 		return // roster names a live owner and it isn't me: don't drain a sibling's mail
 	}
 
-	label := tmuxenv.CurrentSessionOption(tmuxenv.LabelOption())
 	reason := hookReason(total, action, aliases, label)
 	b, err := json.Marshal(stopReason{Decision: "block", Reason: reason})
 	if err != nil {
@@ -446,7 +510,15 @@ func hookStopPaneless(h harnessenv.Capture, out io.Writer) {
 // stampHarnessLinks attaches h.SessionID to every alias of MY tuple that
 // lacks a harness link. Best-effort per alias: a failed get or stamp is
 // skipped — hooks never block a session.
-func stampHarnessLinks(aliases []string, h harnessenv.Capture, socketPath, sessionID string) {
+//
+// myPane scopes the stamp to panes THIS hook actually is (finding F3): two
+// agent panes can share one tmux session, and without the pane check pane
+// A's Stop would stamp A's harness UUID onto sibling pane B's link-less
+// alias — mirroring the pane predicate hookOwnsIdentity already applies to
+// deregistration. A row with no stored pane_id carries no ownership
+// information (same convention as hookOwnsIdentity/hookStopOwnsAnyAlias) and
+// is never skipped on that basis alone.
+func stampHarnessLinks(aliases []string, h harnessenv.Capture, socketPath, sessionID, myPane string) {
 	if h.SessionID == "" {
 		return
 	}
@@ -455,6 +527,9 @@ func stampHarnessLinks(aliases []string, h harnessenv.Capture, socketPath, sessi
 		if !ok || ag.Departed || ag.HarnessSessionID != "" ||
 			ag.SocketPath != socketPath || ag.SessionID != sessionID {
 			continue
+		}
+		if ag.PaneID != "" && ag.PaneID != myPane {
+			continue // a sibling pane's alias: not mine to stamp
 		}
 		_, _ = callData("stamp_harness_session", map[string]any{
 			"alias": alias, "harness_session_id": h.SessionID,
@@ -502,11 +577,13 @@ func sessionUnreadForHook(socketPath, sessionID string) (total, action int, ok b
 // is a named owner. It resolves each alias's stored pane_id via get_agent —
 // cheap, local, at most a couple of daemon round trips — and engages ONLY
 // when the roster actually names a live pane_id for at least one alias and
-// none of them is mine. An empty $TMUX_PANE, an unresolvable roster, or every
+// none of them is mine. An empty myPane, an unresolvable roster, or every
 // alias having no stored pane_id all mean the roster can't name an owner, so
-// this falls through to true — today's unconditional drain.
-func hookStopOwnsAnyAlias(aliases []string) bool {
-	myPane := os.Getenv("TMUX_PANE")
+// this falls through to true — today's unconditional drain. myPane is the
+// caller's resolved pane (ambient $TMUX_PANE, or the ancestry walk's pane for
+// an env-stripped hook) — not read from the environment here, so the walked
+// path (finding F1) can supply its own.
+func hookStopOwnsAnyAlias(aliases []string, myPane string) bool {
 	if myPane == "" {
 		return true
 	}

--- a/internal/humancli/hook_test.go
+++ b/internal/humancli/hook_test.go
@@ -3,10 +3,14 @@ package humancli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/schuettc/muster/internal/harnessenv"
 	"github.com/schuettc/muster/internal/mustertest"
 	"github.com/schuettc/muster/internal/tmuxenv"
 )
@@ -45,6 +49,12 @@ func TestHookStopNoTmux(t *testing.T) {
 	// inside a Claude session whose CLAUDE_CODE_SESSION_ID would otherwise
 	// give this "no identity" scenario a paneless identity and a daemon dial.
 	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	// Pin the ancestry-walk fallback away too (finding F1 made hookStop try
+	// it when $TMUX is empty): on a dev machine `go test` itself commonly
+	// runs inside a real tmux pane, and without this the walk could resolve
+	// that real pane and turn this "genuinely paneless" test into the tmux
+	// path.
+	pinAncestryWalkAway(t)
 	var buf bytes.Buffer
 	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{}`), &buf); err != nil {
 		t.Fatal(err)
@@ -884,6 +894,13 @@ func TestHookSessionEndUnresolvableIdentityNeverDialsDaemon(t *testing.T) {
 	// identity (the paneless tuple) and dialing would be correct — this test
 	// is specifically about the no-identity-at-all branch.
 	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	// Pin the ancestry-walk fallback away too (finding F2 routes SessionEnd
+	// through hookCapture, which tries this walk when $TMUX is empty): on a
+	// dev machine `go test` itself commonly runs inside a real tmux pane,
+	// and a resolved walk would legitimately have a tuple to dial the
+	// daemon about — this test is specifically about the walk ALSO coming
+	// back empty.
+	pinAncestryWalkAway(t)
 
 	done := make(chan error, 1)
 	go func() {
@@ -966,6 +983,160 @@ func TestHookStopStampsHarnessLink(t *testing.T) {
 	ag, ok := hookGetAgent("backend")
 	if !ok || ag.HarnessSessionID != "uuid-9" {
 		t.Fatalf("harness link after Stop = %q (found=%v), want uuid-9", ag.HarnessSessionID, ok)
+	}
+}
+
+// stubAncestryWalkToPane makes tmuxenv.CaptureFromAncestry resolve a single
+// fake pane on socket, the way a hook spawned env-stripped but still a
+// descendant of its pane's shell would (see ancestry_test.go's own
+// TestCaptureFromAncestryMatchesPanePID for the same list-panes shape). Any
+// display-message query not explicitly stubbed in extra falls through to "".
+// Returns the socket path CaptureFromAncestry will actually report — a
+// full temp-dir path, not the caller's nominal name, since the walk reports
+// whatever it globbed.
+func stubAncestryWalkToPane(t *testing.T, paneID, sessionID, sessionName string, sessionCreated int64, extra map[string]string) string {
+	t.Helper()
+	prevAnc, prevDir, prevRun := tmuxenv.AncestorPIDs, tmuxenv.SocketDir, tmuxenv.Run
+	t.Cleanup(func() { tmuxenv.AncestorPIDs, tmuxenv.SocketDir, tmuxenv.Run = prevAnc, prevDir, prevRun })
+
+	const fakePID = 4242
+	tmuxenv.AncestorPIDs = func() []int { return []int{fakePID} }
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "proj-walk"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tmuxenv.SocketDir = func() string { return dir }
+	sock := filepath.Join(dir, "proj-walk")
+
+	tmuxenv.Run = func(args ...string) (string, error) {
+		for _, a := range args {
+			if a == "list-panes" {
+				return fmt.Sprintf("%d\t%s\t%s\t%s\t%d", fakePID, paneID, sessionID, sessionName, sessionCreated), nil
+			}
+		}
+		last := args[len(args)-1]
+		if v, ok := extra[last]; ok {
+			return v, nil
+		}
+		return "", nil
+	}
+	return sock
+}
+
+// TestHookStopRepairsHarnessLinkViaAncestryWalk covers finding F1 end to end:
+// a harness spawns the Stop hook with $TMUX stripped (the production shape —
+// every harness hook runs env-stripped), and the ONLY way to resolve tmux
+// identity is the process-ancestry walk hookCapture already uses for
+// SessionStart. Before the fix, hookStop gated on the literal $TMUX env var
+// and ALWAYS took the paneless branch here, so it could never see the mail,
+// never emit the drain decision, and never run stampHarnessLinks (the
+// resume spec's repair path) — this alias would stay linkless forever.
+func TestHookStopRepairsHarnessLinkViaAncestryWalk(t *testing.T) {
+	startTestDaemon(t)
+	sock := stubAncestryWalkToPane(t, "%7", "$3", "muster-walk", 555, map[string]string{
+		"#{@muster_inbox}": "1",
+	})
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "walked-backend", "socket_path": sock, "session_id": "$3", "pane_id": "%7",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/tmp/otherWalk", "session_id": "$4",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "walked-backend", "subject": "s", "body": "b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{"session_id":"uuid-walk"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "alias 'walked-backend'") {
+		t.Fatalf("expected the walked pane's Stop to drain, got %q", buf.String())
+	}
+	ag, ok := hookGetAgent("walked-backend")
+	if !ok || ag.HarnessSessionID != "uuid-walk" {
+		t.Fatalf("harness link after walked Stop = %q (found=%v), want uuid-walk", ag.HarnessSessionID, ok)
+	}
+}
+
+// TestHookStopWalkedSilentWhenNoUnread covers the walked path's cheap gate
+// (finding F1): the @muster_inbox option read socket-aware against the
+// walked tuple must still gate the daemon calls — a walked pane with no mail
+// must produce no output and no stamp attempt.
+func TestHookStopWalkedSilentWhenNoUnread(t *testing.T) {
+	startTestDaemon(t)
+	stubAncestryWalkToPane(t, "%7", "$3", "muster-walk", 555, nil) // "@muster_inbox" unstubbed -> ""
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected silence with no unread mail, got %q", buf.String())
+	}
+}
+
+// TestStampHarnessLinksScopesToOwnedPane covers finding F3: two agent panes
+// sharing one tmux session (a primary plus a subagent pane, say) must not
+// have one pane's Stop hook stamp its harness UUID onto a SIBLING pane's
+// link-less alias. Only the calling pane's own alias gets stamped; the
+// sibling's stays link-less.
+func TestStampHarnessLinksScopesToOwnedPane(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sockPane,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "mine", "socket_path": "/tmp/sockPane", "session_id": "$1", "pane_id": "%1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "sibling", "socket_path": "/tmp/sockPane", "session_id": "$1", "pane_id": "%2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/tmp/otherPane", "session_id": "$2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "mine", "subject": "s", "body": "b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"@muster_inbox":   "1",
+		"#{session_id}":   "$1",
+		"#{session_name}": "mine",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	// stampHarnessLinks only ever looks at aliases session_aliases returns
+	// (both, since they share the tuple) — call it directly to isolate F3
+	// from Stop's ownership gate (hookStopOwnsAnyAlias), which is a separate
+	// concern already covered elsewhere.
+	stampHarnessLinks([]string{"mine", "sibling"}, harnessenv.Capture{SessionID: "uuid-pane"}, "/tmp/sockPane", "$1", "%1")
+
+	mine, _ := hookGetAgent("mine")
+	sibling, _ := hookGetAgent("sibling")
+	if mine.HarnessSessionID != "uuid-pane" {
+		t.Fatalf("my own alias must be stamped, got %+v", mine)
+	}
+	if sibling.HarnessSessionID != "" {
+		t.Fatalf("a sibling pane's alias must NOT be stamped, got %+v", sibling)
 	}
 }
 
@@ -1059,5 +1230,8 @@ func TestHookSessionStartResumeSkipsLiveCollision(t *testing.T) {
 	ag, _ := hookGetAgent("backend-2")
 	if ag.SessionID != "$OLD" {
 		t.Fatalf("collision row moved to %q — must stay on $OLD", ag.SessionID)
+	}
+	if fallback, found := hookGetAgent("muster-3"); !found || fallback.Departed || fallback.SessionID != "$NEW" {
+		t.Fatalf("nothing reclaimed: expected the default session-name alias 'muster-3' registered on $NEW, got %+v found=%v", fallback, found)
 	}
 }

--- a/internal/humancli/hook_test.go
+++ b/internal/humancli/hook_test.go
@@ -968,3 +968,96 @@ func TestHookStopStampsHarnessLink(t *testing.T) {
 		t.Fatalf("harness link after Stop = %q (found=%v), want uuid-9", ag.HarnessSessionID, ok)
 	}
 }
+
+// TestHookSessionStartResumeReclaimsAlias is the durable-alias spec's core
+// scenario end to end: a conversation's alias was registered in a now-dead
+// tmux session (tombstoned), mail arrived, and the conversation is resumed
+// in a brand-new tmux session. The SessionStart hook with source:"resume"
+// must re-register the alias onto the NEW tuple and print a summary line
+// (which Claude Code injects into the session's context) naming the alias
+// and the backlog — and must NOT additionally register a fresh
+// session-name alias.
+func TestHookSessionStartResumeReclaimsAlias(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{
+		"alias": "backend-2", "socket_path": "/tmp/sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42", "label": "lake", "label_manual": true,
+	})
+	seed("register_agent", map[string]any{"alias": "sender", "socket_path": "/tmp/sock", "session_id": "$2"})
+	seed("send_message", map[string]any{"from": "sender", "to_kind": "agent", "to_target": "backend-2", "subject": "s", "body": "b"})
+	seed("deregister_agent", map[string]any{"alias": "backend-2"})
+
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}":      "$NEW",
+		"#{session_name}":    "muster-3",
+		"#{session_created}": "222",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "backend-2") || !strings.Contains(out, "1 unread") {
+		t.Fatalf("resume summary missing alias/backlog:\n%s", out)
+	}
+	ag, ok := hookGetAgent("backend-2")
+	if !ok || ag.Departed || ag.SessionID != "$NEW" || ag.Label != "lake" {
+		t.Fatalf("reclaimed row = %+v (found=%v), want live on $NEW with label kept", ag, ok)
+	}
+	if _, exists := hookGetAgent("muster-3"); exists {
+		t.Fatalf("resume must not also register a fresh session-name alias")
+	}
+}
+
+// TestHookSessionStartResumeSkipsLiveCollision: a row still provably live in
+// another tmux session is reported, never clobbered — and with nothing
+// reclaimed the hook falls through to the normal session-name register.
+func TestHookSessionStartResumeSkipsLiveCollision(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "backend-2", "socket_path": "/other-sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		// The liveness probe against /other-sock/$OLD must confirm alive.
+		for _, a := range args {
+			if a == "/other-sock" {
+				return "111", nil
+			}
+		}
+		return hookRun(map[string]string{
+			"#{session_id}": "$NEW", "#{session_name}": "muster-3", "#{session_created}": "222",
+		})(args...)
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "not reclaimed") {
+		t.Fatalf("expected a collision notice, got:\n%s", buf.String())
+	}
+	ag, _ := hookGetAgent("backend-2")
+	if ag.SessionID != "$OLD" {
+		t.Fatalf("collision row moved to %q — must stay on $OLD", ag.SessionID)
+	}
+}

--- a/internal/humancli/hook_test.go
+++ b/internal/humancli/hook_test.go
@@ -763,6 +763,7 @@ func TestHookSessionStartBestEffortWhenDaemonUnreachable(t *testing.T) {
 	t.Setenv("TMUX_PANE", "")
 	t.Setenv("MUSTER_ALIAS", "")
 	t.Setenv("CLAUDE_CODE_SESSION_ID", "") // pin: a dev machine's own Claude session must not lend this test an identity
+	pinAncestryWalkAway(t)                 // pin: hookCapture's ancestry fallback must not resolve this test process's real tmux pane
 	var buf bytes.Buffer
 	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(""), &buf); err != nil {
 		t.Fatalf("hook must never return an error, got %v", err)
@@ -923,5 +924,47 @@ func TestHookReasonMultiAliasWithLabel(t *testing.T) {
 	got := hookReason(3, 0, []string{"timewalk-2", "timewalk-2002"}, "standard 2000")
 	if !strings.Contains(got, "You are 'standard 2000' — muster aliases 'timewalk-2', 'timewalk-2002'") {
 		t.Fatalf("multi-alias reason must lead with the label, got %q", got)
+	}
+}
+
+// TestHookStopStampsHarnessLink covers the repair half of the durable-alias
+// spec: a custom alias registered via the MCP tool (no harness link) gets the
+// payload's session_id stamped when the Stop hook fires for real mail — so a
+// later resume can find the row. The stamp piggybacks on the mail gate: no
+// mail, no daemon dials, no stamp.
+func TestHookStopStampsHarnessLink(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "backend", "socket_path": "/tmp/sock", "session_id": "$1", "pane_id": "%1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "sender", "socket_path": "/tmp/sock", "session_id": "$2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{
+		"from": "sender", "to_kind": "agent", "to_target": "backend", "subject": "s", "body": "b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"@muster_inbox":   "1",
+		"#{session_id}":   "$1",
+		"#{session_name}": "backend",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{"session_id":"uuid-9"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	ag, ok := hookGetAgent("backend")
+	if !ok || ag.HarnessSessionID != "uuid-9" {
+		t.Fatalf("harness link after Stop = %q (found=%v), want uuid-9", ag.HarnessSessionID, ok)
 	}
 }

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -31,6 +31,10 @@ type agentFull struct {
 	PaneID      string `json:"pane_id"`
 	SessionID   string `json:"session_id"`
 	SessionName string `json:"session_name"`
+	// HarnessSessionID mirrors agentRow's own copy (see store.Agent.HarnessSessionID)
+	// — stampHarnessLinks reads it via hookGetAgent to skip a row that already
+	// has a link.
+	HarnessSessionID string `json:"harness_session_id"`
 	// Departed mirrors store.Agent.Departed (see agentRow's own copy above):
 	// get_agent returns tombstoned rows with found=true, so hook gates must
 	// decode this to tell a live owner from a dead one.

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -39,6 +39,9 @@ type agentFull struct {
 	// get_agent returns tombstoned rows with found=true, so hook gates must
 	// decode this to tell a live owner from a dead one.
 	Departed bool `json:"departed"`
+	// Label mirrors agentRow's own copy — the resume reclaim test asserts a
+	// manually-pinned label survives the reclaim onto the new tuple.
+	Label string `json:"label"`
 }
 
 type agentRow struct {

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -83,9 +83,14 @@ func cmdRegister(args []string, out io.Writer) error {
 			// prior paneless one): refresh/revive it with its stored shape
 			// intact rather than allocating another.
 			alias = owned[0].Alias
-			reviveRow(owned[0], *model)
-			_, err := fmt.Fprintf(out, "registered %s (existing identity, project %q, model %s)\n", alias, owned[0].Project, *model)
-			return err
+			ack := reviveRow(owned[0], *model)
+			if _, err := fmt.Fprintf(out, "registered %s (existing identity, project %q, model %s)\n", alias, owned[0].Project, *model); err != nil {
+				return err
+			}
+			if s := ack.line(alias); s != "" {
+				_, _ = fmt.Fprint(out, s)
+			}
+			return nil
 		}
 		var err error
 		if alias, err = allocPanelessAlias(h.Alias(), h.SessionID, regFn); err != nil {
@@ -116,22 +121,30 @@ func cmdRegister(args []string, out io.Writer) error {
 	if harnessID == "" {
 		harnessID = h.SessionID
 	}
-	if _, err := callData("register_agent", map[string]any{
+	raw, err := callData("register_agent", map[string]any{
 		"alias": alias, "role": *role, "model_type": *model,
 		"session_name": sessionName, "session_id": sessionID,
 		"session_created":    created,
 		"harness_session_id": harnessID,
 		"socket_path":        socketPath, "pane_id": paneID,
 		"project": project, "label": c.Label, "label_manual": c.LabelManual,
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 	shape := ""
 	if paneless {
 		shape = "paneless, "
 	}
-	_, err := fmt.Fprintf(out, "registered %s (%sproject %q, model %s)\n", alias, shape, project, *model)
-	return err
+	if _, err := fmt.Fprintf(out, "registered %s (%sproject %q, model %s)\n", alias, shape, project, *model); err != nil {
+		return err
+	}
+	if s := decodeRegisterAck(raw).line(alias); s != "" {
+		if _, err := fmt.Fprint(out, s); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // cmdDeregister removes an agent's registration. Alias precedence mirrors

--- a/internal/humancli/identity_test.go
+++ b/internal/humancli/identity_test.go
@@ -266,3 +266,33 @@ func TestGCRejectsNonPositiveEventsKeep(t *testing.T) {
 		t.Fatalf("expected --events-keep must be > 0 error, got %v", err)
 	}
 }
+
+// TestRegisterPrintsRevivalAndUnread covers the resume loop's CLI surface:
+// re-registering a departed alias that accrued mail must say so, so the
+// operator (or a resumed agent using the CLI) learns the backlog in the
+// same command.
+func TestRegisterPrintsRevivalAndUnread(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("MUSTER_ALIAS", "")
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{"alias": "backend", "socket_path": "/s", "session_id": "$1"})
+	seed("register_agent", map[string]any{"alias": "sender", "socket_path": "/s", "session_id": "$2"})
+	seed("send_message", map[string]any{"from": "sender", "to_kind": "agent", "to_target": "backend", "subject": "hi", "body": "b"})
+	seed("deregister_agent", map[string]any{"alias": "backend"})
+
+	var buf bytes.Buffer
+	if err := cmdRegister([]string{"backend"}, &buf); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "revived") || !strings.Contains(out, "1 unread") {
+		t.Fatalf("register output missing revival/unread notice:\n%s", out)
+	}
+}

--- a/internal/humancli/paneless.go
+++ b/internal/humancli/paneless.go
@@ -137,3 +137,23 @@ func reviveRow(ag agentRow, model string) registerAck {
 	})
 	return decodeRegisterAck(raw)
 }
+
+// reclaimRow re-registers a conversation's row onto the tmux session it
+// resumed in: role, model, label, and harness link are echoed from the row
+// (they belong to the conversation), while the tuple is the CURRENT
+// capture's (the conversation moved). Contrast reviveRow, which echoes the
+// stored tuple back for an in-place revival.
+func reclaimRow(ag agentRow, c tmuxenv.Capture, harnessID, model string) registerAck {
+	if model == "" {
+		model = ag.ModelType
+	}
+	raw, _ := callData("register_agent", map[string]any{
+		"alias": ag.Alias, "role": ag.Role, "model_type": model,
+		"session_name": c.SessionName, "session_id": c.SessionID,
+		"session_created":    c.SessionCreated,
+		"harness_session_id": harnessID,
+		"socket_path":        c.SocketPath, "pane_id": c.PaneID,
+		"project": c.Project, "label": ag.Label, "label_manual": ag.LabelManual,
+	})
+	return decodeRegisterAck(raw)
+}

--- a/internal/humancli/paneless.go
+++ b/internal/humancli/paneless.go
@@ -119,12 +119,15 @@ func harnessOwnedRows(uuid string) []agentRow {
 
 // reviveRow re-registers a tombstoned row echoing back its own stored
 // identity — tuple, harness link, project, label — so revival never rewrites
-// what the row already knows about itself.
-func reviveRow(ag agentRow, model string) {
+// what the row already knows about itself. Returns the daemon's ack (outcome
+// + unread) so callers that want to surface it can; callers that don't care
+// may call this as a bare statement — Go permits discarding a value-returning
+// function's result.
+func reviveRow(ag agentRow, model string) registerAck {
 	if model == "" {
 		model = ag.ModelType
 	}
-	_, _ = callData("register_agent", map[string]any{
+	raw, _ := callData("register_agent", map[string]any{
 		"alias": ag.Alias, "role": ag.Role, "model_type": model,
 		"session_name": ag.SessionName, "session_id": ag.SessionID,
 		"session_created":    ag.SessionCreated,
@@ -132,4 +135,5 @@ func reviveRow(ag agentRow, model string) {
 		"socket_path":        ag.SocketPath, "pane_id": ag.PaneID,
 		"project": ag.Project, "label": ag.Label, "label_manual": ag.LabelManual,
 	})
+	return decodeRegisterAck(raw)
 }

--- a/internal/humancli/paneless_test.go
+++ b/internal/humancli/paneless_test.go
@@ -213,6 +213,65 @@ func TestHookSessionEndPanelessReapsOnlyOwnAliases(t *testing.T) {
 	}
 }
 
+// TestHookSessionEndPanelessSparesLiveOtherTuple is finding F2's core
+// scenario: the resume-coexistence race. harnessOwnedRows keys purely on the
+// harness session UUID with no tuple discrimination, so a dying paneless
+// SessionEnd that enumerates them could tombstone a DIFFERENT alias's row
+// that a concurrent resume has already reclaimed onto a brand-new, live tmux
+// tuple sharing the same UUID. The belt-and-suspenders check
+// (tmuxenv.IsSessionAlive, mirroring hookSessionStartResume's own collision
+// predicate) must spare that provably-alive row while still tombstoning the
+// dying tuple's own (paneless, unqueryable) row. Contrast
+// TestLaunchHandshakeLifecycle, which pins the mirror case: a row whose tmux
+// tuple is genuinely gone must still be tombstoned as before.
+func TestHookSessionEndPanelessSparesLiveOtherTuple(t *testing.T) {
+	startTestDaemon(t)
+	seed := func(args map[string]any) {
+		t.Helper()
+		if _, err := callData("register_agent", args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The dying side: a paneless row (no tmux tuple to probe at all).
+	seed(map[string]any{
+		"alias": "race-old", "socket_path": "", "session_id": "uuid-race",
+		"harness_session_id": "uuid-race",
+	})
+	// The other side: already reclaimed onto a brand-new, live tmux tuple,
+	// sharing the SAME harness UUID (the reclaim race's live half).
+	seed(map[string]any{
+		"alias": "race-new", "socket_path": "/tmp/sockRace", "session_id": "$9",
+		"session_created": 777, "harness_session_id": "uuid-race",
+	})
+
+	panelessEnv(t, "uuid-race", "race-dir")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		for _, a := range args {
+			if a == "/tmp/sockRace" {
+				return "777", nil // IsSessionAlive: matches the stored created time -> alive
+			}
+		}
+		return "", fmt.Errorf("gone")
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionEnd"}, strings.NewReader(`{"session_id":"uuid-race"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	departed := map[string]bool{}
+	for _, a := range listAgentsForTest(t, "") {
+		departed[a.Alias] = a.Departed
+	}
+	if !departed["race-old"] {
+		t.Fatalf("the dying (paneless) tuple's row must still be tombstoned, got %+v", departed)
+	}
+	if departed["race-new"] {
+		t.Fatalf("a provably-live other-tuple row sharing the UUID must survive the race, got %+v", departed)
+	}
+}
+
 func TestHookStopPanelessBlocksOnUnread(t *testing.T) {
 	startTestDaemon(t)
 	if _, err := callData("register_agent", map[string]any{
@@ -361,6 +420,13 @@ func TestLaunchHandshakeLifecycle(t *testing.T) {
 		t.Fatalf("Stop must address the handshake alias and lead with its label, got %q", stop.String())
 	}
 
+	// By the time the daemon-hosted session's own SessionEnd fires, the
+	// launching pane has actually closed too (a realistic teardown order,
+	// and the ordinary case finding F2's belt-and-suspenders IsSessionAlive
+	// check must still let through) — every tmux probe now answers "gone".
+	// Contrast TestHookSessionEndPanelessSparesLiveOtherTuple, which pins the
+	// OTHER half: a tuple that IS still alive must survive.
+	tmuxenv.Run = func(_ ...string) (string, error) { return "", fmt.Errorf("pane closed") }
 	if err := cmdHook([]string{"SessionEnd"}, strings.NewReader(payload), &buf); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/humancli/paneless_test.go
+++ b/internal/humancli/paneless_test.go
@@ -12,17 +12,35 @@ import (
 	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
+// pinAncestryWalkAway neuters tmuxenv.CaptureFromAncestry for the duration of
+// a test by making its two seams find nothing: no ancestor PIDs, no socket
+// directory to glob. Without this, a paneless test (empty $TMUX/$TMUX_PANE)
+// leaves hookCapture() falling through to the REAL ancestry walk — and on a
+// dev machine, `go test` itself commonly runs inside a real tmux pane (e.g. a
+// coding-agent session on the muster bus), so the walk can find that real
+// pane and turn an intended paneless SessionStart into a pane-anchored one.
+func pinAncestryWalkAway(t *testing.T) {
+	t.Helper()
+	prevAnc, prevDir := tmuxenv.AncestorPIDs, tmuxenv.SocketDir
+	tmuxenv.AncestorPIDs = func() []int { return nil }
+	tmuxenv.SocketDir = func() string { return t.TempDir() } // fresh empty dir: Glob matches nothing
+	t.Cleanup(func() { tmuxenv.AncestorPIDs, tmuxenv.SocketDir = prevAnc, prevDir })
+}
+
 // panelessEnv pins the process into a paneless shape: no tmux, a known
 // harness session UUID, and a working directory whose basename is the
 // expected fallback alias. CLAUDE_CODE_SESSION_ID must be pinned in every
 // paneless test — on a dev machine `go test` itself runs inside a Claude
-// session whose UUID would otherwise leak in.
+// session whose UUID would otherwise leak in. Also pins the ancestry-walk
+// seams away (see pinAncestryWalkAway) so hookCapture()'s fallback can't
+// resolve this test process's real tmux pane.
 func panelessEnv(t *testing.T, uuid, dirName string) string {
 	t.Helper()
 	t.Setenv("TMUX", "")
 	t.Setenv("TMUX_PANE", "")
 	t.Setenv("MUSTER_ALIAS", "")
 	t.Setenv("CLAUDE_CODE_SESSION_ID", uuid)
+	pinAncestryWalkAway(t)
 	dir := filepath.Join(t.TempDir(), dirName)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/humancli/register_ack.go
+++ b/internal/humancli/register_ack.go
@@ -1,0 +1,38 @@
+package humancli
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// registerAck decodes register_agent's response data (durable-alias spec
+// change 1): how the daemon classified this registration, and the alias's
+// unread-thread count at that moment.
+type registerAck struct {
+	Outcome string `json:"outcome"`
+	Unread  int    `json:"unread"`
+}
+
+// decodeRegisterAck tolerantly decodes a register_agent response. A daemon
+// predating the outcome field (or any decode failure) yields the zero value,
+// whose line() renders nothing — callers degrade to today's output.
+func decodeRegisterAck(raw json.RawMessage) registerAck {
+	var a registerAck
+	_ = json.Unmarshal(raw, &a)
+	return a
+}
+
+// line renders the human-facing follow-up for a registration worth
+// remarking on: a revival, or pending mail. "" for an unremarkable new or
+// refreshed registration with an empty inbox — the existing "registered X"
+// line already says everything.
+func (a registerAck) line(alias string) string {
+	if a.Outcome != "revived" && a.Unread == 0 {
+		return ""
+	}
+	msg := fmt.Sprintf("reconnected: identity '%s' %s", alias, a.Outcome)
+	if a.Unread > 0 {
+		msg += fmt.Sprintf(" — %d unread thread(s); run `muster inbox '%s'`", a.Unread, alias)
+	}
+	return msg + "\n"
+}

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -247,6 +247,20 @@ from tmux (internal/tmuxenv) so other commands can address it.`,
 			Run:      cmdLabel,
 		},
 		{
+			Name:     "whereami",
+			Synopsis: "whereami [--json]",
+			Summary:  "Print the tmux identity of the pane this process runs under.",
+			Help: `Resolves via $TMUX when present, else by walking process ancestry (works
+inside env-stripped harness hooks). For muster's own hooks and operator
+convenience. Prints "socket=<path> session_id=<id> session_name=<name>
+pane=<id> created=<ts>" (one line); --json emits the same fields as a JSON
+object. Empty stdout and a nonzero exit when no pane resolves — never a
+cwd guess.`,
+			Group:    GroupIdentity,
+			NewFlags: newWhereamiFlags,
+			Run:      cmdWhereami,
+		},
+		{
 			Name:     "gc",
 			Synopsis: "gc [--events-keep <dur>] [--purge-agents]",
 			Summary:  "Reap dead agents and prune old journal events.",

--- a/internal/humancli/registry_test.go
+++ b/internal/humancli/registry_test.go
@@ -16,7 +16,7 @@ import (
 var wantCommandNames = []string{
 	"send", "nudge", "reply",
 	"agents", "inbox", "tasks", "thread", "events", "watch", "station",
-	"register", "deregister", "label", "gc",
+	"register", "deregister", "label", "whereami", "gc",
 	"serve", "mcp", "hook", "debug",
 }
 

--- a/internal/humancli/whereami.go
+++ b/internal/humancli/whereami.go
@@ -1,0 +1,77 @@
+package humancli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// newWhereamiFlagsWithVals declares whereami's flags and returns typed
+// access to their values — shared by cmdWhereami (real parsing) and
+// newWhereamiFlags (registry help/man rendering).
+func newWhereamiFlagsWithVals() (fs *flag.FlagSet, jsonOut *bool) {
+	fs = flag.NewFlagSet("whereami", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut = fs.Bool("json", false, "print a JSON object instead of the one-line tuple")
+	return fs, jsonOut
+}
+
+// newWhereamiFlags builds whereami's flag.FlagSet for registry-driven
+// help/man rendering.
+func newWhereamiFlags() *flag.FlagSet {
+	fs, _ := newWhereamiFlagsWithVals()
+	return fs
+}
+
+// whereamiJSON is the --json shape for `muster whereami`.
+type whereamiJSON struct {
+	SocketPath  string `json:"socket_path"`
+	SessionID   string `json:"session_id"`
+	SessionName string `json:"session_name"`
+	PaneID      string `json:"pane_id"`
+	Created     int64  `json:"session_created"`
+}
+
+// cmdWhereami prints the tmux identity of the pane this process runs under:
+// $TMUX/$TMUX_PANE first (tmuxenv.CaptureEnv), falling back to the process-
+// ancestry walk (tmuxenv.CaptureFromAncestry) when the environment is
+// stripped, as it is inside an agent harness's hooks. Fails with a non-nil
+// error and no stdout when neither resolves — never a cwd guess (the same
+// fail-safe posture CaptureFromAncestry itself commits to).
+func cmdWhereami(args []string, out io.Writer) error {
+	fs, jsonOut := newWhereamiFlagsWithVals()
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("whereami", out)
+		}
+		return err
+	}
+	c := tmuxenv.CaptureEnv()
+	if c.SocketPath == "" || c.PaneID == "" {
+		c = tmuxenv.CaptureFromAncestry()
+	}
+	if c.SocketPath == "" || c.PaneID == "" {
+		return fmt.Errorf("whereami: no tmux pane resolved (not in tmux, and no ancestor pid matched a pane)")
+	}
+	if *jsonOut {
+		b, err := json.Marshal(whereamiJSON{
+			SocketPath:  c.SocketPath,
+			SessionID:   c.SessionID,
+			SessionName: c.SessionName,
+			PaneID:      c.PaneID,
+			Created:     c.SessionCreated,
+		})
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(out, string(b))
+		return err
+	}
+	_, err := fmt.Fprintf(out, "socket=%s session_id=%s session_name=%s pane=%s created=%d\n",
+		c.SocketPath, c.SessionID, c.SessionName, c.PaneID, c.SessionCreated)
+	return err
+}

--- a/internal/humancli/whereami_test.go
+++ b/internal/humancli/whereami_test.go
@@ -1,0 +1,76 @@
+package humancli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// stubAncestryMatch wires AncestorPIDs/SocketDir/Run so the ancestry walk
+// resolves pane %7 / $3 / muster-2 / created 555 on a fake proj-muster
+// socket — the same fixture tmuxenv's own ancestry test uses.
+func stubAncestryMatch(t *testing.T) {
+	t.Helper()
+	prevRun, prevAnc, prevDir := tmuxenv.Run, tmuxenv.AncestorPIDs, tmuxenv.SocketDir
+	t.Cleanup(func() { tmuxenv.Run, tmuxenv.AncestorPIDs, tmuxenv.SocketDir = prevRun, prevAnc, prevDir })
+
+	tmuxenv.AncestorPIDs = func() []int { return []int{999, 4242, 1} }
+	tmuxenv.Run = func(args ...string) (string, error) {
+		for _, a := range args {
+			if filepath.Base(a) == "proj-muster" {
+				for _, x := range args {
+					if x == "list-panes" {
+						return "4242\t%7\t$3\tmuster-2\t555", nil
+					}
+				}
+			}
+		}
+		return "", nil
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "proj-muster"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tmuxenv.SocketDir = func() string { return dir }
+}
+
+// TestWhereamiPrintsResolvedTuple: the verb is the walk's CLI face, for
+// muster's own hooks and operators (dotfiles keeps its own walk — the two
+// share a behavioral contract, not a binary; thread 149).
+func TestWhereamiPrintsResolvedTuple(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	stubAncestryMatch(t)
+
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"whereami"}, &buf); err != nil {
+		t.Fatalf("whereami: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"session_id=$3", "pane=%7", "session_name=muster-2"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("whereami output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestWhereamiFailsWhenUnresolvable: no env, no ancestry match → empty
+// stdout and a non-nil error (the CLI maps it to a nonzero exit).
+func TestWhereamiFailsWhenUnresolvable(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+	prevRun, prevAnc, prevDir := tmuxenv.Run, tmuxenv.AncestorPIDs, tmuxenv.SocketDir
+	t.Cleanup(func() { tmuxenv.Run, tmuxenv.AncestorPIDs, tmuxenv.SocketDir = prevRun, prevAnc, prevDir })
+	tmuxenv.AncestorPIDs = func() []int { return []int{999, 1} }
+	tmuxenv.Run = func(_ ...string) (string, error) { return "", nil }
+	tmuxenv.SocketDir = func() string { return t.TempDir() }
+
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"whereami"}, &buf); err == nil {
+		t.Fatalf("expected an error when no pane resolves, got output %q", buf.String())
+	}
+}

--- a/internal/mcpserver/tools_registry.go
+++ b/internal/mcpserver/tools_registry.go
@@ -44,6 +44,7 @@ func registerAgentHandler(_ context.Context, _ *mcp.CallToolRequest, in Register
 		return nil, OKOut{OK: true, Detail: detail + " — use that alias; not adding a second"}, nil
 	}
 
+	h := harnessenv.FromEnv()
 	sessionName := in.SessionName
 	if sessionName == "" {
 		sessionName = c.SessionName
@@ -58,27 +59,39 @@ func registerAgentHandler(_ context.Context, _ *mcp.CallToolRequest, in Register
 		// half-captured socket (run-shell contexts) is dropped too — a tuple
 		// mixing a real socket with a non-tmux session ID would read as dead
 		// to every liveness check.
-		h := harnessenv.FromEnv()
 		socketPath, paneID = "", ""
 		sessionID, project = h.SessionID, h.Project()
 	}
-	_, err := callDaemon("register_agent", map[string]any{
-		"alias":           in.Alias,
-		"role":            in.Role,
-		"model_type":      in.ModelType,
-		"session_name":    sessionName,
-		"session_id":      sessionID,
-		"session_created": c.SessionCreated,
-		"socket_path":     socketPath,
-		"pane_id":         paneID,
-		"project":         project,
-		"label":           c.Label,
-		"label_manual":    c.LabelManual,
+	raw, err := callDaemon("register_agent", map[string]any{
+		"alias":              in.Alias,
+		"role":               in.Role,
+		"model_type":         in.ModelType,
+		"session_name":       sessionName,
+		"session_id":         sessionID,
+		"session_created":    c.SessionCreated,
+		"socket_path":        socketPath,
+		"pane_id":            paneID,
+		"project":            project,
+		"label":              c.Label,
+		"label_manual":       c.LabelManual,
+		"harness_session_id": h.SessionID,
 	})
 	if err != nil {
 		return nil, OKOut{}, err
 	}
-	return nil, OKOut{OK: true, Detail: "registered " + in.Alias}, nil
+	var ack struct {
+		Outcome string `json:"outcome"`
+		Unread  int    `json:"unread"`
+	}
+	_ = json.Unmarshal(raw, &ack)
+	detail := "registered " + in.Alias
+	if ack.Outcome == "revived" {
+		detail = fmt.Sprintf("reconnected as '%s' — revived a previous registration", in.Alias)
+	}
+	if ack.Unread > 0 {
+		detail += fmt.Sprintf("; %d unread thread(s): call get_inbox with alias '%s'", ack.Unread, in.Alias)
+	}
+	return nil, OKOut{OK: true, Detail: detail}, nil
 }
 
 func listAgentsHandler(_ context.Context, _ *mcp.CallToolRequest, _ ListAgentsIn) (*mcp.CallToolResult, ListAgentsOut, error) {

--- a/internal/mcpserver/tools_registry_test.go
+++ b/internal/mcpserver/tools_registry_test.go
@@ -159,6 +159,50 @@ func TestRegisterAgentSameAliasStillUpserts(t *testing.T) {
 	}
 }
 
+// TestRegisterAgentStampsHarnessLinkAndReportsRevival covers the durable-alias
+// spec's MCP surface: the handler forwards the ambient harness session UUID
+// (so hook reclaim can find this row after a resume), and folds the daemon's
+// outcome/unread into the Detail so a re-registering agent learns its backlog.
+func TestRegisterAgentStampsHarnessLinkAndReportsRevival(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%6")
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "uuid-7")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_id}":
+			return "$5", nil
+		case "#{session_name}":
+			return "muster-2", nil
+		default:
+			return "", nil
+		}
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var got map[string]any
+	prevDaemon := callDaemon
+	callDaemon = func(op string, args map[string]any) (json.RawMessage, error) {
+		if op == "register_agent" {
+			got = args
+			return []byte(`{"outcome":"revived","unread":3}`), nil
+		}
+		return []byte(`[]`), nil // paneRegistration's list_agents probe
+	}
+	t.Cleanup(func() { callDaemon = prevDaemon })
+
+	_, out, err := registerAgentHandler(context.TODO(), nil, RegisterAgentIn{Alias: "backend", Role: "peer", ModelType: "claude"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["harness_session_id"] != "uuid-7" {
+		t.Fatalf("harness_session_id = %v, want uuid-7", got["harness_session_id"])
+	}
+	if !strings.Contains(out.Detail, "revived") || !strings.Contains(out.Detail, "3 unread") {
+		t.Fatalf("Detail = %q, want revival + unread notice", out.Detail)
+	}
+}
+
 func TestRegisterAgentFreshPaneRegisters(t *testing.T) {
 	t.Setenv("TMUX", "/tmp/sock,1,0")
 	t.Setenv("TMUX_PANE", "%14")

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -82,6 +82,17 @@ func (s *Store) TouchAgent(alias string) error {
 	return err
 }
 
+// SetHarnessSessionID stamps the harness session UUID onto an existing row —
+// the repair half of the durable-alias spec: an alias registered without a
+// harness link (an MCP register in an env carrying no harness UUID) gets one
+// attached later by a hook that DOES see the UUID (every hook payload carries
+// it). Identity, tuple, and read-state are untouched; unknown alias is a
+// no-op, mirroring TouchAgent's contract.
+func (s *Store) SetHarnessSessionID(alias, id string) error {
+	_, err := s.db.Exec(`UPDATE agents SET harness_session_id=? WHERE alias=?`, id, alias)
+	return err
+}
+
 // DepartAgent tombstones alias (spec: deregistration must survive so
 // departed history stays drillable): sets departed=1 in place. Identity,
 // project, label, and read-state (last_read_entry_id/last_read_at) are all

--- a/internal/store/agents_test.go
+++ b/internal/store/agents_test.go
@@ -431,3 +431,27 @@ func TestSessionUnreadPerAliasWatermarks(t *testing.T) {
 		t.Fatalf("after MarkRead(aliasB): expected 0 unread, got %d", total)
 	}
 }
+
+// TestSetHarnessSessionID covers the hook-repair path of the durable-alias
+// spec: an alias registered without a harness link (e.g. via the MCP tool in
+// an env with no harness UUID) gets one stamped later by the Stop hook.
+func TestSetHarnessSessionID(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "backend"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetHarnessSessionID("backend", "uuid-1"); err != nil {
+		t.Fatal(err)
+	}
+	ag, ok, err := s.GetAgent("backend")
+	if err != nil || !ok {
+		t.Fatalf("get: %v %v", ok, err)
+	}
+	if ag.HarnessSessionID != "uuid-1" {
+		t.Fatalf("harness_session_id = %q, want uuid-1", ag.HarnessSessionID)
+	}
+	// Unknown alias is a no-op, mirroring TouchAgent's contract.
+	if err := s.SetHarnessSessionID("ghost", "uuid-2"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/tmuxenv/ancestry.go
+++ b/internal/tmuxenv/ancestry.go
@@ -1,0 +1,102 @@
+package tmuxenv
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// ancestryGuard bounds the parent-chain walk; 30 generations is far beyond
+// any real hook → claude → shell nesting (mirrors claude-notify.sh's guard).
+const ancestryGuard = 30
+
+// AncestorPIDs returns this process's parent chain, nearest first, stopping
+// at pid 0/1. Injectable for tests. The real implementation shells out to
+// `ps -o ppid= -p <pid>` per hop — portable across macOS/Linux without cgo.
+var AncestorPIDs = func() []int {
+	pids := []int{os.Getpid()}
+	pid := os.Getpid()
+	for i := 0; i < ancestryGuard; i++ {
+		out, err := exec.Command("ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+		if err != nil {
+			break
+		}
+		next, err := strconv.Atoi(strings.TrimSpace(string(out)))
+		if err != nil || next <= 1 {
+			break
+		}
+		pids = append(pids, next)
+		pid = next
+	}
+	return pids
+}
+
+// SocketDir returns the directory holding this user's tmux server sockets:
+// $TMUX_TMPDIR if set (tmux's own knob — our operator-tunable too), else
+// /tmp/tmux-<uid>, tmux's default. Injectable for tests.
+var SocketDir = func() string {
+	if d := os.Getenv("TMUX_TMPDIR"); d != "" {
+		return filepath.Join(d, "tmux-"+strconv.Itoa(os.Getuid()))
+	}
+	return filepath.Join("/tmp", "tmux-"+strconv.Itoa(os.Getuid()))
+}
+
+// capturePane assembles a Capture for a pane already located on sock, the
+// way CaptureEnv does for its fields: socket/pane/session id/name/created
+// come directly from the matched list-panes row, while Project and Label
+// are read through the SAME query/SessionLabel helpers CaptureEnv uses —
+// one derivation path for both entry points, not a forked copy.
+func capturePane(sock, paneID, sessionID, sessionName string, created int64) Capture {
+	c := Capture{
+		SocketPath:     sock,
+		PaneID:         paneID,
+		SessionID:      sessionID,
+		SessionName:    sessionName,
+		SessionCreated: created,
+		Project:        ProjectFromSocket(sock),
+	}
+	c.Label, c.LabelManual = SessionLabel(sock, paneID)
+	return c
+}
+
+// CaptureFromAncestry locates the tmux pane this PROCESS runs under by
+// walking its parent chain and matching pane PIDs across every tmux server
+// socket on the machine, then captures the same identity CaptureEnv reads
+// from $TMUX/$TMUX_PANE. Hooks need this: harnesses spawn them with a
+// stripped environment (no $TMUX), but the hook is still a descendant of the
+// pane's shell, so the ancestry names the pane even when the env can't
+// (the claude-notify.sh technique, generalized across per-project sockets).
+// Requires the hook to run synchronously — an async hook is reparented and
+// the chain breaks. Fail-safe: no match returns the zero Capture (paneless
+// behavior), NEVER a cwd-derived guess — two sessions in one directory is
+// normal, and mis-anchoring an identity is worse than not anchoring it.
+func CaptureFromAncestry() Capture {
+	ancestors := AncestorPIDs()
+	sockets, _ := filepath.Glob(filepath.Join(SocketDir(), "*"))
+	for _, sock := range sockets {
+		out, err := Run("-S", sock, "list-panes", "-aF",
+			"#{pane_pid}\t#{pane_id}\t#{session_id}\t#{session_name}\t#{session_created}")
+		if err != nil || out == "" {
+			continue
+		}
+		byPID := map[int][]string{}
+		for _, line := range strings.Split(out, "\n") {
+			f := strings.Split(line, "\t")
+			if len(f) != 5 {
+				continue
+			}
+			if pid, err := strconv.Atoi(f[0]); err == nil {
+				byPID[pid] = f
+			}
+		}
+		for _, pid := range ancestors {
+			if f, hit := byPID[pid]; hit {
+				created, _ := strconv.ParseInt(f[4], 10, 64)
+				return capturePane(sock, f[1], f[2], f[3], created)
+			}
+		}
+	}
+	return Capture{}
+}

--- a/internal/tmuxenv/ancestry_test.go
+++ b/internal/tmuxenv/ancestry_test.go
@@ -1,0 +1,71 @@
+package tmuxenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// contains reports whether want is present anywhere in args.
+func contains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// containsSuffix reports whether any arg's basename equals suffix — used to
+// match the "-S <path>" socket argument by its socket-file basename rather
+// than a full temp-dir path.
+func containsSuffix(args []string, suffix string) bool {
+	for _, a := range args {
+		if filepath.Base(a) == suffix {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCaptureFromAncestryMatchesPanePID: the walk must find the pane whose
+// #{pane_pid} is one of this process's ancestors, capture the full tuple
+// from THAT socket, and come back empty (fail-safe) when no pane matches —
+// never a guess.
+func TestCaptureFromAncestryMatchesPanePID(t *testing.T) {
+	prevRun, prevAnc, prevDir := Run, AncestorPIDs, SocketDir
+	t.Cleanup(func() { Run, AncestorPIDs, SocketDir = prevRun, prevAnc, prevDir })
+
+	AncestorPIDs = func() []int { return []int{999, 4242, 1} }
+
+	Run = func(args ...string) (string, error) {
+		// list-panes across sockets: only the proj-muster socket has our pane.
+		switch {
+		case contains(args, "list-panes") && containsSuffix(args, "proj-muster"):
+			return "4242\t%7\t$3\tmuster-2\t555", nil
+		case contains(args, "list-panes"):
+			return "100\t%1\t$1\tother\t111", nil
+		default:
+			return "", nil
+		}
+	}
+	// Socket enumeration: SocketDir points at a temp dir holding two fake
+	// socket files so CaptureFromAncestry's glob finds both "servers".
+	dir := t.TempDir()
+	for _, name := range []string{"proj-other", "proj-muster"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	SocketDir = func() string { return dir }
+
+	c := CaptureFromAncestry()
+	if c.SocketPath == "" || c.PaneID != "%7" || c.SessionID != "$3" || c.SessionCreated != 555 {
+		t.Fatalf("capture = %+v, want pane %%7 on $3 created 555", c)
+	}
+
+	AncestorPIDs = func() []int { return []int{999, 1} } // no pane pid in chain
+	if c := CaptureFromAncestry(); c.SocketPath != "" || c.PaneID != "" {
+		t.Fatalf("no-match capture = %+v, want zero value (fail-safe)", c)
+	}
+}

--- a/internal/tmuxenv/tmuxenv.go
+++ b/internal/tmuxenv/tmuxenv.go
@@ -165,6 +165,18 @@ func CurrentSessionOption(name string) string {
 	return out
 }
 
+// SessionOption reads a tmux user option's raw value for a specific
+// (socket, target) pair — the socket-aware counterpart to
+// CurrentSessionOption, via the same query seam as SessionLabel/SessionName.
+// A hook spawned with $TMUX stripped from its environment (the harness-hosted
+// production case) has no ambient session for CurrentSessionOption to read;
+// when identity instead came from tmuxenv.CaptureFromAncestry, this is how a
+// caller reads an option (e.g. "@muster_inbox") for that WALKED tuple rather
+// than trusting an environment that isn't there.
+func SessionOption(socket, target, name string) string {
+	return query(socket, target, "#{"+name+"}")
+}
+
 // CurrentSessionName returns the ambient session's name (no -S/-t), or "" if
 // tmux isn't reachable (e.g. not running inside tmux).
 func CurrentSessionName() string {


### PR DESCRIPTION
## What

A resumed harness conversation (`claude --resume` into a brand-new tmux session) now reclaims its bus alias — inbox, threads, read-state — automatically. The alias is the durable identity, seeded from the tmux session name at first registration but owned by the conversation thereafter.

Spec: `docs/superpowers/specs/2026-08-01-durable-alias-identity-design.md` (in this PR). Design settled with the dotfiles session on bus thread 149.

## The four changes

1. **Classified register response** — `register_agent` returns `{outcome: new|refreshed|revived, unread}`; revivals are journaled. The CLI prints "reconnected … N unread", the MCP tool folds it into its Detail. Backward-compatible both directions (old clients discard Data; new clients zero-value against old daemons).
2. **`stamp_harness_session` op** — hooks attach the harness session UUID to already-registered aliases (repairs MCP-registered custom aliases whose server env lacked the UUID).
3. **Ancestry-based pane capture** (`tmuxenv.CaptureFromAncestry` + `muster whereami`) — hooks run env-stripped, so they self-locate by walking process ancestry to a `#{pane_pid}` match across all per-project sockets. Four-point behavioral contract shared with dotfiles (independent implementations, no cross-product dependency). Stop and SessionEnd route through the same env-else-walk capture.
4. **Register-on-resume reclaim** — SessionStart `source:"resume"` re-registers the conversation's rows (found by `harness_session_id`) onto the new tmux tuple and prints "muster: reconnected as 'X' (revived) — N unread thread(s)" into the session's context. Live collisions (row provably alive in another tmux session) are reported, never clobbered; if nothing reclaims, the normal session-name register runs.

## Review trail

Built subagent-driven: 8 implementation tasks, each task-reviewed clean; whole-branch final review found 3 Important findings on one seam (Stop/SessionEnd still assumed env capture, which is stripped in production) — fixed in `f2f26fa`, scoped re-review: all addressed, no new breakage.

## Residuals (accepted, documented)

- Stop-hook stamp repair piggybacks on the existing mail gate — a link-less alias that never receives mail rides the re-register-by-transcript contract instead.
- A still-open-pane session whose ancestry walk fails gets *eventual* (gc) rather than immediate tombstoning at SessionEnd — matches the existing IsSessionAlive liveness model.
- Codex rides the contract (no hook payload session ID); Cursor payload fields to be verified empirically during live verification and posted to bus thread 149.

## Operator checklist before/after merge

- [ ] Live verification: register + mail in tmux session A, kill A, `claude --resume` in new session B → SessionEnd releases, SessionStart reclaims, summary lands in context, `muster agents` shows the alias live on B's tuple. Also try resume-while-old-still-open (the collision notice path).
- [ ] Capture real `cursor-agent` hook payload fields; post findings + final `whereami` name to bus thread 149.
- [ ] VERSION bump rides a separate chore PR when releasing.