### PR TITLE
feat(cli): register --if-absent — race-free launch-wrapper seeding

### DIFF
--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -18,19 +18,20 @@ import (
 // newRegisterFlagsWithVals declares register's flags and returns typed
 // access to their values — shared by cmdRegister (real parsing) and
 // newRegisterFlags (registry help/man rendering).
-func newRegisterFlagsWithVals() (fs *flag.FlagSet, role, model, harness *string) {
+func newRegisterFlagsWithVals() (fs *flag.FlagSet, role, model, harness *string, ifAbsent *bool) {
 	fs = flag.NewFlagSet("register", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	role = fs.String("role", "", "this agent's role")
 	model = fs.String("model", "claude", "model backing this agent: claude, codex, or cursor")
+	ifAbsent = fs.Bool("if-absent", false, "fail instead of upserting when the alias is already registered to a DIFFERENT session — the race-free guard for launch wrappers seeding a session-name alias")
 	harness = fs.String("harness-session", "", "harness session UUID this registration belongs to — the pane-side launch handshake passes the UUID it then hands to `claude --session-id`, so the session's own hooks (which see no tmux) can find this row")
-	return fs, role, model, harness
+	return fs, role, model, harness, ifAbsent
 }
 
 // newRegisterFlags builds register's flag.FlagSet for registry-driven
 // help/man rendering.
 func newRegisterFlags() *flag.FlagSet {
-	fs, _, _, _ := newRegisterFlagsWithVals()
+	fs, _, _, _, _ := newRegisterFlagsWithVals()
 	return fs
 }
 
@@ -42,11 +43,14 @@ func newRegisterFlags() *flag.FlagSet {
 // harness session UUID, so hook ownership and sibling grouping still have an
 // identity tuple, ("", uuid), to key on.
 func cmdRegister(args []string, out io.Writer) error {
-	fs, role, model, harness := newRegisterFlagsWithVals()
-	// register has no boolean flags: --role and --model both take values, so
-	// pass an empty bool-flags set (an implicit default would wrongly reuse
-	// send's --role, which IS boolean there).
-	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{})
+	fs, role, model, harness, ifAbsent := newRegisterFlagsWithVals()
+	// --role and --model both take values, so they must be absent from the
+	// bool-flags set (an implicit default would wrongly reuse send's --role,
+	// which IS boolean there) — but --if-absent genuinely is boolean, so it
+	// must be listed here or splitFlagsAndPositional will misparse it as a
+	// value flag and swallow whatever token follows it (e.g. a positional
+	// alias) as its bogus value.
+	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{"if-absent": true})
 	if err := fs.Parse(flagArgs); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return HelpFor("register", out)
@@ -72,6 +76,16 @@ func cmdRegister(args []string, out io.Writer) error {
 		// registers exactly, above.
 		if h.Alias() == "" && h.SessionID == "" {
 			return fmt.Errorf("cannot determine alias: no tmux session and no usable working directory; pass one explicitly or set $MUSTER_ALIAS")
+		}
+		if *ifAbsent {
+			// allocPanelessAlias already runs its own internal if_absent CAS
+			// per candidate (base, base-2, ...) to keep two sessions launching
+			// in the same directory from colliding -- layering the caller's
+			// flag on top has no clean meaning here (which candidate would it
+			// even guard?). --if-absent is for the tmux-anchored seed path,
+			// where the alias is a single fixed target (the tmux session
+			// name), not an allocated one.
+			return fmt.Errorf("--if-absent is for the tmux-anchored seed path; paneless registration already allocates a unique alias race-free (see allocPanelessAlias)")
 		}
 		regFn := func(a string, ifAbsent bool) error {
 			args := registerPanelessArgs(a, *role, *model, h, ifAbsent)
@@ -134,6 +148,7 @@ func cmdRegister(args []string, out io.Writer) error {
 		"harness_session_id": harnessID,
 		"socket_path":        socketPath, "pane_id": paneID,
 		"project": project, "label": c.Label, "label_manual": c.LabelManual,
+		"if_absent": *ifAbsent,
 	})
 	if err != nil {
 		return err

--- a/internal/humancli/identity.go
+++ b/internal/humancli/identity.go
@@ -23,7 +23,7 @@ func newRegisterFlagsWithVals() (fs *flag.FlagSet, role, model, harness *string,
 	fs.SetOutput(io.Discard)
 	role = fs.String("role", "", "this agent's role")
 	model = fs.String("model", "claude", "model backing this agent: claude, codex, or cursor")
-	ifAbsent = fs.Bool("if-absent", false, "fail instead of upserting when the alias is already registered to a DIFFERENT session — the race-free guard for launch wrappers seeding a session-name alias")
+	ifAbsent = fs.Bool("if-absent", false, "fail instead of upserting when the alias is already registered to a DIFFERENT session — the race-free guard for launch wrappers seeding a session-name alias. A same-tuple re-register (the ordinary relaunch-in-the-same-session seed path, even over a departed row) still succeeds; only a cross-session (different socket_path/session_id, or a differently-owned harness link) claim is refused")
 	harness = fs.String("harness-session", "", "harness session UUID this registration belongs to — the pane-side launch handshake passes the UUID it then hands to `claude --session-id`, so the session's own hooks (which see no tmux) can find this row")
 	return fs, role, model, harness, ifAbsent
 }

--- a/internal/humancli/identity_test.go
+++ b/internal/humancli/identity_test.go
@@ -315,6 +315,41 @@ func TestRegisterIfAbsentConflict(t *testing.T) {
 	}
 }
 
+// TestRegisterIfAbsentRefusesForeignHarnessClaim pins the semantics the
+// whole feature exists for: a fresh session's --if-absent seed must NOT take
+// over an alias already LIVE-claimed by a different owner. Alias "seed-owned"
+// is registered on tuple A carrying a real harness link (harness_session_id
+// "uuid-owner" — a genuinely claimed identity, not a bare tmux row). A
+// --if-absent register from tuple B, itself linked to a DIFFERENT harness
+// UUID ("uuid-attacker"), must fail with "if_absent conflict" and leave the
+// row on tuple A untouched — including its harness link, which a successful
+// (bad) overwrite would have clobbered.
+func TestRegisterIfAbsentRefusesForeignHarnessClaim(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/tmux-0/proj-muster,1,0")
+	t.Setenv("TMUX_PANE", "%0")
+	t.Setenv("MUSTER_ALIAS", "")
+	socketPath := "/tmp/tmux-0/proj-muster"
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "seed-owned", "socket_path": socketPath, "session_id": "$A",
+		"harness_session_id": "uuid-owner",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tmuxCaptureStub(t, "$B", "seed-owned")
+
+	var buf bytes.Buffer
+	err := cmdRegister([]string{"seed-owned", "--if-absent", "--harness-session", "uuid-attacker"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "if_absent conflict") {
+		t.Fatalf("expected an if_absent conflict error refusing the foreign claim, got %v", err)
+	}
+	agents := listAgentsForTest(t, "")
+	if len(agents) != 1 || agents[0].SessionID != "$A" || agents[0].HarnessSessionID != "uuid-owner" {
+		t.Fatalf("expected the owned row to survive untouched (tuple A, harness uuid-owner), got %+v", agents)
+	}
+}
+
 // TestRegisterIfAbsentSameTupleIdempotent covers the non-conflicting case:
 // re-registering with --if-absent from the SAME (socket_path, session_id)
 // tuple already on the row is a no-op upsert, not a conflict — a launch

--- a/internal/humancli/identity_test.go
+++ b/internal/humancli/identity_test.go
@@ -267,6 +267,114 @@ func TestGCRejectsNonPositiveEventsKeep(t *testing.T) {
 	}
 }
 
+// tmuxCaptureStub wires tmuxenv.Run to answer the register-path queries used
+// by cmdRegister's tmux-anchored branch: #{session_id} and #{session_name}
+// from the given values, everything else (the project/branch probe) with a
+// constant benign answer. Mirrors TestRegisterUsesAliasPrecedenceAndCaptures's
+// inline stub, factored out so the --if-absent tests can vary just the
+// session_id (the tuple's second half — socket_path comes from $TMUX itself).
+func tmuxCaptureStub(t *testing.T, sessionID, sessionName string) {
+	t.Helper()
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_id}":
+			return sessionID, nil
+		case "#{session_name}":
+			return sessionName, nil
+		default:
+			return "frontend\x1f1", nil
+		}
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+}
+
+// TestRegisterIfAbsentConflict covers the CAS the whole feature exists for: a
+// launch wrapper seeding a tmux-session-name alias must not silently steal it
+// out from under a LIVE claimed identity. Alias "seed" is already registered
+// to tuple A ($A); a --if-absent register capturing a DIFFERENT tuple ($B)
+// must fail with "if_absent conflict" and leave the row on tuple A untouched.
+func TestRegisterIfAbsentConflict(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/tmux-0/proj-muster,1,0")
+	t.Setenv("TMUX_PANE", "%0")
+	t.Setenv("MUSTER_ALIAS", "")
+	socketPath := "/tmp/tmux-0/proj-muster"
+	registerViaDaemon(t, "", "seed", socketPath, "$A")
+
+	tmuxCaptureStub(t, "$B", "seed")
+
+	var buf bytes.Buffer
+	err := cmdRegister([]string{"seed", "--if-absent"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "if_absent conflict") {
+		t.Fatalf("expected an if_absent conflict error, got %v", err)
+	}
+	agents := listAgentsForTest(t, "")
+	if len(agents) != 1 || agents[0].SessionID != "$A" {
+		t.Fatalf("expected the row to remain on tuple A untouched, got %+v", agents)
+	}
+}
+
+// TestRegisterIfAbsentSameTupleIdempotent covers the non-conflicting case:
+// re-registering with --if-absent from the SAME (socket_path, session_id)
+// tuple already on the row is a no-op upsert, not a conflict — a launch
+// wrapper re-running against its own already-seeded identity must succeed.
+func TestRegisterIfAbsentSameTupleIdempotent(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/tmux-0/proj-muster,1,0")
+	t.Setenv("TMUX_PANE", "%0")
+	t.Setenv("MUSTER_ALIAS", "")
+	socketPath := "/tmp/tmux-0/proj-muster"
+	registerViaDaemon(t, "", "seed2", socketPath, "$SAME")
+
+	tmuxCaptureStub(t, "$SAME", "seed2")
+
+	var buf bytes.Buffer
+	if err := cmdRegister([]string{"seed2", "--if-absent"}, &buf); err != nil {
+		t.Fatalf("same-tuple --if-absent register should succeed idempotently, got %v", err)
+	}
+	agents := listAgentsForTest(t, "")
+	if len(agents) != 1 || agents[0].SessionID != "$SAME" {
+		t.Fatalf("expected the row unchanged on the same tuple, got %+v", agents)
+	}
+}
+
+// TestRegisterIfAbsentOnFreshAlias covers the absent case: --if-absent
+// against an alias with no existing row at all must succeed and create it —
+// the CAS only ever blocks a DIFFERENT-tuple collision, never a fresh claim.
+func TestRegisterIfAbsentOnFreshAlias(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/tmux-0/proj-muster,1,0")
+	t.Setenv("TMUX_PANE", "%0")
+	t.Setenv("MUSTER_ALIAS", "")
+	tmuxCaptureStub(t, "$FRESH", "freshalias")
+
+	var buf bytes.Buffer
+	if err := cmdRegister([]string{"freshalias", "--if-absent"}, &buf); err != nil {
+		t.Fatalf("--if-absent on a fresh alias should succeed, got %v", err)
+	}
+	agents := listAgentsForTest(t, "")
+	if len(agents) != 1 || agents[0].Alias != "freshalias" {
+		t.Fatalf("expected a fresh row to be created, got %+v", agents)
+	}
+}
+
+// TestRegisterIfAbsentRejectedForPaneless covers the paneless-path decision:
+// allocPanelessAlias already runs its own internal if_absent CAS per
+// candidate suffix, so layering the CLI flag on top has no clean meaning —
+// cmdRegister must reject it with a clear, actionable error rather than
+// silently ignoring it or picking an arbitrary interpretation.
+func TestRegisterIfAbsentRejectedForPaneless(t *testing.T) {
+	startTestDaemon(t)
+	panelessEnv(t, "hs-ifabsent", "wt-ifabsent")
+
+	var buf bytes.Buffer
+	err := cmdRegister([]string{"--if-absent"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "--if-absent is for the tmux-anchored seed path") {
+		t.Fatalf("expected a paneless rejection error, got %v", err)
+	}
+}
+
 // TestRegisterPrintsRevivalAndUnread covers the resume loop's CLI surface:
 // re-registering a departed alias that accrued mail must say so, so the
 // operator (or a resumed agent using the CLI) learns the backlog in the


### PR DESCRIPTION
Exposes the daemon's existing register CAS on the CLI so the dotfiles launch wrapper can seed a session-name alias without stealing a live claimed identity (thread 154 ask, rides v0.9.0). Conflict → stderr + exit 1; same-tuple relaunch stays idempotent by design; paneless path explicitly rejects the flag (allocPanelessAlias already runs its own per-candidate CAS). Five pinning tests incl. foreign-harness-owned row integrity. Note: refusal is the tuple CAS — no harness-aware daemon logic; a foreign claim is always cross-tuple.