### PR TITLE
chore: document worktree location standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ bus.db-wal
 
 # SDD / superpowers scratch (transient build artifacts)
 .superpowers/
+
+# git worktrees (see CLAUDE.md)
+.worktrees/
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,25 @@ notify · `internal/nudge` send-keys · `internal/tmuxenv` tmux capture/liveness
 If you're an agent working here and want to coordinate with sessions in other
 terminals, the `.claude/skills/muster-coordination` skill is the etiquette
 (register, inbox, send/reply, addressing, the wake model).
+
+## Worktrees
+
+Every distinct line of work — a feature, a fix, an agent's task — runs in its own
+git worktree on its own branch. **Never branch-switch this clone**; it may hold
+uncommitted work.
+
+Worktrees live at **`<repo-root>/.worktrees/<branch>`** — inside the repo, resolved
+from the repo root, never as a sibling directory:
+
+```bash
+ROOT=$(git rev-parse --show-toplevel)
+git -C "$ROOT" worktree add "$ROOT/.worktrees/<branch>" -b <branch> origin/dev
+```
+
+- **Never a sibling** (`../<repo>-<topic>`, `<repo>-worktrees/`). Siblings escape the
+  repo, clutter the parent directory, and strand themselves when the repo moves.
+- **Never `/tmp`.** On macOS it symlinks to `/private/tmp`; worktrees under it break
+  vite-node/vitest module resolution *before a single test runs*.
+- Remove the worktree and its branch once merged:
+  `git -C "$ROOT" worktree remove "$ROOT/.worktrees/<branch>"`.
+- `.worktrees/` and `.claude/worktrees/` are gitignored.


### PR DESCRIPTION
Documents the worktree location standard: worktrees belong at `<repo-root>/.worktrees/<branch>` — inside the repo, never a sibling directory, never under `/tmp`.

Six different worktree layouts had accumulated across these repos because the convention lived only in dated plan docs rather than any standing instruction. This records the rule where every session will see it, and gitignores `.worktrees/` and `.claude/worktrees/`.

Docs and gitignore only — no code changes.