### PR TITLE
fix(mcp): the roster shows what the resolver routes on

### DIFF
--- a/internal/mcpserver/call.go
+++ b/internal/mcpserver/call.go
@@ -81,11 +81,25 @@ var callDaemon = func(op string, args map[string]any) (json.RawMessage, error) {
 
 // AgentView is the tool-facing shape of a registered agent. Field tags match
 // the daemon's JSON case-insensitively.
+//
+// Project/Label/LabelManual/Departed exist because an alias is not the only
+// address on this bus: internal/resolve matches an exact alias FIRST, then a
+// qualified "project:label", then a bare label scoped to the sender's own
+// project. A roster that showed aliases alone therefore described a smaller
+// bus than the daemon actually routes — an agent reading it concluded a live
+// label address did not exist and proposed retiring a durable alias to
+// "fix" mail that was already being delivered. These four fields are exactly
+// what the resolver decides on, so a caller can build any address the daemon
+// will accept, and none it won't.
 type AgentView struct {
 	Alias        string `json:"alias" jsonschema:"the agent's addressable alias"`
 	Role         string `json:"role" jsonschema:"the agent's role (producer, consumer, reviewer, ...)"`
 	ModelType    string `json:"model_type" jsonschema:"the agent's model (claude, codex, or cursor)"`
 	SessionName  string `json:"session_name" jsonschema:"the tmux session the agent runs in"`
+	Project      string `json:"project" jsonschema:"the project the agent is registered under; the qualifier in a 'project:label' address"`
+	Label        string `json:"label" jsonschema:"what the agent is working on right now; addressable as 'project:label' (or bare within your own project) only when label_manual is true"`
+	LabelManual  bool   `json:"label_manual" jsonschema:"true when a human pinned this label, which is what makes it addressable; an auto-generated label is display-only and will not resolve"`
+	Departed     bool   `json:"departed" jsonschema:"true for a deregistered agent: its alias still accepts mail (it may return) but its label no longer resolves"`
 	RegisteredAt int64  `json:"registered_at" jsonschema:"when the agent first registered (unix ms)"`
 	LastSeen     int64  `json:"last_seen" jsonschema:"when the agent was last active (unix ms)"`
 }

--- a/internal/mcpserver/tools_messages.go
+++ b/internal/mcpserver/tools_messages.go
@@ -11,7 +11,7 @@ import (
 type SendMessageIn struct {
 	From     string `json:"from" jsonschema:"the sending agent's alias"`
 	ToKind   string `json:"to_kind" jsonschema:"agent, role, or broadcast"`
-	ToTarget string `json:"to_target,omitempty" jsonschema:"the recipient alias or role; for broadcast: empty reaches every agent on the bus, or a project name reaches only that project's agents (unknown projects are rejected)"`
+	ToTarget string `json:"to_target,omitempty" jsonschema:"the recipient: an alias, a 'project:label' pair, or a bare label of an agent in your own project (resolved in that order) — or a role with to_kind=role; for broadcast: empty reaches every agent on the bus, or a project name reaches only that project's agents (unknown projects are rejected)"`
 	Subject  string `json:"subject" jsonschema:"a short subject line"`
 	Ref      string `json:"ref,omitempty" jsonschema:"optional pointer to the work (repo/branch/endpoint/file)"`
 	Body     string `json:"body" jsonschema:"the message body"`

--- a/internal/mcpserver/tools_registry.go
+++ b/internal/mcpserver/tools_registry.go
@@ -129,6 +129,6 @@ func registerRegistryTools(srv *mcp.Server) {
 	}, registerAgentHandler)
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_agents",
-		Description: "List all agents currently registered on the muster bus.",
+		Description: "List all agents currently registered on the muster bus, with the fields an address is built from. An alias is not the only way to reach someone: a target resolves as exact alias first, then 'project:label', then a bare label within your own project. So a session you know by a label (its label field, when label_manual is true) is reachable by that label even though the label is not an alias — do not report such a target as unreachable. Departed agents remain listed: their alias still accepts mail, their label no longer resolves.",
 	}, listAgentsHandler)
 }

--- a/internal/mcpserver/tools_registry_test.go
+++ b/internal/mcpserver/tools_registry_test.go
@@ -308,3 +308,57 @@ func TestRegisterAgentRefusalAdvertisesBecome(t *testing.T) {
 		t.Fatalf("Detail = %q, want become-advertisement", out.Detail)
 	}
 }
+
+// TestListAgentsCarriesAddressableLabel pins the roster against the resolver
+// (internal/resolve): an address is BUILT from project + label — the
+// "proj:label" and bare-label rungs below exact-alias — and a label is
+// addressable only while it is manually pinned on a live row. list_agents
+// must therefore carry all four fields, or an MCP agent sees aliases alone
+// and concludes a working address does not exist. That is not hypothetical:
+// a live session whose operator had labeled it "nfl-3" reported to that
+// operator that "nfl-3" was a dead address and offered to retire its durable
+// alias to fix it, because list_agents could not show the label that was
+// already routing mail to it.
+func TestListAgentsCarriesAddressableLabel(t *testing.T) {
+	startTestDaemon(t)
+	for _, a := range []map[string]any{
+		{"alias": "bettor-help-workspace-2", "project": "bettor-help-workspace", "label": "nfl-3", "label_manual": true},
+		{"alias": "bettor-help-workspace-4", "project": "bettor-help-workspace", "label": "debug alarms", "label_manual": false},
+		{"alias": "bettor-help-workspace-5", "project": "bettor-help-workspace", "label": "corpus-rebuild", "label_manual": true},
+	} {
+		if _, err := callDaemon("register_agent", a); err != nil {
+			t.Fatalf("register %v: %v", a["alias"], err)
+		}
+	}
+	if _, err := callDaemon("deregister_agent", map[string]any{"alias": "bettor-help-workspace-5"}); err != nil {
+		t.Fatalf("deregister: %v", err)
+	}
+
+	_, out, err := listAgentsHandler(context.TODO(), nil, ListAgentsIn{})
+	if err != nil {
+		t.Fatalf("list_agents: %v", err)
+	}
+	byAlias := map[string]AgentView{}
+	for _, ag := range out.Agents {
+		byAlias[ag.Alias] = ag
+	}
+
+	// The addressable one: every field a caller needs to write
+	// "bettor-help-workspace:nfl-3" (or bare "nfl-3" from inside the project).
+	live := byAlias["bettor-help-workspace-2"]
+	if live.Project != "bettor-help-workspace" || live.Label != "nfl-3" || !live.LabelManual || live.Departed {
+		t.Fatalf("addressable row = %+v, want project/label carried with label_manual set and not departed", live)
+	}
+	// An auto-generated label is display-only — the resolver skips it, so the
+	// roster must say so rather than let a caller address it.
+	auto := byAlias["bettor-help-workspace-4"]
+	if auto.Label != "debug alarms" || auto.LabelManual {
+		t.Fatalf("auto-labeled row = %+v, want label carried with label_manual false", auto)
+	}
+	// A tombstone keeps its alias addressable (mail waits) but not its label;
+	// without Departed the caller cannot tell the two apart.
+	gone := byAlias["bettor-help-workspace-5"]
+	if !gone.Departed || gone.Label != "corpus-rebuild" {
+		t.Fatalf("departed row = %+v, want departed true with its label still visible", gone)
+	}
+}

--- a/internal/mcpserver/tools_tasks.go
+++ b/internal/mcpserver/tools_tasks.go
@@ -11,7 +11,7 @@ import (
 type TaskCreateIn struct {
 	From     string `json:"from" jsonschema:"the requesting agent's alias"`
 	ToKind   string `json:"to_kind" jsonschema:"agent, role, or broadcast"`
-	ToTarget string `json:"to_target" jsonschema:"the assignee alias or role; for broadcast: empty for every agent, or a project name for that project's agents only"`
+	ToTarget string `json:"to_target" jsonschema:"the assignee: an alias, a 'project:label' pair, or a bare label of an agent in your own project (resolved in that order) — or a role with to_kind=role; for broadcast: empty for every agent, or a project name for that project's agents only"`
 	Subject  string `json:"subject" jsonschema:"a short task title"`
 	Ref      string `json:"ref,omitempty" jsonschema:"optional pointer to the work (repo/branch/endpoint/file)"`
 	Body     string `json:"body" jsonschema:"task details"`


### PR DESCRIPTION
## The bug

`list_agents` returned `alias`, `role`, `model_type`, `session_name`, and timestamps — **none of the fields an address is actually built from**. But `internal/resolve` matches an exact alias first, then `project:label`, then a bare label scoped to the sender's own project. The roster therefore described a smaller bus than the daemon routes: a target that resolves and delivers was invisible to every MCP caller.

## How it surfaced

A live session labeled `nfl-3` (project `bettor-help-workspace`) was addressed as `bettor-help-workspace:nfl-3`. The message resolved to `bettor-help-workspace-2`, delivered, set the `@muster_inbox` badge, and got a reply. Meanwhile that same session, reading `list_agents`, told its operator that `nfl-3` was a dead address — "anyone sending to nfl-3 will get nothing" — and offered to retire its durable alias via `become` to fix it.

The bus was right the whole time. The roster was the only thing that was wrong, and it very nearly cost a durable identity to a problem that did not exist. This is the same class as the black-hole incident `internal/resolve` was created to close: two surfaces disagreeing about what an address is.

## The fix

`AgentView` now carries `project`, `label`, `label_manual`, and `departed` — exactly the four fields the resolver decides on, so a caller can construct any address the daemon will accept and none it won't:

- **`label_manual`** is what makes a label addressable; an auto-generated label is display-only and will not resolve.
- **`departed`** keeps a caller from addressing a tombstone's label, which resolution refuses (its alias still accepts mail).

All four are additive JSON fields — existing callers are unaffected.

The address-constructing surfaces now say so too: `list_agents`' description states the resolution order and that a label is not an alias but is still a target, and `send_message`/`task_create`'s `to_target` no longer claim "alias or role" when a label works just as well.

## Tests

`TestListAgentsCarriesAddressableLabel` pins all three rows through a real daemon round trip: an addressable manual label, an auto label that must report `label_manual: false`, and a tombstone that must report `departed: true` with its label still visible. It failed to compile before the change.

`just verify` clean: gofmt, golangci-lint (0 issues), `go test -race ./...`, and the cross-compile matrix.