### PR TITLE
feat: muster become — claim your name

### DIFF
--- a/.claude/skills/muster-coordination/SKILL.md
+++ b/.claude/skills/muster-coordination/SKILL.md
@@ -32,6 +32,12 @@ Codex session is not addressable until someone says something to it ("hi" is
 enough). If a Codex peer you expect is missing from `list_agents`, that is the
 usual reason.
 
+Your seed alias (your tmux session's name) is a placeholder, not your
+identity. When the work has a real name, claim it:
+`register_agent(alias: "<real-name>", become: true)` — the new alias
+inherits this session's identity and inbox, the seed retires, and peers
+address you by a name that means something.
+
 ## The core loop
 
 - **`list_agents`** — who's on the bus (project, label, liveness).

--- a/docs/superpowers/plans/2026-08-01-become-claim-your-name.md
+++ b/docs/superpowers/plans/2026-08-01-become-claim-your-name.md
@@ -1,0 +1,518 @@
+# `muster become` (Claim Your Name) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A session claims its real name (`muster become alias-routing` / MCP `register_agent(..., become:true)`): a new identity row is created under the claimed alias (read watermark carried over) and the tmux-seeded row retires.
+
+**Architecture:** One daemon op (`become`) backed by one transactional store method; a CLI verb reusing the hook layer's env-else-walk capture; a `become` flag threaded through the MCP pane guard that currently refuses second aliases; two sentences of skill text. No wrapper, hook, label, or dotfiles changes. Spec: `docs/superpowers/specs/2026-08-01-become-claim-your-name-design.md`.
+
+**Tech Stack:** Go, pure-Go SQLite, newline-JSON daemon protocol, MCP go-sdk.
+
+## Global Constraints
+
+- **Worktree from `origin/dev`** (primary clone lags): `git fetch origin && git worktree add ~/GitHub/worktrees/muster-become -b feat/become-claim-your-name origin/dev`. First commit copies this plan + the spec from the primary clone.
+- **`just verify` before every commit**; cgo-free; `internal/daemon`/`internal/store` stay tmux/harness-agnostic.
+- **stdout sacred in mcp mode**; hooks-never-block untouched (this feature adds no hook paths).
+- House style: full-sentence rationale-carrying doc comments; test harnesses: `startWithNotifier`/`call` (daemon), `startTestDaemon`/`callData`/`hookRun`/`pinAncestryWalkAway` (humancli), `callDaemon` stub var (mcpserver).
+- Wire-shape reference points on origin/dev: `store.Agent` fields incl. `HarnessSessionID` + `LastReadEntryID` (`internal/store/models.go`); register outcome response and `storeAPI` (`internal/daemon/daemon.go`); `hookCapture()` (`internal/humancli/hook.go` — unexported, same package as the new CLI verb, reuse directly); pane guard (`internal/mcpserver/tools_registry.go` + `validate.go`); registry pattern (`internal/humancli/registry.go`, goldens in `registry_test.go`).
+- Exact strings (spec): journal event `Kind:"become", Agent:<to>, Detail:"<from> → <to>"`; daemon response Data `{"from","to","unread"}`; CLI output `you are now '<to>' (was '<from>') — N unread thread(s)`; MCP become Detail `you are now '<to>' (was '<from>'); N unread thread(s): call get_inbox with alias '<to>'`; refusal message gains `, or pass become:true to claim '<requested>' as this session's name`.
+
+## Interfaces established by this plan
+
+- `store.Become(from, to string) error` — transactional clone+retire; typed sentinel errors `store.ErrBecomeFromMissing`, `store.ErrBecomeToExists`.
+- Daemon op `become {from, to}` → `ok(map{"from","to","unread"})`; guards map sentinels to loud messages; journal + badge reconcile.
+- CLI `muster become <name> [--from <alias>]`.
+- MCP `RegisterAgentIn.Become bool` (`json:"become,omitempty"`).
+
+---
+
+### Task 1: store.Become — transactional clone + retire
+
+**Files:**
+- Modify: `internal/store/agents.go`
+- Test: `internal/store/agents_test.go` (append)
+
+**Interfaces:**
+- Produces: `Become(from, to string) error`; `ErrBecomeFromMissing`, `ErrBecomeToExists` (package-level `errors.New`).
+
+- [ ] **Step 1: Write the failing test** (use this file's existing store-opening helper):
+
+```go
+// TestBecomeClonesIdentityAndRetiresSeed covers the become spec's core move:
+// the claimed alias inherits the seed's full identity INCLUDING the read
+// watermark (without it, all of history would flip unread), and the seed
+// retires as a tombstone with its own history intact.
+func TestBecomeClonesIdentityAndRetiresSeed(t *testing.T) {
+	s := openTestStore(t) // match the helper name used by neighboring tests
+	if err := s.RegisterAgent(Agent{
+		Alias: "muster-2", Role: "peer", ModelType: "claude",
+		SocketPath: "/s", SessionID: "$1", SessionCreated: 111, PaneID: "%1",
+		SessionName: "muster-2", HarnessSessionID: "uuid-1",
+		Project: "muster", Label: "durable-alias", LabelManual: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkRead("muster-2"); err != nil { // establish a nonzero watermark
+		t.Fatal(err)
+	}
+	seed, _, _ := s.GetAgent("muster-2")
+
+	if err := s.Become("muster-2", "alias-routing"); err != nil {
+		t.Fatal(err)
+	}
+	to, ok, err := s.GetAgent("alias-routing")
+	if err != nil || !ok {
+		t.Fatalf("claimed alias missing: %v %v", ok, err)
+	}
+	if to.SocketPath != "/s" || to.SessionID != "$1" || to.SessionCreated != 111 ||
+		to.PaneID != "%1" || to.HarnessSessionID != "uuid-1" ||
+		to.Project != "muster" || to.Label != "durable-alias" || !to.LabelManual ||
+		to.Role != "peer" || to.ModelType != "claude" || to.Departed {
+		t.Fatalf("clone dropped identity fields: %+v", to)
+	}
+	if to.LastReadEntryID != seed.LastReadEntryID {
+		t.Fatalf("watermark not carried: got %d want %d", to.LastReadEntryID, seed.LastReadEntryID)
+	}
+	from, _, _ := s.GetAgent("muster-2")
+	if !from.Departed {
+		t.Fatalf("seed not retired: %+v", from)
+	}
+}
+
+// TestBecomeGuards: missing from and existing to (live OR tombstoned) both
+// fail with the typed sentinels — become never silently fuses identities.
+func TestBecomeGuards(t *testing.T) {
+	s := openTestStore(t)
+	if err := s.Become("ghost", "x"); !errors.Is(err, ErrBecomeFromMissing) {
+		t.Fatalf("missing from: got %v", err)
+	}
+	_ = s.RegisterAgent(Agent{Alias: "a"})
+	_ = s.RegisterAgent(Agent{Alias: "b"})
+	if err := s.Become("a", "b"); !errors.Is(err, ErrBecomeToExists) {
+		t.Fatalf("live to: got %v", err)
+	}
+	_ = s.DepartAgent("b")
+	if err := s.Become("a", "b"); !errors.Is(err, ErrBecomeToExists) {
+		t.Fatalf("tombstoned to must ALSO refuse: got %v", err)
+	}
+	// Departed FROM is fine: a session may claim after gc tombstoned its seed.
+	_ = s.DepartAgent("a")
+	if err := s.Become("a", "c"); err != nil {
+		t.Fatalf("departed from should still clone: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run** `go test ./internal/store/ -run TestBecome -race` — expect FAIL (undefined).
+
+- [ ] **Step 3: Implement** in `internal/store/agents.go`:
+
+```go
+// ErrBecomeFromMissing / ErrBecomeToExists are become's guard sentinels —
+// the daemon maps them to loud, hint-carrying wire errors.
+var (
+	ErrBecomeFromMissing = errors.New("become: from alias not found")
+	ErrBecomeToExists    = errors.New("become: to alias already exists")
+)
+
+// Become claims a new name for an existing identity (spec:
+// become-claim-your-name): inserts to as a CLONE of from — tuple, harness
+// link, project, label, role, model, and the READ WATERMARK, without which
+// the claimed identity would see all of history as unread — then retires
+// from as a tombstone. to must not exist at all: a live row is someone
+// else's identity and a tombstone is some other conversation's history;
+// merging identities is exactly the confusion this feature exists to kill.
+// from may already be departed (a claim after gc swept the seed). One
+// transaction: a crash mid-become never leaves both rows live.
+func (s *Store) Become(from, to string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var n int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM agents WHERE alias=?`, to).Scan(&n); err != nil {
+		return err
+	}
+	if n > 0 {
+		return ErrBecomeToExists
+	}
+	now := clock.NowMillis()
+	res, err := tx.Exec(`
+INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, departed, registered_at, last_seen, last_read_entry_id, last_read_at)
+SELECT ?, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, 0, ?, ?, last_read_entry_id, last_read_at
+FROM agents WHERE alias=?`, to, now, now, from)
+	if err != nil {
+		return err
+	}
+	if rows, err := res.RowsAffected(); err != nil {
+		return err
+	} else if rows == 0 {
+		return ErrBecomeFromMissing
+	}
+	if _, err := tx.Exec(`UPDATE agents SET departed=1 WHERE alias=?`, from); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+```
+
+(Check the INSERT column list against the CURRENT schema/RegisterAgent on the worktree — if `last_read_at` isn't in RegisterAgent's list it still exists as a column via migration; include it. Adjust to the real column set.)
+
+- [ ] **Step 4: Run** the package — `go test ./internal/store/ -race` — expect PASS.
+- [ ] **Step 5: Commit** — `feat(store): Become clones an identity under its claimed name and retires the seed`
+
+---
+
+### Task 2: Daemon op `become`
+
+**Files:**
+- Modify: `internal/daemon/daemon.go` (dispatch switch + storeAPI)
+- Test: `internal/daemon/become_test.go` (new)
+
+**Interfaces:**
+- Consumes: Task 1's `Become` + sentinels; existing `UnreadCount`, `logEvent`, `reconcileBadge`.
+- Produces: op `become {from, to}` → `ok(map[string]any{"from": from, "to": to, "unread": n})`.
+
+- [ ] **Step 1: Failing test:**
+
+```go
+// TestBecomeOpClaimsAndReports: end-to-end over the wire — identity moves,
+// seed retires, journal records the claim, unread rides the response so
+// surfaces can say "you are now X — N unread".
+func TestBecomeOpClaimsAndReports(t *testing.T) {
+	sock := startWithNotifier(t, &fakeNotifier{})
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/s", "session_id": "$1", "harness_session_id": "uuid-1",
+	})
+	call(t, sock, "register_agent", map[string]any{"alias": "peer", "socket_path": "/s", "session_id": "$2"})
+	call(t, sock, "send_message", map[string]any{
+		"from": "peer", "to_kind": "agent", "to_target": "muster-2", "subject": "s", "body": "b",
+	})
+
+	resp := call(t, sock, "become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+	if !resp.OK {
+		t.Fatalf("become: %+v", resp)
+	}
+	data, _ := resp.Data.(map[string]any)
+	if data["to"] != "alias-routing" || data["from"] != "muster-2" {
+		t.Fatalf("response = %+v", data)
+	}
+	if n, _ := data["unread"].(float64); n < 1 {
+		t.Fatalf("unread = %v, want >= 1 (pre-claim mail concerns the claimed identity's session)", data["unread"])
+	}
+
+	ev := call(t, sock, "list_events", map[string]any{"agent": "alias-routing"})
+	if !containsEventDetail(t, ev, "become", "muster-2 → alias-routing") {
+		t.Fatalf("no become journal event: %+v", ev.Data)
+	}
+
+	resp = call(t, sock, "become", map[string]any{"from": "alias-routing", "to": "peer"})
+	if resp.OK || !strings.Contains(resp.Error, "already has history") {
+		t.Fatalf("existing-to guard: %+v", resp)
+	}
+}
+```
+
+(`containsEventDetail` exists in `register_outcome_test.go` — same package, reuse. NOTE the unread assertion: unread is computed for the TO alias via `UnreadCount(to)`; the message was addressed to the seed. If `UnreadCount("alias-routing")` doesn't count the seed-addressed thread — threadConcerns matches by alias text — the assertion will fail. In that case compute unread via `SessionUnread(tuple)` in the op instead: the spec's intent is "how much mail is waiting for this session", and SessionUnread is the canonical session-level number. Decide by what the first test run shows; document the choice in the op's comment.)
+
+- [ ] **Step 2: Run** — expect FAIL (unknown op).
+- [ ] **Step 3: Implement.** Add `Become(from, to string) error` to `storeAPI`. Dispatch case:
+
+```go
+	case "become":
+		from, to := str(a, "from"), str(a, "to")
+		if err := d.s.Become(from, to); err != nil {
+			switch {
+			case errors.Is(err, store.ErrBecomeFromMissing):
+				return fail(fmt.Errorf("become: no such alias %q to become from; register first", from))
+			case errors.Is(err, store.ErrBecomeToExists):
+				return fail(fmt.Errorf("become: alias %q already has history; pick another name, or purge it with `muster gc --purge-agents`", to))
+			}
+			return fail(err)
+		}
+		d.logEvent(store.Event{Kind: "become", Agent: to, Detail: from + " → " + to})
+		ag, _, err := d.s.GetAgent(to)
+		if err != nil {
+			return fail(err)
+		}
+		d.reconcileBadge(ag.SocketPath, ag.SessionID)
+		unread, _, err := d.s.SessionUnread(ag.SocketPath, ag.SessionID)
+		if err != nil {
+			unread = 0 // best-effort: the claim already succeeded
+		}
+		return ok(map[string]any{"from": from, "to": to, "unread": unread})
+```
+
+(Adjust the unread source per Step 1's note; SessionUnread shown here as the likely-correct choice. For a paneless tuple SessionUnread still groups by ("", uuid) — fine.)
+
+- [ ] **Step 4: Run** `go test ./internal/daemon/ -race` — expect PASS.
+- [ ] **Step 5: Commit** — `feat(daemon): become op — claim a name, retire the seed, report unread`
+
+---
+
+### Task 3: CLI `muster become <name>`
+
+**Files:**
+- Create: `internal/humancli/become.go`
+- Modify: `internal/humancli/registry.go` (+ goldens per its tests)
+- Test: `internal/humancli/become_test.go` (new)
+
+**Interfaces:**
+- Consumes: `hookCapture()` (same package), `callData`, session_aliases op, Task 2's op.
+- Produces: `muster become <name> [--from <alias>]`.
+
+- [ ] **Step 1: Failing tests** (mirror `whereami_test.go`'s setup style; `pinAncestryWalkAway(t)` on env-empty tests):
+
+```go
+// TestBecomeClaimsSingleAliasSession: the happy path — one live alias on
+// this session; become claims the new name and reports the trade.
+func TestBecomeClaimsSingleAliasSession(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$1", "#{session_name}": "muster-2", "#{session_created}": "111",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$1", "session_created": 111,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"become", "alias-routing"}, &buf); err != nil {
+		t.Fatalf("become: %v", err)
+	}
+	if !strings.Contains(buf.String(), "you are now 'alias-routing' (was 'muster-2')") {
+		t.Fatalf("output = %q", buf.String())
+	}
+	ag, ok := hookGetAgent("alias-routing")
+	if !ok || ag.Departed || ag.SessionID != "$1" {
+		t.Fatalf("claimed row = %+v (ok=%v)", ag, ok)
+	}
+}
+
+// TestBecomeRequiresFromWhenSplit: two live aliases on one session — never
+// guess which identity is being claimed over.
+func TestBecomeRequiresFromWhenSplit(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{"#{session_id}": "$1"})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	for _, a := range []string{"muster-2", "cost-audit"} {
+		if _, err := callData("register_agent", map[string]any{
+			"alias": a, "socket_path": "/tmp/sock", "session_id": "$1",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var buf bytes.Buffer
+	err := Dispatch([]string{"become", "alias-routing"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "--from") {
+		t.Fatalf("want --from requirement error, got %v (out %q)", err, buf.String())
+	}
+	if err := Dispatch([]string{"become", "alias-routing", "--from", "cost-audit"}, &buf); err != nil {
+		t.Fatalf("explicit --from: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run** — expect FAIL (unknown command).
+- [ ] **Step 3: Implement `cmdBecome`:** parse `--from` via the flag pattern `cmdRegister` uses; resolve identity with `hookCapture()`; list live aliases via `callData("session_aliases", ...)` filtered to non-departed via `hookGetAgent` (session_aliases includes departed on purpose — filter here); 0 live → `fmt.Errorf("nothing to become from on this session; register first")`; >1 live and no `--from` → `fmt.Errorf("this session has aliases %s; pass --from <alias>", list)`; call the op; print `you are now '<to>' (was '<from>') — N unread thread(s)`. Register in `registry.go` (help: "claim this session's real name: a new alias inherits this session's identity and inbox watermark, and the tmux-seeded alias retires — route traffic by a name the work deserves"). Fix registry goldens.
+- [ ] **Step 4: Run** `go test ./internal/humancli/ -race` — expect PASS.
+- [ ] **Step 5: Commit** — `feat(cli): muster become — claim this session's real name`
+
+---
+
+### Task 4: MCP — become flag on register_agent
+
+**Files:**
+- Modify: `internal/mcpserver/tools_registry.go`
+- Test: `internal/mcpserver/tools_registry_test.go` (append)
+
+**Interfaces:**
+- Consumes: existing `paneRegistration` guard, `callDaemon` stub seam, Task 2's op.
+- Produces: `RegisterAgentIn.Become bool `+"`json:\"become,omitempty\" jsonschema:\"claim this alias as the session's name: the current alias retires and its identity and read-state carry over\"`"+`.
+
+- [ ] **Step 1: Failing tests** (mirror the existing `callDaemon`-stub tests):
+
+```go
+// TestRegisterAgentBecomeClaimsThroughPaneGuard: an already-registered pane
+// calling register_agent with become:true issues the become op instead of
+// the refusal, and the Detail reports the trade.
+func TestRegisterAgentBecomeClaimsThroughPaneGuard(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%6")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) { return "", nil }
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var becomeArgs map[string]any
+	prevDaemon := callDaemon
+	callDaemon = func(op string, args map[string]any) (json.RawMessage, error) {
+		switch op {
+		case "become":
+			becomeArgs = args
+			return []byte(`{"from":"muster-2","to":"alias-routing","unread":2}`), nil
+		default: // paneRegistration's roster probe: this pane already owns muster-2
+			return []byte(`[{"alias":"muster-2","socket_path":"/tmp/sock","session_id":"$1","pane_id":"%6"}]`), nil
+		}
+	}
+	t.Cleanup(func() { callDaemon = prevDaemon })
+
+	_, out, err := registerAgentHandler(context.TODO(), nil, RegisterAgentIn{
+		Alias: "alias-routing", Role: "peer", ModelType: "claude", Become: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if becomeArgs["from"] != "muster-2" || becomeArgs["to"] != "alias-routing" {
+		t.Fatalf("become args = %+v", becomeArgs)
+	}
+	if !strings.Contains(out.Detail, "you are now 'alias-routing' (was 'muster-2')") ||
+		!strings.Contains(out.Detail, "2 unread") {
+		t.Fatalf("Detail = %q", out.Detail)
+	}
+}
+
+// TestRegisterAgentRefusalAdvertisesBecome: the become:false refusal now
+// tells the agent how to claim instead of dead-ending.
+func TestRegisterAgentRefusalAdvertisesBecome(t *testing.T) {
+	// same stubs as above, Become:false
+	// assert out.Detail contains "pass become:true to claim 'alias-routing'"
+}
+```
+
+(Adapt the roster-probe stub to `paneRegistration`'s REAL call+shape on the worktree — read `validate.go` first; the existing idempotent-pane test shows the working stub. Fill the second test fully from the first's scaffolding.)
+
+- [ ] **Step 2: Run** — expect FAIL.
+- [ ] **Step 3: Implement:** add `Become` to `RegisterAgentIn`. In `registerAgentHandler`'s pane-guard branch: if `row.Alias != in.Alias` and `in.Become` → `callDaemon("become", {"from": row.Alias, "to": in.Alias})`, decode `{from,to,unread}`, Detail `fmt.Sprintf("you are now '%s' (was '%s'); %d unread thread(s): call get_inbox with alias '%s'", to, from, unread, to)`; on daemon error return it (loud — an existing-to guard message must reach the agent). If `in.Become` and the pane is NOT registered → fall through to the normal register (degrade gracefully). Update the refusal Detail: append `", or pass become:true to claim '" + in.Alias + "' as this session's name"`.
+- [ ] **Step 4: Run** `go test ./internal/mcpserver/ -race` — expect PASS.
+- [ ] **Step 5: Commit** — `feat(mcp): register_agent become:true claims the alias through the pane guard`
+
+---
+
+### Task 5: Integration tests + skill text
+
+**Files:**
+- Test: `internal/humancli/become_integration_test.go` (new)
+- Modify: `.claude/skills/muster-coordination/SKILL.md`
+
+- [ ] **Step 1: Failing integration tests:**
+
+```go
+// TestStopHookDrainsSeedStragglerAfterBecome: mail sent to the retired seed
+// AFTER the claim still reaches the session's drain — session_aliases
+// includes departed aliases on purpose, and become must not break that.
+func TestStopHookDrainsSeedStragglerAfterBecome(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"@muster_inbox": "1", "#{session_id}": "$1", "#{session_name}": "muster-2",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$1", "pane_id": "%1"})
+	seed("become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+	seed("register_agent", map[string]any{"alias": "peer", "socket_path": "/tmp/sock", "session_id": "$9"})
+	seed("send_message", map[string]any{"from": "peer", "to_kind": "agent", "to_target": "alias-routing", "subject": "s", "body": "b"})
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	outStr := buf.String()
+	if !strings.Contains(outStr, "alias-routing") {
+		t.Fatalf("drain reason must name the claimed alias:\n%s", outStr)
+	}
+}
+
+// TestResumeReclaimsClaimedName: the v0.8.0 resume chain composed with
+// become — kill the tmux session, resume env-stripped in a new one, and the
+// CLAIMED alias (not the seed) reconnects onto the new tuple.
+func TestResumeReclaimsClaimedName(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$NEW", "#{session_name}": "muster-9", "#{session_created}": "222",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42",
+	})
+	seed("become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "reconnected as 'alias-routing'") {
+		t.Fatalf("resume summary:\n%s", buf.String())
+	}
+	ag, ok := hookGetAgent("alias-routing")
+	if !ok || ag.Departed || ag.SessionID != "$NEW" {
+		t.Fatalf("claimed row after resume = %+v (ok=%v)", ag, ok)
+	}
+	if seedRow, _ := hookGetAgent("muster-2"); !seedRow.Departed {
+		t.Fatalf("seed must stay retired after resume, got %+v", seedRow)
+	}
+}
+```
+
+(The Stop test's stub map: extend with whatever formats the walked/env Stop path queries — mirror `TestHookStopUnreadEmitsBlockDecision`'s working map. IsSessionAlive for the resume test's $OLD tuple: the row is DEPARTED, so the collision predicate skips liveness — no extra stub needed.)
+
+- [ ] **Step 2: Run** — expect FAIL until wired end-to-end (these may pass immediately if Tasks 1–4 are complete — that's fine; they're regression armor, note it in the report).
+- [ ] **Step 3: Skill edit** — in the "Register at the start — and on resume" section of `.claude/skills/muster-coordination/SKILL.md`, append:
+
+```markdown
+Your seed alias (your tmux session's name) is a placeholder, not your
+identity. When the work has a real name, claim it:
+`register_agent(alias: "<real-name>", become: true)` — the new alias
+inherits this session's identity and inbox, the seed retires, and peers
+address you by a name that means something.
+```
+
+- [ ] **Step 4: Run** `just verify` — expect PASS.
+- [ ] **Step 5: Commit** — `feat: become integration armor + skill teaches the claim`
+
+---
+
+### Task 6: Gate, PR, live check
+
+- [ ] **Step 1:** `just verify` — green.
+- [ ] **Step 2:** Push; PR to `dev`: `feat: muster become — claim your name`. Body links the spec, states the claim-and-retire model, the rejected rename-with-history alternative and why (operator: old stuff doesn't matter; written-reference promise holds post-claim), and the surfaces touched.
+- [ ] **Step 3 (controller, post-merge):** scripted live check on an isolated MUSTER_HOME (same rig as v0.8.0's): seed a tmux session, become, verify roster shows only the claimed name, send mail to it, then the resume flow reclaims the claimed name. Operator's own `become` on a real session is the final feel-check.
+- [ ] **Step 4:** VERSION bump rides the release train when the operator says so.
+
+---
+
+## Self-review notes (spec ↔ plan)
+
+- Spec mechanism 1 (op: guards/clone/watermark/retire/journal/badges/response) → Tasks 1–2. The unread-source ambiguity (UnreadCount(to) vs SessionUnread) is called out in Task 2 Step 1 with the decision rule.
+- Spec mechanism 2 (CLI, hookCapture reuse, --from on split) → Task 3.
+- Spec mechanism 3 (MCP become flag, refusal advertises it, unregistered degrades to plain register) → Task 4.
+- Spec mechanism 4 (skill text only; no wrapper/hook/dotfiles changes) → Task 5 Step 3; no task touches hooks or the wrapper.
+- Spec interplay checks (straggler drain, resume-after-become) → Task 5 tests; SessionEnd/ghost-reap/gc need no new code (clone carries real session_created; departed seed is purgeable) — final review verifies by reading, not new tasks.
+- Exact strings centralized in Global Constraints; all tasks reference them.

--- a/docs/superpowers/specs/2026-08-01-become-claim-your-name-design.md
+++ b/docs/superpowers/specs/2026-08-01-become-claim-your-name-design.md
@@ -1,0 +1,157 @@
+# `muster become` — claim your name
+
+**Date:** 2026-08-01
+**Status:** proposed
+**Depends on:** durable alias identity (v0.8.0 — register outcome/unread, harness links, ancestry capture, resume reclaim)
+
+## Problem
+
+v0.8.0 made aliases durable but not meaningful. The launch wrapper seeds every
+session's alias from its tmux session name — the right default at launch, when
+nothing meaningful exists yet — but nothing ever replaces the seed. So the
+roster and all traffic read in terminal vocabulary (`muster-2`,
+`bettor-help-workspace-7`) even after a conversation has become something
+nameable. Routing by alias only means what it should when the alias names the
+conversation, not the terminal it started in.
+
+The operator's verdict (this is the point of the whole effort, not a polish
+item): traffic should route by a name the work deserves. Retroactive
+coherence explicitly does NOT matter — old threads reading as the old name is
+fine ("that's what it was called then").
+
+## Decision
+
+A session **claims** its real name once the work has one: a new identity row
+is created under the claimed alias and the seed row retires. The alias itself
+stays immutable — `become` is a claim-and-retire, never a rewrite — so the
+stability promise that makes aliases worth routing on (written references
+never dangle; history is append-only and truthful) holds after the claim.
+
+Explicitly rejected: **rename-that-moves-history** (rewriting alias text
+across threads/entries/events). Its only unique benefit is retroactive
+coherence, which the operator doesn't want; its costs are breaking the
+written-reference promise (the skill's own handoffs-use-aliases rule),
+falsifying the journal, and a database-wide rewrite of the one field
+everything keys on.
+
+Also rejected: piggybacking on the label. The 0.7.4 division of labor stands
+and gets cleaner: **label = what the session is doing right now** (topical,
+churns freely, prefix T untouched); **alias = who the conversation is**
+(claimed once, then stable). Prefix T must NOT trigger become — identity must
+not churn with topic. Claude's `/rename` and tmux session renames stay
+display-only.
+
+## Mechanism
+
+### 1. Daemon op `become` (the one canonical move)
+
+`become {from, to}` — atomic, in one transaction where SQLite allows:
+
+1. **Guard `from`:** must exist. (Departed `from` is fine — a session may
+   claim after its seed was gc-tombstoned; the clone below revives nothing,
+   it copies.)
+2. **Guard `to`:** must not exist AT ALL. A live `to` is someone else's
+   identity; a tombstoned `to` is some other conversation's history and
+   read-state, and merging identities is exactly the confusion this feature
+   kills. Fail loudly with a hint (`alias 'x' already has history; pick
+   another name, or purge it with muster gc --purge-agents`). This is the
+   black-hole-fix philosophy applied to naming: never silently fuse.
+3. **Clone:** insert the `to` row copying from `from`: tuple (socket, session
+   id/name/created, pane), harness_session_id, project, label, label_manual,
+   role, model_type, **and the read watermark** (`last_read_entry_id`,
+   `last_read_at`) — without the watermark copy the new identity would see
+   all of history as unread. `registered_at` stamps now (it is a new
+   identity's birth); `last_seen` stamps now.
+4. **Retire:** tombstone `from` (DepartAgent — normal soft delete; its mail
+   history stays drillable and drainable).
+5. **Journal:** `Kind:"become", Agent:<to>, Detail:"<from> → <to>"`.
+6. **Badges:** reconcile the tuple's badges (the @muster_agent alias list
+   now shows the claimed name; departed rows are already excluded).
+
+Response mirrors register's classified shape: `{"ok":true}` with
+`{"from","to","unread"}` so surfaces can say "you are now 'x' — N unread".
+
+Mail addressed to the retired seed afterwards: lands on its threads
+(black-hole backstop still resolves exact aliases even departed — verify at
+implementation; if resolve rejects departed targets, that is CORRECT and the
+sender gets a loud error naming the live roster), and any pre-claim unread
+drains normally — `session_aliases` includes departed aliases on purpose, so
+the Stop hook still lists and drains the seed's stragglers. Notify skips
+departed rows (existing behavior), which is fine: the live claimed alias on
+the same tuple gets the badge.
+
+### 2. CLI verb `muster become <name>`
+
+Resolves the session's current identity the same way hooks do (env capture,
+ancestry-walk fallback — `hookCapture`'s logic, which should be exported or
+mirrored per the existing one-canonical-capture rule), finds the session's
+live aliases via the tuple, and calls the op. Zero live aliases → error
+("nothing to become from; register first"). Exactly one → that's `from`.
+More than one → require `--from <alias>` (split identities are rare but
+legal; never guess). Prints: `you are now 'alias-routing' (was 'muster-2') —
+N unread thread(s)`.
+
+### 3. MCP surface: a `become` flag on register_agent
+
+No new tool. `register_agent` gains optional `become: true`. Today, calling
+register_agent with a different alias from an already-registered pane REFUSES
+("already registered as 'muster-2' — use that alias; not adding a second") —
+the guard against accidental split identity. That refusal is exactly where
+the claim belongs:
+
+- `become:true` + pane already registered → the daemon op runs
+  (from = the pane's current alias, to = the requested alias); Detail:
+  `"you are now 'alias-routing' (was 'muster-2'); N unread thread(s)"`.
+- `become:true` + pane NOT registered → plain register (nothing to claim
+  from; degrade gracefully, don't error).
+- The refusal message (become:false path) is updated to advertise the flag:
+  `"already registered as 'muster-2' — use that alias, or pass become:true
+  to claim '<requested>' as this session's name"`.
+
+Deliberate split identity (two live aliases, one session) remains possible
+via the CLI (`muster register <extra>`); the MCP path now nudges toward
+become because accidental splits were always the bug there (lake-broker).
+
+### 4. Teaching: two sentences, one nudge
+
+- Coordination skill, in the register section: when the work has a name,
+  claim it — `register_agent(alias:"<real-name>", become:true)`; the seed
+  name (your tmux session's) is a placeholder, not your identity.
+- No stop-hook wording changes, no wrapper changes, no dotfiles changes.
+  The wrapper keeps seeding the tmux name at launch (correct: nothing
+  meaningful exists yet); prefix T keeps setting labels; become is the rare,
+  deliberate identity claim.
+
+### Interplay with v0.8.0 machinery (all verified conceptually; test each)
+
+- **Resume reclaim:** the claimed row carries the harness link, so
+  SessionStart source:"resume" reclaims the claimed name onto the new tuple.
+  The retired seed is departed and (usually) dead-tupled — reclaim revives
+  the claimed alias, not the seed. Test the full chain: seed → become →
+  kill tmux → resume → "reconnected as '<claimed>'".
+- **SessionEnd:** tombstones every alias the pane owns — claimed row
+  included, seed already departed. No change.
+- **Ghost reap / DepartStaleSiblings:** become clones the CURRENT tuple with
+  its real session_created, so the clone is never reaped as a ghost.
+- **gc:** the retired seed is departed → purgeable per existing rules.
+
+## Non-goals
+
+- Renaming that rewrites history (rejected above).
+- Automatic naming (deriving a name from the conversation topic): the claim
+  is a deliberate act by the agent or operator; a wrong auto-name is worse
+  than a placeholder.
+- Merging two existing identities (become refuses existing `to`).
+- Label semantics changes of any kind.
+
+## Test surface
+
+- Store/daemon: become clone copies watermark + identity fields; guards
+  (missing from; existing to, live and tombstoned); journal event; badge
+  reconcile; unread in response.
+- CLI: single-alias happy path; multi-alias requires --from; zero-alias
+  error; env-stripped resolution via walk.
+- MCP: become:true claims through the pane guard; become:true unregistered
+  degrades to plain register; refusal message advertises the flag.
+- Integration: post-become Stop hook drains a straggler sent to the seed
+  pre-claim; resume-after-become reclaims the claimed name.

--- a/internal/daemon/become_test.go
+++ b/internal/daemon/become_test.go
@@ -1,0 +1,42 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBecomeOpClaimsAndReports: end-to-end over the wire — identity moves,
+// seed retires, journal records the claim, unread rides the response so
+// surfaces can say "you are now X — N unread".
+func TestBecomeOpClaimsAndReports(t *testing.T) {
+	sock := startWithNotifier(t, &fakeNotifier{})
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/s", "session_id": "$1", "harness_session_id": "uuid-1",
+	})
+	call(t, sock, "register_agent", map[string]any{"alias": "peer", "socket_path": "/s", "session_id": "$2"})
+	call(t, sock, "send_message", map[string]any{
+		"from": "peer", "to_kind": "agent", "to_target": "muster-2", "subject": "s", "body": "b",
+	})
+
+	resp := call(t, sock, "become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+	if !resp.OK {
+		t.Fatalf("become: %+v", resp)
+	}
+	data, _ := resp.Data.(map[string]any)
+	if data["to"] != "alias-routing" || data["from"] != "muster-2" {
+		t.Fatalf("response = %+v", data)
+	}
+	if n, _ := data["unread"].(float64); n < 1 {
+		t.Fatalf("unread = %v, want >= 1 (pre-claim mail concerns the claimed identity's session)", data["unread"])
+	}
+
+	ev := call(t, sock, "list_events", map[string]any{"agent": "alias-routing"})
+	if !containsEventDetail(t, ev, "become", "muster-2 → alias-routing") {
+		t.Fatalf("no become journal event: %+v", ev.Data)
+	}
+
+	resp = call(t, sock, "become", map[string]any{"from": "alias-routing", "to": "peer"})
+	if resp.OK || !strings.Contains(resp.Error, "already has history") {
+		t.Fatalf("existing-to guard: %+v", resp)
+	}
+}

--- a/internal/daemon/become_test.go
+++ b/internal/daemon/become_test.go
@@ -1,8 +1,14 @@
 package daemon
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/schuettc/muster/internal/mustertest"
+	"github.com/schuettc/muster/internal/paths"
+	"github.com/schuettc/muster/internal/store"
 )
 
 // TestBecomeOpClaimsAndReports: end-to-end over the wire — identity moves,
@@ -38,5 +44,73 @@ func TestBecomeOpClaimsAndReports(t *testing.T) {
 	resp = call(t, sock, "become", map[string]any{"from": "alias-routing", "to": "peer"})
 	if resp.OK || !strings.Contains(resp.Error, "already has history") {
 		t.Fatalf("existing-to guard: %+v", resp)
+	}
+}
+
+// getAgentFailStore wraps a real *store.Store and injects a GetAgent failure
+// for one alias, leaving every other storeAPI method (including Become
+// itself) untouched — the error-injecting-wrapper pattern storeAPI's doc
+// comment describes.
+type getAgentFailStore struct {
+	*store.Store
+	failAlias string
+}
+
+func (s *getAgentFailStore) GetAgent(alias string) (store.Agent, bool, error) {
+	if alias == s.failAlias {
+		return store.Agent{}, false, fmt.Errorf("injected GetAgent failure")
+	}
+	return s.Store.GetAgent(alias)
+}
+
+// TestBecomeOpDegradesOnPostCommitGetAgentFailure is finding F3: store.Become
+// commits the claim first, then the become op reads the claimed row back
+// (GetAgent) purely to reconcile the badge and compute unread. A failure in
+// that read-back must not turn a successful claim into a caller-visible
+// error — a caller that retried on error would hit ErrBecomeToExists for a
+// claim that had already gone through. The op must degrade best-effort,
+// exactly like the SessionUnread failure path already does, and report
+// unread:0 rather than fail(...).
+func TestBecomeOpDegradesOnPostCommitGetAgentFailure(t *testing.T) {
+	dir, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+	t.Setenv("MUSTER_HOME", dir)
+	s, err := store.Open(filepath.Join(dir, "bus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	wrapped := &getAgentFailStore{Store: s, failAlias: "alias-routing"}
+	d, err := Serve(paths.SocketPath(), wrapped, &fakeNotifier{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	sock := paths.SocketPath()
+
+	call(t, sock, "register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/s", "session_id": "$1",
+	})
+
+	resp := call(t, sock, "become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+	if !resp.OK {
+		t.Fatalf("become must report success — the claim already committed despite the injected GetAgent failure: %+v", resp)
+	}
+	data, _ := resp.Data.(map[string]any)
+	if data["to"] != "alias-routing" || data["from"] != "muster-2" {
+		t.Fatalf("response = %+v", data)
+	}
+	if n, _ := data["unread"].(float64); n != 0 {
+		t.Fatalf("unread must degrade to 0 on a post-commit GetAgent failure, got %v", data["unread"])
+	}
+
+	// The claim itself must have gone through in the store regardless of the
+	// injected read-back failure.
+	ag, found, err := s.GetAgent("alias-routing")
+	if err != nil || !found || ag.Departed {
+		t.Fatalf("claim should have committed: ag=%+v found=%v err=%v", ag, found, err)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -800,7 +800,13 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 		d.logEvent(store.Event{Kind: "become", Agent: to, Detail: from + " → " + to})
 		ag, _, err := d.s.GetAgent(to)
 		if err != nil {
-			return fail(err)
+			// store.Become above already committed: the claim itself succeeded,
+			// so a GetAgent read failure here must not surface as an op failure
+			// (finding F3) — a caller retrying on error would then hit
+			// ErrBecomeToExists for a claim that already went through. Degrade
+			// best-effort exactly like the unread lookup below already does:
+			// skip the badge reconcile and report unread:0 instead of failing.
+			return ok(map[string]any{"from": from, "to": to, "unread": 0})
 		}
 		d.reconcileBadge(ag.SocketPath, ag.SessionID)
 		unread, _, err := d.s.SessionUnread(ag.SocketPath, ag.SessionID)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4,6 +4,7 @@ package daemon
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -36,6 +37,7 @@ type storeAPI interface {
 	SetSessionLabel(socketPath, sessionID, label string, manual bool) (int64, error)
 	SetHarnessSessionID(alias, id string) error
 	DeleteAgent(alias string) error
+	Become(from, to string) error
 	CreateThread(t store.Thread, firstBody string) (int64, error)
 	AppendEntry(threadID int64, fromAgent, body, statusChange string) (int64, error)
 	ClaimTask(threadID int64, byAgent string) error
@@ -773,6 +775,39 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			d.reconcileBadge(old.SocketPath, old.SessionID)
 		}
 		return ok(nil)
+	case "become":
+		// Claim a durable name: the seed's identity moves to `to` and the
+		// seed retires (store.Become). unread is computed via SessionUnread
+		// on the claimed alias's (socket_path, session_id) tuple, not
+		// UnreadCount(to) — mail addressed to the pre-claim seed alias
+		// concerns that alias's *text*, not the destination alias's, so
+		// UnreadCount(to) would miss it. SessionUnread groups by the
+		// session tuple, which now belongs to `to` post-claim, so it
+		// correctly picks up mail that arrived before the claim. This
+		// matches the spec's intent: "how much mail is waiting for this
+		// session", reported so a caller can say "you are now X — N
+		// unread" in one round trip.
+		from, to := str(a, "from"), str(a, "to")
+		if err := d.s.Become(from, to); err != nil {
+			switch {
+			case errors.Is(err, store.ErrBecomeFromMissing):
+				return fail(fmt.Errorf("become: no such alias %q to become from; register first", from))
+			case errors.Is(err, store.ErrBecomeToExists):
+				return fail(fmt.Errorf("become: alias %q already has history; pick another name, or purge it with `muster gc --purge-agents`", to))
+			}
+			return fail(err)
+		}
+		d.logEvent(store.Event{Kind: "become", Agent: to, Detail: from + " → " + to})
+		ag, _, err := d.s.GetAgent(to)
+		if err != nil {
+			return fail(err)
+		}
+		d.reconcileBadge(ag.SocketPath, ag.SessionID)
+		unread, _, err := d.s.SessionUnread(ag.SocketPath, ag.SessionID)
+		if err != nil {
+			unread = 0 // best-effort: the claim already succeeded
+		}
+		return ok(map[string]any{"from": from, "to": to, "unread": unread})
 	default:
 		return proto.Response{Error: "unknown op: " + req.Op}
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -48,6 +48,7 @@ type storeAPI interface {
 	MarkRead(alias string) error
 	UnreadCount(alias string) (int, error)
 	SessionUnread(socketPath, sessionID string) (total, action int, err error)
+	SessionAliasLineage(socketPath, sessionID string) ([]string, error)
 	KVSet(key, value, updatedBy string) error
 	KVGet(key string) (store.KVPair, bool, error)
 	AppendEvent(e store.Event) error
@@ -637,22 +638,23 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 		// socket_path may be empty: a paneless session's tuple is ("",
 		// harness session UUID) — see internal/harnessenv. Only a missing
 		// session_id leaves no tuple to key on.
+		//
+		// SessionAliasLineage (not a flat tuple filter over ListAgents) walks
+		// supersession lineage the same way SessionUnread does: a
+		// become-retired seed's row sits on its OLD tuple forever (reclaim
+		// correctly never resurrects it there), so a flat filter would drop
+		// it from the very session its identity moved to. Lineage rows are
+		// additive to this op's existing include-departed-on-purpose
+		// behavior — nothing here narrows what used to come back, it only
+		// adds the aliases a flat tuple match was missing.
 		socketPath, sessionID := str(a, "socket_path"), str(a, "session_id")
 		if sessionID == "" {
 			return fail(fmt.Errorf("session_aliases: session_id is required"))
 		}
-		agents, err := d.s.ListAgents()
+		aliases, err := d.s.SessionAliasLineage(socketPath, sessionID)
 		if err != nil {
 			return fail(err)
 		}
-		aliases := []string{}
-		for _, ag := range agents {
-			if ag.SocketPath == socketPath && ag.SessionID == sessionID {
-				aliases = append(aliases, ag.Alias)
-			}
-		}
-		sort.Strings(aliases)
-		aliases = compactStrings(aliases)
 		return ok(map[string]any{"aliases": aliases})
 	case "session_unread":
 		// Read-only display data (spec §3/§4 hook wiring): no lock needed —
@@ -791,9 +793,14 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 		if err := d.s.Become(from, to); err != nil {
 			switch {
 			case errors.Is(err, store.ErrBecomeFromMissing):
-				return fail(fmt.Errorf("become: no such alias %q to become from; register first", from))
+				// No self-prefix (finding F3): callData already renders
+				// "<op>: <resp.Error>" for every op — send_message's resolve
+				// errors follow the same convention (no "send_message: "
+				// baked in here). A daemon error that also opened with
+				// "become: " doubled into "become: become: ..." on the CLI.
+				return fail(fmt.Errorf("no such alias %q to become from; register first", from))
 			case errors.Is(err, store.ErrBecomeToExists):
-				return fail(fmt.Errorf("become: alias %q already has history; pick another name, or purge it with `muster gc --purge-agents`", to))
+				return fail(fmt.Errorf("alias %q already has history; pick another name, or purge it with `muster gc --purge-agents`", to))
 			}
 			return fail(err)
 		}

--- a/internal/humancli/become.go
+++ b/internal/humancli/become.go
@@ -1,0 +1,103 @@
+package humancli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// newBecomeFlagsWithVals declares become's flags and returns typed access to
+// their values — shared by cmdBecome (real parsing) and newBecomeFlags
+// (registry help/man rendering).
+func newBecomeFlagsWithVals() (fs *flag.FlagSet, from *string) {
+	fs = flag.NewFlagSet("become", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	from = fs.String("from", "", "the alias to claim from, required when this session has more than one live alias")
+	return fs, from
+}
+
+// newBecomeFlags builds become's flag.FlagSet for registry-driven help/man
+// rendering.
+func newBecomeFlags() *flag.FlagSet {
+	fs, _ := newBecomeFlagsWithVals()
+	return fs
+}
+
+// cmdBecome claims a durable name for this tmux session: a new alias
+// inherits the calling session's identity and inbox read watermark, and the
+// seed alias it claimed from retires (the daemon's "become" op, store.Become).
+// The seed is resolved automatically when this session has exactly one live
+// alias; a split identity (more than one) requires --from so the claim never
+// guesses which one is being renamed.
+func cmdBecome(args []string, out io.Writer) error {
+	fs, from := newBecomeFlagsWithVals()
+	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{})
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("become", out)
+		}
+		return err
+	}
+	if len(rest) < 1 {
+		return fmt.Errorf("usage: muster become <name> [--from <alias>]")
+	}
+	to := rest[0]
+
+	c := hookCapture()
+
+	live, err := becomeLiveAliases(c.SocketPath, c.SessionID)
+	if err != nil {
+		return err
+	}
+
+	fromAlias := *from
+	if fromAlias == "" {
+		switch len(live) {
+		case 0:
+			return fmt.Errorf("nothing to become from on this session; register first")
+		case 1:
+			fromAlias = live[0]
+		default:
+			return fmt.Errorf("this session has aliases %s; pass --from <alias>", strings.Join(live, ", "))
+		}
+	}
+
+	raw, err := callData("become", map[string]any{"from": fromAlias, "to": to})
+	if err != nil {
+		return err
+	}
+	var res struct {
+		Unread int `json:"unread"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(out, "you are now '%s' (was '%s') — %d unread thread(s)\n", to, fromAlias, res.Unread)
+	return err
+}
+
+// becomeLiveAliases lists the session's live (non-departed) aliases. The
+// session_aliases op includes departed aliases on purpose (history), so each
+// candidate is confirmed live via hookGetAgent here.
+func becomeLiveAliases(socketPath, sessionID string) ([]string, error) {
+	raw, err := callData("session_aliases", map[string]any{"socket_path": socketPath, "session_id": sessionID})
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Aliases []string `json:"aliases"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, err
+	}
+	live := make([]string, 0, len(res.Aliases))
+	for _, a := range res.Aliases {
+		if ag, ok := hookGetAgent(a); ok && !ag.Departed {
+			live = append(live, a)
+		}
+	}
+	return live, nil
+}

--- a/internal/humancli/become.go
+++ b/internal/humancli/become.go
@@ -45,6 +45,12 @@ func cmdBecome(args []string, out io.Writer) error {
 		return fmt.Errorf("usage: muster become <name> [--from <alias>]")
 	}
 	to := rest[0]
+	if strings.TrimSpace(to) == "" {
+		// Mirrors cmdRegister's empty-alias rejection (finding F4): reject
+		// before dialing the daemon rather than letting an empty/blank name
+		// round-trip into a claim nobody could address afterward.
+		return fmt.Errorf("cannot become an empty alias")
+	}
 
 	c := hookCapture()
 

--- a/internal/humancli/become_integration_test.go
+++ b/internal/humancli/become_integration_test.go
@@ -81,3 +81,109 @@ func TestResumeReclaimsClaimedName(t *testing.T) {
 		t.Fatalf("seed must stay retired after resume, got %+v", seedRow)
 	}
 }
+
+// TestResumeAfterGracefulExitReclaimsOnlyClaimedName is fix round 1's main
+// regression: the COMMON flow, not the killed-without-SessionEnd variant
+// TestResumeReclaimsClaimedName models. become claims the name, then the
+// session exits gracefully — SessionEnd tombstones BOTH rows sharing the
+// harness UUID (the claimed alias AND the already-retired seed) — so on
+// resume there is no live sibling left for a tuple-sharing heuristic to key
+// on. Only store.Become's persisted superseded_by tells resume the seed must
+// never come back; a departed row's tuple/liveness alone cannot.
+func TestResumeAfterGracefulExitReclaimsOnlyClaimedName(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$NEW", "#{session_name}": "muster-9", "#{session_created}": "222",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42",
+	})
+	seed("become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+	// The graceful-exit half: SessionEnd tombstones every alias the dying
+	// session owns, including the claimed one — unlike the killed-session
+	// variant, alias-routing is departed too by the time resume runs.
+	seed("deregister_agent", map[string]any{"alias": "alias-routing"})
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "reconnected as 'alias-routing'") {
+		t.Fatalf("resume summary must reclaim the claimed alias:\n%s", out)
+	}
+	if strings.Contains(out, "'muster-2'") {
+		t.Fatalf("resume summary must not resurrect the retired seed:\n%s", out)
+	}
+	ag, ok := hookGetAgent("alias-routing")
+	if !ok || ag.Departed || ag.SessionID != "$NEW" {
+		t.Fatalf("claimed row after resume = %+v (ok=%v)", ag, ok)
+	}
+	if seedRow, _ := hookGetAgent("muster-2"); !seedRow.Departed || seedRow.SessionID == "$NEW" {
+		t.Fatalf("seed must stay retired, never touching the new tuple: %+v", seedRow)
+	}
+}
+
+// TestResumeChainedBecomeReclaimsOnlyFinalName: two claims in the same
+// session's lifetime (A becomes B, B becomes C), all three rows now sharing
+// one harness UUID with A and B departed. Resume must reclaim only C — the
+// end of the chain — never A or B, proving superseded_by (not a
+// single-hop heuristic) is what resume actually trusts.
+func TestResumeChainedBecomeReclaimsOnlyFinalName(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$NEW", "#{session_name}": "muster-9", "#{session_created}": "222",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42",
+	})
+	seed("become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+	seed("become", map[string]any{"from": "alias-routing", "to": "final-name"})
+	seed("deregister_agent", map[string]any{"alias": "final-name"})
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "reconnected as 'final-name'") {
+		t.Fatalf("resume summary must reclaim only the chain's end:\n%s", out)
+	}
+	if strings.Contains(out, "'muster-2'") || strings.Contains(out, "'alias-routing'") {
+		t.Fatalf("resume summary must not resurrect either superseded link:\n%s", out)
+	}
+	final, ok := hookGetAgent("final-name")
+	if !ok || final.Departed || final.SessionID != "$NEW" {
+		t.Fatalf("final row after resume = %+v (ok=%v)", final, ok)
+	}
+	if seedRow, _ := hookGetAgent("muster-2"); !seedRow.Departed || seedRow.SessionID == "$NEW" {
+		t.Fatalf("seed must stay retired: %+v", seedRow)
+	}
+	if midRow, _ := hookGetAgent("alias-routing"); !midRow.Departed || midRow.SessionID == "$NEW" {
+		t.Fatalf("middle link must stay retired: %+v", midRow)
+	}
+}

--- a/internal/humancli/become_integration_test.go
+++ b/internal/humancli/become_integration_test.go
@@ -1,0 +1,83 @@
+package humancli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// TestStopHookDrainsSeedStragglerAfterBecome: mail sent to the retired seed
+// AFTER the claim still reaches the session's drain — session_aliases
+// includes departed aliases on purpose, and become must not break that.
+func TestStopHookDrainsSeedStragglerAfterBecome(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"@muster_inbox": "1", "#{session_id}": "$1", "#{session_name}": "muster-2",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$1", "pane_id": "%1"})
+	seed("become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+	seed("register_agent", map[string]any{"alias": "peer", "socket_path": "/tmp/sock", "session_id": "$9"})
+	seed("send_message", map[string]any{"from": "peer", "to_kind": "agent", "to_target": "alias-routing", "subject": "s", "body": "b"})
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	outStr := buf.String()
+	if !strings.Contains(outStr, "alias-routing") {
+		t.Fatalf("drain reason must name the claimed alias:\n%s", outStr)
+	}
+}
+
+// TestResumeReclaimsClaimedName: the v0.8.0 resume chain composed with
+// become — kill the tmux session, resume env-stripped in a new one, and the
+// CLAIMED alias (not the seed) reconnects onto the new tuple.
+func TestResumeReclaimsClaimedName(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$NEW", "#{session_name}": "muster-9", "#{session_created}": "222",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42",
+	})
+	seed("become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "reconnected as 'alias-routing'") {
+		t.Fatalf("resume summary:\n%s", buf.String())
+	}
+	ag, ok := hookGetAgent("alias-routing")
+	if !ok || ag.Departed || ag.SessionID != "$NEW" {
+		t.Fatalf("claimed row after resume = %+v (ok=%v)", ag, ok)
+	}
+	if seedRow, _ := hookGetAgent("muster-2"); !seedRow.Departed {
+		t.Fatalf("seed must stay retired after resume, got %+v", seedRow)
+	}
+}

--- a/internal/humancli/become_integration_test.go
+++ b/internal/humancli/become_integration_test.go
@@ -187,3 +187,106 @@ func TestResumeChainedBecomeReclaimsOnlyFinalName(t *testing.T) {
 		t.Fatalf("middle link must stay retired: %+v", midRow)
 	}
 }
+
+// TestResumeSummaryReportsSessionUnreadTruth is finding F2, live rig: mail
+// addressed to the retired seed alias pends BEFORE resume. Before the fix,
+// the printed resume summary used the per-alias register ack (UnreadCount of
+// the CLAIMED alias only), which never sees mail addressed to the SEED's
+// name and printed "0 unread thread(s)" while a real thread pended — the
+// injected context lied to the agent about its own backlog. This asserts
+// the exact count, not just non-zero: session_unread's lineage-aware total.
+func TestResumeSummaryReportsSessionUnreadTruth(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$NEW", "#{session_name}": "muster-9", "#{session_created}": "222",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42",
+	})
+	seed("become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+	seed("register_agent", map[string]any{"alias": "peer", "socket_path": "/tmp/sock2", "session_id": "$peer"})
+	// A straggler addressed to the RETIRED seed name, sent BEFORE resume —
+	// the exact live-rig topology: the mail's target is a departed alias
+	// whose superseded_by carries the identity forward.
+	seed("send_message", map[string]any{"from": "peer", "to_kind": "agent", "to_target": "muster-2", "subject": "s", "body": "for the old name"})
+
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "reconnected as 'alias-routing' (refreshed) — 1 unread thread(s)") {
+		t.Fatalf("resume summary must report the true (lineage) pending count, got:\n%s", out)
+	}
+}
+
+// TestStopHookDrainsSeedStragglerAfterResume: extends
+// TestStopHookDrainsSeedStragglerAfterBecome across resume. A straggler sent
+// to the RETIRED name AFTER the conversation resumed onto a brand-new tmux
+// tuple must still light the Stop-hook drain on the NEW tuple — the seed's
+// own row never moves off the dead old tuple, so this only works if the
+// drain path (session_aliases + session_unread) follows supersession
+// lineage rather than a flat tuple match (finding F1).
+func TestStopHookDrainsSeedStragglerAfterResume(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%9")
+	t.Setenv("MUSTER_ALIAS", "")
+	prevRun := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$NEW", "#{session_name}": "muster-9", "#{session_created}": "222",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prevRun })
+	seed := func(op string, args map[string]any) {
+		t.Helper()
+		if _, err := callData(op, args); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$OLD",
+		"session_created": 111, "harness_session_id": "uuid-42",
+	})
+	seed("become", map[string]any{"from": "muster-2", "to": "alias-routing"})
+
+	var resumeBuf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(`{"source":"resume","session_id":"uuid-42"}`), &resumeBuf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resumeBuf.String(), "reconnected as 'alias-routing'") {
+		t.Fatalf("setup: resume did not reclaim as expected:\n%s", resumeBuf.String())
+	}
+
+	// A straggler addressed to the RETIRED seed name, sent AFTER resume: the
+	// seed's own row is still departed on the OLD (now-dead) tuple.
+	seed("register_agent", map[string]any{"alias": "peer", "socket_path": "/tmp/sock2", "session_id": "$peer"})
+	seed("send_message", map[string]any{"from": "peer", "to_kind": "agent", "to_target": "muster-2", "subject": "s", "body": "still for the old name"})
+
+	// Stop, on the NEW tuple, driven by tmux env matching the resumed session.
+	tmuxenv.Run = hookRun(map[string]string{
+		"@muster_inbox": "1", "#{session_id}": "$NEW", "#{session_name}": "muster-9",
+	})
+	var stopBuf bytes.Buffer
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(`{}`), &stopBuf); err != nil {
+		t.Fatal(err)
+	}
+	out := stopBuf.String()
+	if !strings.Contains(out, "alias-routing") {
+		t.Fatalf("Stop-hook drain on the new tuple must surface the unread mail (either by naming the alias or the count), got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 unread") && !strings.Contains(out, `"reason"`) {
+		t.Fatalf("Stop-hook drain must surface the straggler as pending mail:\n%s", out)
+	}
+}

--- a/internal/humancli/become_test.go
+++ b/internal/humancli/become_test.go
@@ -99,3 +99,41 @@ func TestBecomeRejectsEmptyAlias(t *testing.T) {
 		t.Fatal("whitespace-only alias must never reach the daemon")
 	}
 }
+
+// TestBecomeToExistsErrorHasNoPrefixStutter is finding F3, live rig:
+// `muster become` on an already-claimed name used to print "become: become:
+// alias ..." — the daemon's own error text for this guard baked in a
+// "become: " prefix, and callData (the ONE place that renders "<op>:
+// <daemon error>" for every op) added a second one on top. cmd/muster's
+// main() then prints "muster: " + err.Error() verbatim, so the doubled
+// prefix reached the operator's terminal unchanged. The error text
+// Dispatch returns here is exactly what main() prints after "muster: ", so
+// asserting on err.Error() catches the stutter at its source.
+func TestBecomeToExistsErrorHasNoPrefixStutter(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{"#{session_id}": "$1"})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("register_agent", map[string]any{"alias": "taken"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := Dispatch([]string{"become", "taken"}, &buf)
+	if err == nil {
+		t.Fatal("want an error claiming an already-existing alias")
+	}
+	if n := strings.Count(err.Error(), "become:"); n != 1 {
+		t.Fatalf("error must carry exactly one 'become:' prefix, got %d: %q", n, err.Error())
+	}
+	if strings.Contains(err.Error(), "become: become:") {
+		t.Fatalf("prefix stutter survived: %q", err.Error())
+	}
+}

--- a/internal/humancli/become_test.go
+++ b/internal/humancli/become_test.go
@@ -1,0 +1,64 @@
+package humancli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// TestBecomeClaimsSingleAliasSession: the happy path — one live alias on
+// this session; become claims the new name and reports the trade.
+func TestBecomeClaimsSingleAliasSession(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{
+		"#{session_id}": "$1", "#{session_name}": "muster-2", "#{session_created}": "111",
+	})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$1", "session_created": 111,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"become", "alias-routing"}, &buf); err != nil {
+		t.Fatalf("become: %v", err)
+	}
+	if !strings.Contains(buf.String(), "you are now 'alias-routing' (was 'muster-2')") {
+		t.Fatalf("output = %q", buf.String())
+	}
+	ag, ok := hookGetAgent("alias-routing")
+	if !ok || ag.Departed || ag.SessionID != "$1" {
+		t.Fatalf("claimed row = %+v (ok=%v)", ag, ok)
+	}
+}
+
+// TestBecomeRequiresFromWhenSplit: two live aliases on one session — never
+// guess which identity is being claimed over.
+func TestBecomeRequiresFromWhenSplit(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{"#{session_id}": "$1"})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	for _, a := range []string{"muster-2", "cost-audit"} {
+		if _, err := callData("register_agent", map[string]any{
+			"alias": a, "socket_path": "/tmp/sock", "session_id": "$1",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var buf bytes.Buffer
+	err := Dispatch([]string{"become", "alias-routing"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "--from") {
+		t.Fatalf("want --from requirement error, got %v (out %q)", err, buf.String())
+	}
+	if err := Dispatch([]string{"become", "alias-routing", "--from", "cost-audit"}, &buf); err != nil {
+		t.Fatalf("explicit --from: %v", err)
+	}
+}

--- a/internal/humancli/become_test.go
+++ b/internal/humancli/become_test.go
@@ -62,3 +62,40 @@ func TestBecomeRequiresFromWhenSplit(t *testing.T) {
 		t.Fatalf("explicit --from: %v", err)
 	}
 }
+
+// TestBecomeRejectsEmptyAlias is finding F4: `muster become ""` (or a
+// whitespace-only name) must error before dialing the daemon at all,
+// mirroring cmdRegister's empty-alias rejection — a blank claimed name would
+// round-trip into a row nothing could ever address again.
+func TestBecomeRejectsEmptyAlias(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%1")
+	prev := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{"#{session_id}": "$1"})
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"", "   "} {
+		var buf bytes.Buffer
+		err := Dispatch([]string{"become", name}, &buf)
+		if err == nil {
+			t.Fatalf("become %q: want an error, got none (out %q)", name, buf.String())
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("become %q: must not print anything before erroring, got %q", name, buf.String())
+		}
+	}
+
+	// No row must have been created for either rejected name.
+	if _, found := hookGetAgent(""); found {
+		t.Fatal("empty alias must never reach the daemon")
+	}
+	if _, found := hookGetAgent("   "); found {
+		t.Fatal("whitespace-only alias must never reach the daemon")
+	}
+}

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -111,18 +111,24 @@ func hookRegisterPane(c tmuxenv.Capture, h harnessenv.Capture, model string) {
 // path: read-state survives, the daemon reports outcome+unread), EXCEPT a
 // row still live in a different, provably-alive tmux session — that is a
 // real collision (the old side's SessionEnd reason:"resume" normally
-// tombstones first), reported rather than clobbered. Returns true when at
-// least one alias was reclaimed: the caller then skips the default
-// session-name register — the conversation's identity IS the reclaimed one,
-// and minting a second alias would split it. Output goes to stdout, which
-// the harness injects into the session's context: the agent wakes up
-// knowing who it is and what's waiting.
+// tombstones first), reported rather than clobbered — OR a row
+// hookResumeSuperseded identifies as a become-retired seed, which must never
+// resurrect alongside the name that claimed it. Returns true when at least
+// one alias was reclaimed: the caller then skips the default session-name
+// register — the conversation's identity IS the reclaimed one, and minting a
+// second alias would split it. Output goes to stdout, which the harness
+// injects into the session's context: the agent wakes up knowing who it is
+// and what's waiting.
 func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model string, out io.Writer) bool {
 	if h.SessionID == "" {
 		return false
 	}
+	owned := harnessOwnedRows(h.SessionID)
 	reclaimed := 0
-	for _, ag := range harnessOwnedRows(h.SessionID) {
+	for _, ag := range owned {
+		if hookResumeSuperseded(ag, owned) {
+			continue // become-retired seed: the live claimed alias already carries this identity forward
+		}
 		sameTuple := ag.SocketPath == c.SocketPath && ag.SessionID == c.SessionID
 		if !ag.Departed && !sameTuple && ag.SocketPath != "" &&
 			tmuxenv.IsSessionAlive(ag.SocketPath, ag.SessionID, ag.SessionCreated) {
@@ -135,6 +141,30 @@ func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model strin
 		reclaimed++
 	}
 	return reclaimed > 0
+}
+
+// hookResumeSuperseded reports whether ag is a become-retired seed: a
+// departed row whose (socket_path, session_id) tuple is ALSO held by a live
+// sibling among this harness session's own rows. store.Become clones the
+// seed's exact tuple onto the claimed alias and marks only the seed
+// departed, so nothing else in the row itself distinguishes "retired because
+// its name was claimed" from an ordinary Stop/SessionEnd tombstone — this
+// tuple-sharing signature is unique to become (a live split-identity sibling
+// pair is tombstoned together by hookSessionEnd, never leaving one live and
+// one departed on the same tuple). Without this check, resume would
+// reclaim the seed right alongside the alias that already claimed its
+// identity, resurrecting a name the operator explicitly retired.
+func hookResumeSuperseded(ag agentRow, owned []agentRow) bool {
+	if !ag.Departed {
+		return false
+	}
+	for _, other := range owned {
+		if other.Alias != ag.Alias && !other.Departed &&
+			other.SocketPath == ag.SocketPath && other.SessionID == ag.SessionID {
+			return true
+		}
+	}
+	return false
 }
 
 // hookSessionStartPaneless auto-registers a session that has no tmux pane in

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -121,11 +121,26 @@ func hookRegisterPane(c tmuxenv.Capture, h harnessenv.Capture, model string) {
 // reclaimed one, and minting a second alias would split it. Output goes to
 // stdout, which the harness injects into the session's context: the agent
 // wakes up knowing who it is and what's waiting.
+//
+// The printed unread count is session truth, not per-alias truth (finding
+// F2, live rig): register_agent's ack.Unread is store.UnreadCount(alias) —
+// text-matched to the single alias just reclaimed, blind to mail addressed
+// to a superseded seed whose identity moved onto this same tuple (F1). Once
+// at least one alias reclaims, session_unread's lineage-aware total (see
+// store.SessionUnread) is queried ONCE for the current tuple and substituted
+// into every printed line — a session's pending mail is one number, not a
+// sum of per-alias guesses, so all reclaimed aliases share it. A
+// session_unread failure degrades to the per-alias acks already collected,
+// unchanged, rather than block the hook.
 func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model string, out io.Writer) bool {
 	if h.SessionID == "" {
 		return false
 	}
-	reclaimed := 0
+	type reclaimedLine struct {
+		alias, outcome string
+		unread         int
+	}
+	var lines []reclaimedLine
 	for _, ag := range harnessOwnedRows(h.SessionID) {
 		if ag.Departed && ag.SupersededBy != "" {
 			continue // become-retired seed: SupersededBy already carries this identity forward, never resurrect it
@@ -137,11 +152,21 @@ func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model strin
 			continue
 		}
 		ack := reclaimRow(ag, c, h.SessionID, model)
-		_, _ = fmt.Fprintf(out, "muster: reconnected as '%s' (%s) — %d unread thread(s); call get_inbox with alias '%s'\n",
-			ag.Alias, ack.Outcome, ack.Unread, ag.Alias)
-		reclaimed++
+		lines = append(lines, reclaimedLine{ag.Alias, ack.Outcome, ack.Unread})
 	}
-	return reclaimed > 0
+	if len(lines) == 0 {
+		return false
+	}
+	if total, _, ok := sessionUnreadForHook(c.SocketPath, c.SessionID); ok {
+		for i := range lines {
+			lines[i].unread = total
+		}
+	}
+	for _, ln := range lines {
+		_, _ = fmt.Fprintf(out, "muster: reconnected as '%s' (%s) — %d unread thread(s); call get_inbox with alias '%s'\n",
+			ln.alias, ln.outcome, ln.unread, ln.alias)
+	}
+	return true
 }
 
 // hookSessionStartPaneless auto-registers a session that has no tmux pane in

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -171,14 +171,20 @@ func hookSessionStartPaneless(h harnessenv.Capture, model string) {
 		// handshake pre-registered a tmux-anchored row, or a prior life of
 		// this session (resume) left one. A live row needs nothing from
 		// this hook; if every owned row is a tombstone, revive the first
-		// with its stored identity intact.
+		// UNSUPERSEDED one with its stored identity intact (finding F1: a
+		// become-retired seed must never be revived under its old alias —
+		// firstUnsuperseded skips it). If every owned row turns out to be
+		// superseded, there is no identity left to revive; fall through to
+		// allocation below exactly as if owned had been empty.
 		for _, ag := range owned {
 			if !ag.Departed {
 				return
 			}
 		}
-		reviveRow(owned[0], model)
-		return
+		if ag, ok := firstUnsuperseded(owned); ok {
+			reviveRow(ag, model)
+			return
+		}
 	}
 	_, _ = allocPanelessAlias(h.Alias(), h.SessionID, regFn)
 }

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -111,23 +111,24 @@ func hookRegisterPane(c tmuxenv.Capture, h harnessenv.Capture, model string) {
 // path: read-state survives, the daemon reports outcome+unread), EXCEPT a
 // row still live in a different, provably-alive tmux session — that is a
 // real collision (the old side's SessionEnd reason:"resume" normally
-// tombstones first), reported rather than clobbered — OR a row
-// hookResumeSuperseded identifies as a become-retired seed, which must never
-// resurrect alongside the name that claimed it. Returns true when at least
-// one alias was reclaimed: the caller then skips the default session-name
-// register — the conversation's identity IS the reclaimed one, and minting a
-// second alias would split it. Output goes to stdout, which the harness
-// injects into the session's context: the agent wakes up knowing who it is
-// and what's waiting.
+// tombstones first), reported rather than clobbered — OR a departed row
+// whose SupersededBy is set (store.Become stamps this on the seed in the
+// same transaction that clones its identity onto the claimed alias): that
+// row's identity was explicitly claimed away and must never resurrect on
+// resume, no matter whether the row that claimed it is itself still live.
+// Returns true when at least one alias was reclaimed: the caller then skips
+// the default session-name register — the conversation's identity IS the
+// reclaimed one, and minting a second alias would split it. Output goes to
+// stdout, which the harness injects into the session's context: the agent
+// wakes up knowing who it is and what's waiting.
 func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model string, out io.Writer) bool {
 	if h.SessionID == "" {
 		return false
 	}
-	owned := harnessOwnedRows(h.SessionID)
 	reclaimed := 0
-	for _, ag := range owned {
-		if hookResumeSuperseded(ag, owned) {
-			continue // become-retired seed: the live claimed alias already carries this identity forward
+	for _, ag := range harnessOwnedRows(h.SessionID) {
+		if ag.Departed && ag.SupersededBy != "" {
+			continue // become-retired seed: SupersededBy already carries this identity forward, never resurrect it
 		}
 		sameTuple := ag.SocketPath == c.SocketPath && ag.SessionID == c.SessionID
 		if !ag.Departed && !sameTuple && ag.SocketPath != "" &&
@@ -141,30 +142,6 @@ func hookSessionStartResume(c tmuxenv.Capture, h harnessenv.Capture, model strin
 		reclaimed++
 	}
 	return reclaimed > 0
-}
-
-// hookResumeSuperseded reports whether ag is a become-retired seed: a
-// departed row whose (socket_path, session_id) tuple is ALSO held by a live
-// sibling among this harness session's own rows. store.Become clones the
-// seed's exact tuple onto the claimed alias and marks only the seed
-// departed, so nothing else in the row itself distinguishes "retired because
-// its name was claimed" from an ordinary Stop/SessionEnd tombstone — this
-// tuple-sharing signature is unique to become (a live split-identity sibling
-// pair is tombstoned together by hookSessionEnd, never leaving one live and
-// one departed on the same tuple). Without this check, resume would
-// reclaim the seed right alongside the alias that already claimed its
-// identity, resurrecting a name the operator explicitly retired.
-func hookResumeSuperseded(ag agentRow, owned []agentRow) bool {
-	if !ag.Departed {
-		return false
-	}
-	for _, other := range owned {
-		if other.Alias != ag.Alias && !other.Departed &&
-			other.SocketPath == ag.SocketPath && other.SessionID == ag.SessionID {
-			return true
-		}
-	}
-	return false
 }
 
 // hookSessionStartPaneless auto-registers a session that has no tmux pane in

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -42,6 +42,10 @@ type agentFull struct {
 	// Label mirrors agentRow's own copy — the resume reclaim test asserts a
 	// manually-pinned label survives the reclaim onto the new tuple.
 	Label string `json:"label"`
+	// SupersededBy mirrors store.Agent.SupersededBy — hookSessionStartResume
+	// reads it via hookGetAgent/harnessOwnedRows to tell a become-retired
+	// seed (never reclaim) from an ordinary tombstone (reclaim as before).
+	SupersededBy string `json:"superseded_by"`
 }
 
 type agentRow struct {
@@ -70,6 +74,12 @@ type agentRow struct {
 	// --purge-agents both key off this to decide whether a row still needs
 	// reaping or is already history.
 	Departed bool `json:"departed"`
+	// SupersededBy mirrors store.Agent.SupersededBy — non-empty on a row
+	// retired via `become`, naming the alias that now carries its identity
+	// forward. hookSessionStartResume uses this as ground truth: a departed
+	// row with SupersededBy set must never reclaim on resume, regardless of
+	// whether its successor is currently live.
+	SupersededBy string `json:"superseded_by"`
 }
 
 // threadRow decodes daemon thread responses (get_inbox, get_thread, list_tasks).

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -80,17 +80,23 @@ func cmdRegister(args []string, out io.Writer) error {
 		}
 		if owned := harnessOwnedRows(h.SessionID); len(owned) > 0 {
 			// This session already has an identity (a handshake tmux row or a
-			// prior paneless one): refresh/revive it with its stored shape
-			// intact rather than allocating another.
-			alias = owned[0].Alias
-			ack := reviveRow(owned[0], *model)
-			if _, err := fmt.Fprintf(out, "registered %s (existing identity, project %q, model %s)\n", alias, owned[0].Project, *model); err != nil {
-				return err
+			// prior paneless one): refresh/revive it with its stored shape intact
+			// rather than allocating another — but never a become-retired seed
+			// (finding F1): firstUnsuperseded skips any row already claimed away
+			// via `muster become`. If every owned row is superseded there is no
+			// identity left to revive here; fall through to allocation below
+			// exactly as if owned had been empty.
+			if ag, ok := firstUnsuperseded(owned); ok {
+				alias = ag.Alias
+				ack := reviveRow(ag, *model)
+				if _, err := fmt.Fprintf(out, "registered %s (existing identity, project %q, model %s)\n", alias, ag.Project, *model); err != nil {
+					return err
+				}
+				if s := ack.line(alias); s != "" {
+					_, _ = fmt.Fprint(out, s)
+				}
+				return nil
 			}
-			if s := ack.line(alias); s != "" {
-				_, _ = fmt.Fprint(out, s)
-			}
-			return nil
 		}
 		var err error
 		if alias, err = allocPanelessAlias(h.Alias(), h.SessionID, regFn); err != nil {

--- a/internal/humancli/paneless.go
+++ b/internal/humancli/paneless.go
@@ -117,6 +117,24 @@ func harnessOwnedRows(uuid string) []agentRow {
 	return mine
 }
 
+// firstUnsuperseded returns the first row in owned whose SupersededBy is
+// empty, and true. A non-empty SupersededBy means this row is a
+// become-retired seed: store.Become already cloned its identity onto the
+// named successor in the same transaction that tombstoned it, so reviving
+// THIS row would resurrect a retired identity under its old alias — exactly
+// the bug finding F1 closes. false means every row in owned is superseded
+// (or owned is empty); callers must treat that as "no identity here" and
+// fall through to ordinary allocation/registration, never revive one of
+// them.
+func firstUnsuperseded(owned []agentRow) (agentRow, bool) {
+	for _, ag := range owned {
+		if ag.SupersededBy == "" {
+			return ag, true
+		}
+	}
+	return agentRow{}, false
+}
+
 // reviveRow re-registers a tombstoned row echoing back its own stored
 // identity — tuple, harness link, project, label — so revival never rewrites
 // what the row already knows about itself. Returns the daemon's ack (outcome

--- a/internal/humancli/paneless_test.go
+++ b/internal/humancli/paneless_test.go
@@ -435,3 +435,55 @@ func TestLaunchHandshakeLifecycle(t *testing.T) {
 		t.Fatalf("SessionEnd must tombstone the handshake row, got %+v found=%v", ag, found)
 	}
 }
+
+// TestHookSessionStartPanelessRevivesSuccessorNotSupersededSeed is finding
+// F1's core scenario: a harness session UUID owns TWO tombstoned rows —
+// "aaa-old" (become-retired: superseded_by="zzz-new") and "zzz-new" (the
+// successor, also since departed on its own). ORDER BY alias in ListAgents
+// puts "aaa-old" first, so the pre-fix code (owned[0], no SupersededBy
+// check) would revive the RETIRED SEED under its old alias — resurrecting an
+// identity that `muster become` already carried forward. The fix
+// (firstUnsuperseded) must skip it and revive "zzz-new" instead, leaving
+// "aaa-old" departed forever.
+func TestHookSessionStartPanelessRevivesSuccessorNotSupersededSeed(t *testing.T) {
+	startTestDaemon(t)
+	panelessEnv(t, "hs-f1", "f1-dir")
+
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "aaa-old", "session_id": "hs-f1", "harness_session_id": "hs-f1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("become", map[string]any{"from": "aaa-old", "to": "zzz-new"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("deregister_agent", map[string]any{"alias": "zzz-new"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup sanity: both rows departed, and the supersession link points the
+	// direction the fix must respect.
+	old, ok := hookGetAgent("aaa-old")
+	if !ok || !old.Departed || old.SupersededBy != "zzz-new" {
+		t.Fatalf("setup: aaa-old = %+v (ok=%v)", old, ok)
+	}
+	successor, ok := hookGetAgent("zzz-new")
+	if !ok || !successor.Departed || successor.SupersededBy != "" {
+		t.Fatalf("setup: zzz-new = %+v (ok=%v)", successor, ok)
+	}
+
+	payload := `{"session_id":"hs-f1","cwd":"/x/f1-dir"}`
+	var buf bytes.Buffer
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	revived, ok := hookGetAgent("zzz-new")
+	if !ok || revived.Departed || revived.SessionID != "hs-f1" {
+		t.Fatalf("revive must pick the successor zzz-new, got %+v (ok=%v)", revived, ok)
+	}
+	stillOld, ok := hookGetAgent("aaa-old")
+	if !ok || !stillOld.Departed {
+		t.Fatalf("the superseded seed must never be resurrected, got %+v (ok=%v)", stillOld, ok)
+	}
+}

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -230,6 +230,18 @@ from tmux (internal/tmuxenv) so other commands can address it.`,
 			Run:      cmdRegister,
 		},
 		{
+			Name:     "become",
+			Synopsis: "become <name> [--from <alias>]",
+			Summary:  "Claim a durable name for this session.",
+			Help: `Claim this session's real name: a new alias inherits this session's
+identity and inbox watermark, and the tmux-seeded alias retires — route
+traffic by a name the work deserves. --from selects which of this session's
+live aliases to claim from; required when the session has more than one.`,
+			Group:    GroupIdentity,
+			NewFlags: newBecomeFlags,
+			Run:      cmdBecome,
+		},
+		{
 			Name:     "deregister",
 			Synopsis: "deregister [<alias>]",
 			Summary:  "Remove an agent's registration.",

--- a/internal/humancli/registry_test.go
+++ b/internal/humancli/registry_test.go
@@ -16,7 +16,7 @@ import (
 var wantCommandNames = []string{
 	"send", "nudge", "reply",
 	"agents", "inbox", "tasks", "thread", "events", "watch", "station",
-	"register", "deregister", "label", "whereami", "gc",
+	"register", "become", "deregister", "label", "whereami", "gc",
 	"serve", "mcp", "hook", "debug",
 }
 

--- a/internal/mcpserver/tools_registry.go
+++ b/internal/mcpserver/tools_registry.go
@@ -18,6 +18,7 @@ type RegisterAgentIn struct {
 	Role        string `json:"role" jsonschema:"this agent's role: producer, consumer, reviewer, ..."`
 	ModelType   string `json:"model_type" jsonschema:"the model backing this agent: claude, codex, or cursor"`
 	SessionName string `json:"session_name,omitempty" jsonschema:"optional tmux session name for display"`
+	Become      bool   `json:"become,omitempty" jsonschema:"claim this alias as the session's name: the current alias retires and its identity and read-state carry over"`
 }
 
 // OKOut is a simple success acknowledgement for void operations.
@@ -37,11 +38,26 @@ type ListAgentsOut struct {
 func registerAgentHandler(_ context.Context, _ *mcp.CallToolRequest, in RegisterAgentIn) (*mcp.CallToolResult, OKOut, error) {
 	c := tmuxenv.CaptureEnv()
 	if row, ok := paneRegistration(c.SocketPath, c.SessionID, c.PaneID, c.SessionCreated); ok && row.Alias != in.Alias {
+		if in.Become {
+			raw, err := callDaemon("become", map[string]any{"from": row.Alias, "to": in.Alias})
+			if err != nil {
+				return nil, OKOut{}, err
+			}
+			var trade struct {
+				From   string `json:"from"`
+				To     string `json:"to"`
+				Unread int    `json:"unread"`
+			}
+			_ = json.Unmarshal(raw, &trade)
+			detail := fmt.Sprintf("you are now '%s' (was '%s'); %d unread thread(s): call get_inbox with alias '%s'", trade.To, trade.From, trade.Unread, trade.To)
+			return nil, OKOut{OK: true, Detail: detail}, nil
+		}
 		detail := fmt.Sprintf("already registered as '%s'", row.Alias)
 		if row.Label != "" {
 			detail = fmt.Sprintf("already registered as '%s' (label '%s')", row.Alias, row.Label)
 		}
-		return nil, OKOut{OK: true, Detail: detail + " — use that alias; not adding a second"}, nil
+		detail += " — use that alias; not adding a second, or pass become:true to claim '" + in.Alias + "' as this session's name"
+		return nil, OKOut{OK: true, Detail: detail}, nil
 	}
 
 	h := harnessenv.FromEnv()

--- a/internal/mcpserver/tools_registry_test.go
+++ b/internal/mcpserver/tools_registry_test.go
@@ -228,3 +228,83 @@ func TestRegisterAgentFreshPaneRegisters(t *testing.T) {
 		t.Fatalf("fresh pane must register: registered=%v out=%+v err=%v", registered, out, err)
 	}
 }
+
+// TestRegisterAgentBecomeClaimsThroughPaneGuard: an already-registered pane
+// calling register_agent with become:true issues the become op instead of
+// the refusal, and the Detail reports the trade.
+func TestRegisterAgentBecomeClaimsThroughPaneGuard(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%6")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		if args[len(args)-1] == "#{session_id}" {
+			return "$1", nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var becomeArgs map[string]any
+	prevDaemon := callDaemon
+	callDaemon = func(op string, args map[string]any) (json.RawMessage, error) {
+		switch op {
+		case "become":
+			becomeArgs = args
+			return []byte(`{"from":"muster-2","to":"alias-routing","unread":2}`), nil
+		default: // paneRegistration's roster probe: this pane already owns muster-2
+			return []byte(`[{"alias":"muster-2","socket_path":"/tmp/sock","session_id":"$1","pane_id":"%6"}]`), nil
+		}
+	}
+	t.Cleanup(func() { callDaemon = prevDaemon })
+
+	_, out, err := registerAgentHandler(context.TODO(), nil, RegisterAgentIn{
+		Alias: "alias-routing", Role: "peer", ModelType: "claude", Become: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if becomeArgs["from"] != "muster-2" || becomeArgs["to"] != "alias-routing" {
+		t.Fatalf("become args = %+v", becomeArgs)
+	}
+	if !strings.Contains(out.Detail, "you are now 'alias-routing' (was 'muster-2')") ||
+		!strings.Contains(out.Detail, "2 unread") {
+		t.Fatalf("Detail = %q", out.Detail)
+	}
+}
+
+// TestRegisterAgentRefusalAdvertisesBecome: the become:false refusal now
+// tells the agent how to claim instead of dead-ending.
+func TestRegisterAgentRefusalAdvertisesBecome(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%6")
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		if args[len(args)-1] == "#{session_id}" {
+			return "$1", nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	prevDaemon := callDaemon
+	callDaemon = func(op string, _ map[string]any) (json.RawMessage, error) {
+		switch op {
+		case "become":
+			t.Fatalf("must not issue become op when become:false")
+			return nil, nil
+		default: // paneRegistration's roster probe: this pane already owns muster-2
+			return []byte(`[{"alias":"muster-2","socket_path":"/tmp/sock","session_id":"$1","pane_id":"%6"}]`), nil
+		}
+	}
+	t.Cleanup(func() { callDaemon = prevDaemon })
+
+	_, out, err := registerAgentHandler(context.TODO(), nil, RegisterAgentIn{
+		Alias: "alias-routing", Role: "peer", ModelType: "claude", Become: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Detail, "pass become:true to claim 'alias-routing'") {
+		t.Fatalf("Detail = %q, want become-advertisement", out.Detail)
+	}
+}

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -12,12 +12,15 @@ import (
 // departed is always reset to 0 by both the insert and the conflict update, so
 // re-registering a previously-departed alias (a returning session) revives it
 // cleanly — read-state (last_read_entry_id/last_read_at) is untouched by
-// either branch, so it survives the roundtrip intact.
+// either branch, so it survives the roundtrip intact. superseded_by is always
+// reset to ” too: a revived/re-registered alias is no longer superseded by
+// whatever claimed it before (e.g. the operator purged the successor and
+// re-registered the old name) — see Store.Become and hookSessionStartResume.
 func (s *Store) RegisterAgent(a Agent) error {
 	now := clock.NowMillis()
 	_, err := s.db.Exec(`
-INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, departed, registered_at, last_seen)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, departed, superseded_by, registered_at, last_seen)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, '', ?, ?)
 ON CONFLICT(alias) DO UPDATE SET
     role=excluded.role,
     model_type=excluded.model_type,
@@ -31,6 +34,7 @@ ON CONFLICT(alias) DO UPDATE SET
     label=excluded.label,
     label_manual=excluded.label_manual,
     departed=0,
+    superseded_by='',
     last_seen=excluded.last_seen`,
 		a.Alias, a.Role, a.ModelType, a.SocketPath, a.PaneID, a.SessionName, a.SessionID, a.SessionCreated,
 		a.HarnessSessionID, a.Project, a.Label, a.LabelManual, now, now)
@@ -41,7 +45,7 @@ ON CONFLICT(alias) DO UPDATE SET
 // agents included: their rows are history, not gone (see DepartAgent).
 func (s *Store) ListAgents() ([]Agent, error) {
 	rows, err := s.db.Query(`
-SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed
+SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed, superseded_by
 FROM agents ORDER BY alias`)
 	if err != nil {
 		return nil, err
@@ -50,7 +54,7 @@ FROM agents ORDER BY alias`)
 	var out []Agent
 	for rows.Next() {
 		var a Agent
-		if err := rows.Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.HarnessSessionID, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed); err != nil {
+		if err := rows.Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.HarnessSessionID, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed, &a.SupersededBy); err != nil {
 			return nil, err
 		}
 		out = append(out, a)
@@ -64,9 +68,9 @@ FROM agents ORDER BY alias`)
 func (s *Store) GetAgent(alias string) (Agent, bool, error) {
 	var a Agent
 	err := s.db.QueryRow(`
-SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed
+SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed, superseded_by
 FROM agents WHERE alias=?`, alias).
-		Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.HarnessSessionID, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed)
+		Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.HarnessSessionID, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed, &a.SupersededBy)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Agent{}, false, nil
 	}
@@ -242,11 +246,18 @@ var (
 // become-claim-your-name): inserts to as a CLONE of from — tuple, harness
 // link, project, label, role, model, and the READ WATERMARK, without which
 // the claimed identity would see all of history as unread — then retires
-// from as a tombstone. to must not exist at all: a live row is someone
-// else's identity and a tombstone is some other conversation's history;
-// merging identities is exactly the confusion this feature exists to kill.
-// from may already be departed (a claim after gc swept the seed). One
-// transaction: a crash mid-become never leaves both rows live.
+// from as a tombstone AND stamps from.superseded_by = to. to must not exist
+// at all: a live row is someone else's identity and a tombstone is some
+// other conversation's history; merging identities is exactly the confusion
+// this feature exists to kill. from may already be departed (a claim after
+// gc swept the seed). The clone's INSERT deliberately omits superseded_by
+// (it defaults to ”) — the successor starts unsuperseded even if from was
+// itself a superseded row (a chained become A→B→C leaves B's superseded_by
+// pointing at C, never inherited backward onto C). superseded_by is the
+// ground truth hookSessionStartResume uses to keep a retired seed from
+// resurrecting on resume, in place of inferring retirement from tuple
+// coincidence. One transaction: a crash mid-become never leaves both rows
+// live.
 func (s *Store) Become(from, to string) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -274,7 +285,7 @@ FROM agents WHERE alias=?`, to, now, now, from)
 	} else if rows == 0 {
 		return ErrBecomeFromMissing
 	}
-	if _, err := tx.Exec(`UPDATE agents SET departed=1 WHERE alias=?`, from); err != nil {
+	if _, err := tx.Exec(`UPDATE agents SET departed=1, superseded_by=? WHERE alias=?`, to, from); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -308,10 +308,38 @@ FROM agents WHERE alias=?`, to, now, now, from)
 // a real session identity whose sibling aliases group exactly like a tmux
 // session's; the sessionID guard alone keeps pre-harnessenv no-tmux rows
 // (both fields empty) from ever grouping with each other.
+//
+// Mail follows the name, wherever the conversation moved (become-retired
+// lineage, found live: a straggler addressed to a retired seed alias must
+// still light the badge on the tuple its identity moved to). The sess CTE is
+// therefore a WITH RECURSIVE lineage walk, not a flat tuple match: the base
+// case is every alias currently sitting on the queried tuple; each
+// recursive step adds rows whose superseded_by points at an alias already
+// in the set. store.Become stamps superseded_by on the SEED pointing
+// FORWARD at its successor (from.superseded_by = to), so the walk goes
+// backward through the chain — for A→B→C (A became B, B became C: A's
+// superseded_by='B', B's superseded_by='C'), starting from C on the live
+// tuple the first step finds B (superseded_by='C') and the next step finds
+// A (superseded_by='B'), even though A's own row still sits on a
+// long-dead tuple. Each lineage row keeps ITS OWN
+// last_read_entry_id as the EXISTS watermark below — a superseded row's
+// watermark is frozen at the moment it was retired (exactly the read state
+// Become cloned forward onto its successor), so this stays per-row
+// semantics, never a session-wide max. UNION (not UNION ALL) dedups on the
+// full row; since alias is a primary key, that collapses to "one alias
+// enters the set at most once" — a malformed superseded_by cycle (A→B→A)
+// simply produces no new row on the step that would re-add an
+// already-present alias, so the recursion terminates instead of hanging
+// (see TestSessionUnreadLineageCycleGuard).
 func (s *Store) SessionUnread(socketPath, sessionID string) (total, action int, err error) {
 	err = s.db.QueryRow(`
-WITH sess AS (SELECT alias, last_read_entry_id FROM agents
-              WHERE socket_path = ?1 AND session_id = ?2 AND ?2 != '')
+WITH RECURSIVE sess AS (
+  SELECT alias, last_read_entry_id, superseded_by FROM agents
+  WHERE socket_path = ?1 AND session_id = ?2 AND ?2 != ''
+  UNION
+  SELECT a.alias, a.last_read_entry_id, a.superseded_by
+  FROM agents a JOIN sess ON a.superseded_by = sess.alias
+)
 SELECT
   COUNT(DISTINCT threads.id),
   COUNT(DISTINCT CASE WHEN `+effectiveIntent+` = 'action-requested' THEN threads.id END)
@@ -323,4 +351,40 @@ WHERE EXISTS (SELECT 1 FROM entries e
                 AND e.from_agent NOT IN (SELECT alias FROM sess))`,
 		socketPath, sessionID).Scan(&total, &action)
 	return total, action, err
+}
+
+// SessionAliasLineage returns every alias belonging to a session's
+// supersession lineage — the exact same WITH RECURSIVE walk SessionUnread
+// runs (see its doc comment for the "mail follows the name" rule and the
+// cycle-termination argument), projected down to just the alias column. It
+// backs the daemon's session_aliases op, which includes departed aliases ON
+// PURPOSE (their unread mail still needs draining) — lineage rows are
+// additive to that, never a filter: a become-retired seed on a long-dead
+// tuple belongs in the list precisely because it is departed, not despite
+// it. Result is sorted and deduplicated; an empty sessionID matches no
+// agents (mirrors SessionUnread's empty-tuple guard) and returns an empty
+// slice.
+func (s *Store) SessionAliasLineage(socketPath, sessionID string) ([]string, error) {
+	rows, err := s.db.Query(`
+WITH RECURSIVE sess AS (
+  SELECT alias, superseded_by FROM agents
+  WHERE socket_path = ?1 AND session_id = ?2 AND ?2 != ''
+  UNION
+  SELECT a.alias, a.superseded_by
+  FROM agents a JOIN sess ON a.superseded_by = sess.alias
+)
+SELECT alias FROM sess ORDER BY alias`, socketPath, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := []string{}
+	for rows.Next() {
+		var alias string
+		if err := rows.Scan(&alias); err != nil {
+			return nil, err
+		}
+		out = append(out, alias)
+	}
+	return out, rows.Err()
 }

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -231,6 +231,55 @@ func (s *Store) MarkRead(alias string) error {
 	return tx.Commit()
 }
 
+// ErrBecomeFromMissing / ErrBecomeToExists are become's guard sentinels —
+// the daemon maps them to loud, hint-carrying wire errors.
+var (
+	ErrBecomeFromMissing = errors.New("become: from alias not found")
+	ErrBecomeToExists    = errors.New("become: to alias already exists")
+)
+
+// Become claims a new name for an existing identity (spec:
+// become-claim-your-name): inserts to as a CLONE of from — tuple, harness
+// link, project, label, role, model, and the READ WATERMARK, without which
+// the claimed identity would see all of history as unread — then retires
+// from as a tombstone. to must not exist at all: a live row is someone
+// else's identity and a tombstone is some other conversation's history;
+// merging identities is exactly the confusion this feature exists to kill.
+// from may already be departed (a claim after gc swept the seed). One
+// transaction: a crash mid-become never leaves both rows live.
+func (s *Store) Become(from, to string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var n int
+	if err := tx.QueryRow(`SELECT COUNT(*) FROM agents WHERE alias=?`, to).Scan(&n); err != nil {
+		return err
+	}
+	if n > 0 {
+		return ErrBecomeToExists
+	}
+	now := clock.NowMillis()
+	res, err := tx.Exec(`
+INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, departed, registered_at, last_seen, last_read_entry_id, last_read_at)
+SELECT ?, role, model_type, socket_path, pane_id, session_name, session_id, session_created, harness_session_id, project, label, label_manual, 0, ?, ?, last_read_entry_id, last_read_at
+FROM agents WHERE alias=?`, to, now, now, from)
+	if err != nil {
+		return err
+	}
+	if rows, err := res.RowsAffected(); err != nil {
+		return err
+	} else if rows == 0 {
+		return ErrBecomeFromMissing
+	}
+	if _, err := tx.Exec(`UPDATE agents SET departed=1 WHERE alias=?`, from); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // SessionUnread is the ONE canonical session-level unread query (spec §3):
 // all aliases sharing the exact (socketPath, sessionID) tuple are one actor
 // identity for unread math and actor exclusion. total is the count of

--- a/internal/store/agents_test.go
+++ b/internal/store/agents_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/schuettc/muster/internal/clock"
 )
@@ -431,6 +432,124 @@ func TestSessionUnreadPerAliasWatermarks(t *testing.T) {
 	if total != 0 {
 		t.Fatalf("after MarkRead(aliasB): expected 0 unread, got %d", total)
 	}
+}
+
+// TestSessionUnreadFollowsSupersessionLineage reproduces the live-rig gap:
+// become + resume leaves the retired seed's row on its OLD (now-dead) tuple
+// while its identity moved to a NEW tuple. Mail addressed to the retired
+// seed alias must still count against the session now sitting on the new
+// tuple — the lineage walk, not a flat tuple match.
+func TestSessionUnreadFollowsSupersessionLineage(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "seed", SocketPath: "/old", SessionID: "$old"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Become("seed", "claimed"); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate hookSessionStartResume's reclaim: the claimed alias's row
+	// re-registers onto a brand-new tuple (the resumed session), while the
+	// seed's row stays exactly where Become left it — on the OLD tuple,
+	// departed, superseded_by="claimed".
+	if err := s.RegisterAgent(Agent{Alias: "claimed", SocketPath: "/new", SessionID: "$new"}); err != nil {
+		t.Fatal(err)
+	}
+	seed, _, _ := s.GetAgent("seed")
+	if !seed.Departed || seed.SocketPath != "/old" || seed.SessionID != "$old" {
+		t.Fatalf("seed row expected to stay departed on the old tuple: %+v", seed)
+	}
+
+	// A straggler addressed to the RETIRED seed alias.
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "outsider", ToKind: "agent", ToTarget: "seed"}, "hi seed"); err != nil {
+		t.Fatal(err)
+	}
+
+	total, _, err := s.SessionUnread("/new", "$new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 {
+		t.Fatalf("mail addressed to a superseded seed must count on the successor's live tuple: got total=%d, want 1", total)
+	}
+}
+
+// TestSessionUnreadFollowsChainedLineage: A→B→C (A became B, B became C),
+// with only C sitting on the live tuple. The lineage walk must resolve
+// TRANSITIVELY through the middle link — mail addressed to the original
+// alias A must still reach C's tuple, not just B's.
+func TestSessionUnreadFollowsChainedLineage(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "a", SocketPath: "/old", SessionID: "$old"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Become("a", "b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Become("b", "c"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "c", SocketPath: "/new", SessionID: "$new"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "outsider", ToKind: "agent", ToTarget: "a"}, "hi a"); err != nil {
+		t.Fatal(err)
+	}
+
+	total, _, err := s.SessionUnread("/new", "$new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 {
+		t.Fatalf("mail addressed to the ORIGINAL alias of a two-hop chain must reach the final tuple: got total=%d, want 1", total)
+	}
+}
+
+// TestSessionUnreadLineageCycleGuard: a malformed superseded_by cycle
+// (deliberately written past Become's own guards, via raw SQL — Become
+// itself can never produce one) must not hang the recursive CTE and must
+// not miscount. UNION's row-level dedup is what bounds the recursion.
+func TestSessionUnreadLineageCycleGuard(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "x", SocketPath: "/s", SessionID: "$1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "y", SocketPath: "/other", SessionID: "$other"}); err != nil {
+		t.Fatal(err)
+	}
+	// Force a cycle: x superseded_by y, y superseded_by x. Both rows sit on
+	// the queried tuple's neighborhood is irrelevant here — the point is the
+	// recursive walk from x's own tuple must terminate.
+	if _, err := s.DB().Exec(`UPDATE agents SET departed=1, superseded_by='y' WHERE alias='x'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().Exec(`UPDATE agents SET departed=1, superseded_by='x' WHERE alias='y'`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "outsider", ToKind: "agent", ToTarget: "x"}, "hi x"); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	var total, action int
+	var err error
+	go func() {
+		total, action, err = s.SessionUnread("/s", "$1")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SessionUnread hung on a superseded_by cycle")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 {
+		t.Fatalf("cycle must not miscount (double-add) the shared alias: got total=%d, want 1", total)
+	}
+	_ = action
 }
 
 // TestSetHarnessSessionID covers the hook-repair path of the durable-alias

--- a/internal/store/agents_test.go
+++ b/internal/store/agents_test.go
@@ -498,6 +498,61 @@ func TestBecomeClonesIdentityAndRetiresSeed(t *testing.T) {
 	}
 }
 
+// TestBecomeStampsSupersededBy: Become's ground-truth lineage marker (fix
+// round 1, replacing hookResumeSuperseded's tuple-sharing heuristic) —
+// the seed's superseded_by must name the claimed alias, the CLONE must NOT
+// inherit it (a chained become's successor starts unsuperseded even though
+// its own seed was itself superseded), and re-registering the retired seed
+// must clear it (a revived/re-registered alias is no longer superseded — the
+// operator may have purged the successor and taken the name back).
+func TestBecomeStampsSupersededBy(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "muster-2", SocketPath: "/s", SessionID: "$1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Become("muster-2", "alias-routing"); err != nil {
+		t.Fatal(err)
+	}
+	seed, _, _ := s.GetAgent("muster-2")
+	if seed.SupersededBy != "alias-routing" {
+		t.Fatalf("seed.SupersededBy = %q, want %q", seed.SupersededBy, "alias-routing")
+	}
+	successor, _, _ := s.GetAgent("alias-routing")
+	if successor.SupersededBy != "" {
+		t.Fatalf("clone must not inherit SupersededBy: %+v", successor)
+	}
+
+	// Chain the claim again: alias-routing -> final-name. The middle link
+	// (alias-routing) becomes superseded too; the seed (muster-2) is
+	// untouched by this second call and keeps pointing at alias-routing, not
+	// final-name — superseded_by never chases the chain to its end.
+	if err := s.Become("alias-routing", "final-name"); err != nil {
+		t.Fatal(err)
+	}
+	middle, _, _ := s.GetAgent("alias-routing")
+	if middle.SupersededBy != "final-name" {
+		t.Fatalf("middle.SupersededBy = %q, want %q", middle.SupersededBy, "final-name")
+	}
+	seedAfterChain, _, _ := s.GetAgent("muster-2")
+	if seedAfterChain.SupersededBy != "alias-routing" {
+		t.Fatalf("seed.SupersededBy changed by a later become on its successor: %+v", seedAfterChain)
+	}
+	end, _, _ := s.GetAgent("final-name")
+	if end.SupersededBy != "" {
+		t.Fatalf("final clone must not inherit SupersededBy: %+v", end)
+	}
+
+	// Re-registering the retired seed clears it — a revived/re-registered
+	// alias is no longer superseded.
+	if err := s.RegisterAgent(Agent{Alias: "muster-2", SocketPath: "/s2", SessionID: "$9"}); err != nil {
+		t.Fatal(err)
+	}
+	revived, _, _ := s.GetAgent("muster-2")
+	if revived.SupersededBy != "" || revived.Departed {
+		t.Fatalf("re-register must clear SupersededBy and revive: %+v", revived)
+	}
+}
+
 // TestBecomeGuards: missing from and existing to (live OR tombstoned) both
 // fail with the typed sentinels — become never silently fuses identities.
 func TestBecomeGuards(t *testing.T) {

--- a/internal/store/agents_test.go
+++ b/internal/store/agents_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -453,5 +454,69 @@ func TestSetHarnessSessionID(t *testing.T) {
 	// Unknown alias is a no-op, mirroring TouchAgent's contract.
 	if err := s.SetHarnessSessionID("ghost", "uuid-2"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestBecomeClonesIdentityAndRetiresSeed covers the become spec's core move:
+// the claimed alias inherits the seed's full identity INCLUDING the read
+// watermark (without it, all of history would flip unread), and the seed
+// retires as a tombstone with its own history intact.
+func TestBecomeClonesIdentityAndRetiresSeed(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{
+		Alias: "muster-2", Role: "peer", ModelType: "claude",
+		SocketPath: "/s", SessionID: "$1", SessionCreated: 111, PaneID: "%1",
+		SessionName: "muster-2", HarnessSessionID: "uuid-1",
+		Project: "muster", Label: "durable-alias", LabelManual: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkRead("muster-2"); err != nil { // establish a nonzero watermark
+		t.Fatal(err)
+	}
+	seed, _, _ := s.GetAgent("muster-2")
+
+	if err := s.Become("muster-2", "alias-routing"); err != nil {
+		t.Fatal(err)
+	}
+	to, ok, err := s.GetAgent("alias-routing")
+	if err != nil || !ok {
+		t.Fatalf("claimed alias missing: %v %v", ok, err)
+	}
+	if to.SocketPath != "/s" || to.SessionID != "$1" || to.SessionCreated != 111 ||
+		to.PaneID != "%1" || to.HarnessSessionID != "uuid-1" ||
+		to.Project != "muster" || to.Label != "durable-alias" || !to.LabelManual ||
+		to.Role != "peer" || to.ModelType != "claude" || to.Departed {
+		t.Fatalf("clone dropped identity fields: %+v", to)
+	}
+	if to.LastReadEntryID != seed.LastReadEntryID {
+		t.Fatalf("watermark not carried: got %d want %d", to.LastReadEntryID, seed.LastReadEntryID)
+	}
+	from, _, _ := s.GetAgent("muster-2")
+	if !from.Departed {
+		t.Fatalf("seed not retired: %+v", from)
+	}
+}
+
+// TestBecomeGuards: missing from and existing to (live OR tombstoned) both
+// fail with the typed sentinels — become never silently fuses identities.
+func TestBecomeGuards(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.Become("ghost", "x"); !errors.Is(err, ErrBecomeFromMissing) {
+		t.Fatalf("missing from: got %v", err)
+	}
+	_ = s.RegisterAgent(Agent{Alias: "a"})
+	_ = s.RegisterAgent(Agent{Alias: "b"})
+	if err := s.Become("a", "b"); !errors.Is(err, ErrBecomeToExists) {
+		t.Fatalf("live to: got %v", err)
+	}
+	_ = s.DepartAgent("b")
+	if err := s.Become("a", "b"); !errors.Is(err, ErrBecomeToExists) {
+		t.Fatalf("tombstoned to must ALSO refuse: got %v", err)
+	}
+	// Departed FROM is fine: a session may claim after gc tombstoned its seed.
+	_ = s.DepartAgent("a")
+	if err := s.Become("a", "c"); err != nil {
+		t.Fatalf("departed from should still clone: %v", err)
 	}
 }

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -59,6 +59,15 @@ type Agent struct {
 	// row — it sets Departed instead; `gc --purge-agents` hard-deletes
 	// departed/dead rows the old way.
 	Departed bool `json:"departed"`
+	// SupersededBy is non-empty on a departed row that was claimed away via
+	// Become: it names the alias that now carries this identity forward.
+	// RegisterAgent's upsert always resets it to "" (a revived/re-registered
+	// alias is no longer superseded — e.g. the operator purged the successor
+	// and re-registered the old name), and Become's clone does NOT copy it
+	// onto the new alias (the successor starts unsuperseded). Resume reclaim
+	// (hookSessionStartResume) uses this as ground truth to skip resurrecting a
+	// retired seed, rather than inferring it from tuple coincidence.
+	SupersededBy string `json:"superseded_by"`
 }
 
 // Thread is a conversation: a message (no status) or a task (status set).

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS agents (
     last_read_at  INTEGER NOT NULL DEFAULT 0,
     last_read_entry_id INTEGER NOT NULL DEFAULT 0,
     departed      INTEGER NOT NULL DEFAULT 0, -- 1 = deregistered (tombstoned): identity/project/label/read-state all preserved; see store.migrate and Store.DepartAgent
-    superseded_by TEXT NOT NULL DEFAULT '', -- non-empty on a departed row claimed away via Become: names the alias that now carries this identity forward, so resume reclaim never resurrects a retired seed (see Store.Become, hookResumeSuperseded). Cleared on re-register (RegisterAgent's upsert): a revived/re-registered alias is no longer superseded.
+    superseded_by TEXT NOT NULL DEFAULT '', -- non-empty on a departed row claimed away via Become: names the alias that now carries this identity forward, so resume reclaim never resurrects a retired seed (see Store.Become, hookSessionStartResume). Cleared on re-register (RegisterAgent's upsert): a revived/re-registered alias is no longer superseded.
     registered_at INTEGER NOT NULL,
     last_seen     INTEGER NOT NULL
 );

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS agents (
     last_read_at  INTEGER NOT NULL DEFAULT 0,
     last_read_entry_id INTEGER NOT NULL DEFAULT 0,
     departed      INTEGER NOT NULL DEFAULT 0, -- 1 = deregistered (tombstoned): identity/project/label/read-state all preserved; see store.migrate and Store.DepartAgent
+    superseded_by TEXT NOT NULL DEFAULT '', -- non-empty on a departed row claimed away via Become: names the alias that now carries this identity forward, so resume reclaim never resurrects a retired seed (see Store.Become, hookResumeSuperseded). Cleared on re-register (RegisterAgent's upsert): a revived/re-registered alias is no longer superseded.
     registered_at INTEGER NOT NULL,
     last_seen     INTEGER NOT NULL
 );

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -51,6 +51,7 @@ func migrate(db *sql.DB) error {
 		`ALTER TABLE agents ADD COLUMN departed INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE agents ADD COLUMN session_created INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE agents ADD COLUMN harness_session_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE agents ADD COLUMN superseded_by TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, ddl := range alters {
 		if _, err := db.Exec(ddl); err != nil && !strings.Contains(err.Error(), "duplicate column name") {


### PR DESCRIPTION
## What

A session claims its real name once the work has one: `muster become <name>` (CLI) or `register_agent(..., become:true)` (MCP). A new identity row is created under the claimed alias — tuple, harness link, label, and the inbox read-watermark all carry over — and the tmux-seeded row retires with a persisted `superseded_by` stamp. From the claim onward, the roster and all traffic route by the name the work deserves; the seed (`muster-2`-style tmux names) goes back to being a launch placeholder.

Spec: `docs/superpowers/specs/2026-08-01-become-claim-your-name-design.md` (in this PR). This completes the durable-alias thesis from v0.8.0: that release made aliases durable; this one makes them meaningful.

## Design calls

- **Claim-and-retire, never rename-with-history.** Aliases stay immutable, so written references never dangle and the journal stays truthful; old threads read as the old name by design (operator: "we don't care about old stuff").
- **Never merge identities.** `become` refuses an existing target alias — live or tombstoned — with a loud hint.
- **Supersession is persisted, not inferred.** `superseded_by` is stamped in the Become transaction, never inherited by the clone, cleared on deliberate re-registration, and honored by every revive/reclaim path — a retired seed cannot resurrect, including across resume, graceful exit, chained claims, and paneless revival.
- **Labels untouched.** Prefix T / `muster label` stay the fast topical gesture; become is the rare identity claim.

## Review trail

Subagent-driven: 5 implementation tasks task-reviewed clean (one fix round mid-Task-5 after the integration test caught a real resurrection bug — the fix replaced a liveness heuristic with the persisted stamp). Whole-branch final review: one Important (paneless revive paths predating the stamp) + three minors — all fixed in `093435c`, scoped re-review clean.

## Operator notes

- New column `superseded_by` (additive migration; listed in both schema.sql and migrate()).
- Riding follow-ups (ledgered, none blocking): `--from` help-text note, MCP become ignores role/model_type overrides, schema.sql-vs-migrate drift cleanup, station/agents display of supersession.
- VERSION bump rides the next release train.