### PR TITLE
fix: teammate sessions' hooks are no-ops — fleet members never race for identity

### DIFF
--- a/internal/harnessenv/harnessenv.go
+++ b/internal/harnessenv/harnessenv.go
@@ -160,3 +160,41 @@ func CustomTitle(transcriptPath string) string {
 	}
 	return title
 }
+
+// IsTeammate reports whether the transcript at path belongs to a fleet
+// TEAMMATE session — a member spawned into a pane of some primary's tmux
+// session. Members' transcripts carry a top-level teamName (with
+// agentName) on their records from the first few lines; team LEADS and
+// plain primaries never do (verified over 46 transcripts, 2026-08-06 —
+// see the teammate-identity-refusal spec §2; a bare agent-name record
+// does NOT discriminate, /rename'd primaries have those). The scan is
+// bounded to the first 30 lines: the signal sits at the top by
+// construction, and an unbounded scan would false-positive on
+// conversation text that quotes transcripts. Empty path, unreadable
+// file, or no match read as NOT a teammate — hooks fail open, they never
+// block a session.
+func IsTeammate(transcriptPath string) bool {
+	if transcriptPath == "" {
+		return false
+	}
+	f, err := os.Open(transcriptPath)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	for i := 0; i < 30 && sc.Scan(); i++ {
+		line := sc.Bytes()
+		if !bytes.Contains(line, []byte(`"teamName"`)) {
+			continue
+		}
+		var rec struct {
+			TeamName string `json:"teamName"`
+		}
+		if json.Unmarshal(line, &rec) == nil && rec.TeamName != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/harnessenv/harnessenv_test.go
+++ b/internal/harnessenv/harnessenv_test.go
@@ -111,3 +111,62 @@ func TestCustomTitleAbsentOrUnreadable(t *testing.T) {
 		t.Fatalf("no record: got %q", got)
 	}
 }
+
+func TestIsTeammateDetectsMemberTranscript(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "member.jsonl")
+	lines := []string{
+		`{"type":"mode","mode":"normal","sessionId":"u1"}`,
+		`{"type":"permission-mode","permissionMode":"auto","sessionId":"u1"}`,
+		`{"parentUuid":null,"isSidechain":false,"teamName":"session-b41c21dd","agentName":"l5-mlb-measure","type":"user","message":{"role":"user","content":"go"}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !IsTeammate(path) {
+		t.Fatal("teamName-bearing transcript must read as teammate")
+	}
+}
+
+func TestIsTeammateFalseForPrimariesAndLeads(t *testing.T) {
+	dir := t.TempDir()
+	// a lead/primary: custom-title + agent-name records but NO teamName —
+	// the spec's verified shape (an agent-name record alone must not match)
+	path := filepath.Join(dir, "primary.jsonl")
+	lines := []string{
+		`{"type":"custom-title","customTitle":"nfl-3","sessionId":"u2"}`,
+		`{"type":"agent-name","agentName":"nfl-3","sessionId":"u2"}`,
+		`{"type":"user","message":{"role":"user","content":"body mentioning teamName in prose"}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if IsTeammate(path) {
+		t.Fatal("primary transcript must not read as teammate")
+	}
+}
+
+func TestIsTeammateFailOpenAndBounded(t *testing.T) {
+	if IsTeammate("") {
+		t.Fatal("empty path must be false")
+	}
+	if IsTeammate(filepath.Join(t.TempDir(), "missing.jsonl")) {
+		t.Fatal("missing file must be false")
+	}
+	// teamName appearing only AFTER line 30 does not match: the signal
+	// sits in the first few lines by construction, and an unbounded scan
+	// would false-positive on conversation text echoing transcripts.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "late.jsonl")
+	var lines []string
+	for i := 0; i < 30; i++ {
+		lines = append(lines, `{"type":"user","message":{"role":"user","content":"x"}}`)
+	}
+	lines = append(lines, `{"teamName":"t","agentName":"a","type":"user"}`)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if IsTeammate(path) {
+		t.Fatal("teamName beyond line 30 must not match (bounded scan)")
+	}
+}

--- a/internal/humancli/hook.go
+++ b/internal/humancli/hook.go
@@ -38,6 +38,21 @@ func cmdHook(args []string, stdin io.Reader, out io.Writer) error {
 		model = args[1]
 	}
 	payload, _ := io.ReadAll(io.LimitReader(stdin, 1<<20)) // a hook payload is small; the cap only guards a pathological writer
+	// A fleet TEAMMATE's hooks are no-ops (teammate-identity-refusal spec
+	// §3): a teammate is a full Claude session in a pane of some
+	// primary's tmux session, so without this gate it races the primary
+	// for the session's bus identity at every register, resume-reclaim,
+	// projection, tombstone sweep, and stamp — and the pane-ownership
+	// guard only protects a primary while its pane claim is provable
+	// (caught live 2026-08-06: a teammate stamped its pane + harness id
+	// onto two primaries' rows). Explicit registration (MCP
+	// register_agent, `muster register`) is deliberately untouched — a
+	// teammate can still be GIVEN an identity on purpose; what is barred
+	// is automatic capture. Codex/Cursor payloads carry no
+	// transcript_path, so they never match.
+	if harnessenv.IsTeammate(harnessenv.FromHookPayload(payload).TranscriptPath) {
+		return nil
+	}
 	switch args[0] {
 	case "SessionStart":
 		c := hookCapture()

--- a/internal/humancli/hook_test.go
+++ b/internal/humancli/hook_test.go
@@ -1535,3 +1535,194 @@ func TestHookSessionStartSiblingPaneDoesNotStompName(t *testing.T) {
 		t.Fatalf("a non-owning sibling must project nothing, got %q", buf.String())
 	}
 }
+
+// writeTeammateTranscript writes a transcript whose teamName record sits at
+// line 3 — the same fixture shape as harnessenv's TestIsTeammateDetectsMemberTranscript
+// (a fleet member spawned into a pane of some primary's tmux session).
+func writeTeammateTranscript(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "member.jsonl")
+	lines := []string{
+		`{"type":"mode","mode":"normal","sessionId":"u1"}`,
+		`{"type":"permission-mode","permissionMode":"auto","sessionId":"u1"}`,
+		`{"parentUuid":null,"isSidechain":false,"teamName":"session-b41c21dd","agentName":"l5-mlb-measure","type":"user","message":{"role":"user","content":"go"}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// stubTeammateGateTmux swaps tmuxenv.Run for a recorder seeded with values,
+// keyed by the last arg (mirroring hookRun) — realistic enough that, absent
+// the gate, the pre-existing pane-anchored logic (hookCapture,
+// hookMayClaimIdentity, hookStopWalked, ...) would resolve pane %2's tuple
+// onto the primary's own session $1 exactly as the 2026-08-06 incident did.
+// Once the gate is in place, none of this is ever consulted, so the
+// recorded calls come back empty.
+func stubTeammateGateTmux(t *testing.T, values map[string]string) *[][]string {
+	t.Helper()
+	var calls [][]string
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if v, ok := values[args[len(args)-1]]; ok {
+			return v, nil
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+	return &calls
+}
+
+// registerGuardedPrimary registers the primary alias on pane %1 of session
+// $1 (socket /s, incarnation 200) and gives it a manual label via the
+// set_label op — the exact row shape the 2026-08-06 incident stomped when a
+// teammate's SessionStart fired from the sibling pane %2 of the same
+// session.
+func registerGuardedPrimary(t *testing.T) {
+	t.Helper()
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "primary", "socket_path": "/s", "session_id": "$1",
+		"session_created": int64(200), "pane_id": "%1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("set_label", map[string]any{
+		"socket_path": "/s", "session_id": "$1", "session_created": int64(200),
+		"label": "primary-name", "label_manual": true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// teammateGateTmuxValues are the tmux stub answers shared by all three
+// teammate-gate regression tests: the primary's own session/pane identity,
+// so that (absent the gate) the pre-existing logic would resolve pane %2
+// onto the primary's tuple exactly as the incident did.
+var teammateGateTmuxValues = map[string]string{
+	"#{session_id}":      "$1",
+	"#{session_created}": "200",
+	"#{session_name}":    "primary",
+	"#{pane_id}":         "%1", // the primary's pane is still alive
+}
+
+// TestHookTeammateSessionStartTouchesNothing is the 2026-08-06 incident as a
+// regression test: a primary registered on pane %1 of $1; a teammate's
+// SessionStart fires from pane %2 of the SAME session with a teamName-bearing
+// transcript. The row must be byte-for-byte untouched (pane, harness id,
+// label) and the roster must gain no alias.
+func TestHookTeammateSessionStartTouchesNothing(t *testing.T) {
+	tp := writeTeammateTranscript(t)
+	calls := stubTeammateGateTmux(t, teammateGateTmuxValues)
+
+	startCLITestDaemon(t)
+	registerGuardedPrimary(t)
+	before := agentRowForTest(t, "primary")
+
+	t.Setenv("TMUX", "/s,1,0")
+	t.Setenv("TMUX_PANE", "%2")
+	t.Setenv("MUSTER_ALIAS", "")
+
+	var buf bytes.Buffer
+	payload := fmt.Sprintf(`{"source":"startup","session_id":"uuid-tm","transcript_path":%q}`, tp)
+	if err := cmdHook([]string{"SessionStart"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("a teammate SessionStart must print nothing, got %q", buf.String())
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("a teammate SessionStart must make no tmux calls, got %v", *calls)
+	}
+	agents := listAgentsForTest(t, "")
+	if len(agents) != 1 {
+		t.Fatalf("the roster must gain no alias, got %d rows: %+v", len(agents), agents)
+	}
+	after := agentRowForTest(t, "primary")
+	if after.PaneID != before.PaneID || after.HarnessSessionID != before.HarnessSessionID ||
+		after.Label != before.Label || after.LabelManual != before.LabelManual {
+		t.Fatalf("the primary row must be untouched: before=%+v after=%+v", before, after)
+	}
+}
+
+// TestHookTeammateSessionEndTombstonesNothing is TestHookTeammateSessionStartTouchesNothing's
+// SessionEnd counterpart: the same teammate transcript firing SessionEnd from
+// the sibling pane must not tombstone the primary's row.
+func TestHookTeammateSessionEndTombstonesNothing(t *testing.T) {
+	tp := writeTeammateTranscript(t)
+	calls := stubTeammateGateTmux(t, teammateGateTmuxValues)
+
+	startCLITestDaemon(t)
+	registerGuardedPrimary(t)
+
+	t.Setenv("TMUX", "/s,1,0")
+	t.Setenv("TMUX_PANE", "%2")
+	t.Setenv("MUSTER_ALIAS", "")
+
+	var buf bytes.Buffer
+	payload := fmt.Sprintf(`{"session_id":"uuid-tm","transcript_path":%q}`, tp)
+	if err := cmdHook([]string{"SessionEnd"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("a teammate SessionEnd must print nothing, got %q", buf.String())
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("a teammate SessionEnd must make no tmux calls, got %v", *calls)
+	}
+	if ag := agentRowForTest(t, "primary"); ag.Departed {
+		t.Fatal("a teammate SessionEnd must not tombstone the primary")
+	}
+}
+
+// TestHookTeammateStopEmitsNoWake is the Stop counterpart: with an unread
+// message waiting for the primary, the same teammate transcript's Stop must
+// neither print a wake decision nor drain the primary's unread count.
+func TestHookTeammateStopEmitsNoWake(t *testing.T) {
+	tp := writeTeammateTranscript(t)
+	calls := stubTeammateGateTmux(t, teammateGateTmuxValues)
+
+	startCLITestDaemon(t)
+	registerGuardedPrimary(t)
+	if _, err := callData("send_message", map[string]any{
+		"from": "peer", "to_kind": "agent", "to_target": "primary", "subject": "s", "body": "b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TMUX", "/s,1,0")
+	t.Setenv("TMUX_PANE", "%2")
+	t.Setenv("MUSTER_ALIAS", "")
+
+	var buf bytes.Buffer
+	payload := fmt.Sprintf(`{"session_id":"uuid-tm","transcript_path":%q}`, tp)
+	if err := cmdHook([]string{"Stop"}, strings.NewReader(payload), &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("a teammate Stop must emit no wake text, got %q", buf.String())
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("a teammate Stop must make no tmux calls, got %v", *calls)
+	}
+
+	raw, err := callData("session_unread", map[string]any{
+		"socket_path": "/s", "session_id": "$1", "session_created": int64(200),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var res struct {
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Total != 1 {
+		t.Fatalf("the primary's unread count must not be drained, got total=%d", res.Total)
+	}
+}

--- a/internal/humancli/hook_test.go
+++ b/internal/humancli/hook_test.go
@@ -1554,12 +1554,14 @@ func writeTeammateTranscript(t *testing.T) string {
 }
 
 // stubTeammateGateTmux swaps tmuxenv.Run for a recorder seeded with values,
-// keyed by the last arg (mirroring hookRun) — realistic enough that, absent
-// the gate, the pre-existing pane-anchored logic (hookCapture,
-// hookMayClaimIdentity, hookStopWalked, ...) would resolve pane %2's tuple
-// onto the primary's own session $1 exactly as the 2026-08-06 incident did.
-// Once the gate is in place, none of this is ever consulted, so the
-// recorded calls come back empty.
+// keyed by the last arg (mirroring hookRun) — the tmux answers a teammate's
+// SessionStart/SessionEnd/Stop would actually see firing from a sibling pane
+// of the primary's own session. Once the gate is in place none of this is
+// ever consulted, so the recorded calls come back empty; absent the gate,
+// these are exactly the answers the pre-existing pane-anchored logic
+// (hookCapture, hookMayClaimIdentity, hookStopWalked, ...) used on
+// 2026-08-06 to resolve pane %2's tuple onto the primary's own session $1
+// and stomp it.
 func stubTeammateGateTmux(t *testing.T, values map[string]string) *[][]string {
 	t.Helper()
 	var calls [][]string
@@ -1575,16 +1577,18 @@ func stubTeammateGateTmux(t *testing.T, values map[string]string) *[][]string {
 	return &calls
 }
 
-// registerGuardedPrimary registers the primary alias on pane %1 of session
-// $1 (socket /s, incarnation 200) and gives it a manual label via the
-// set_label op — the exact row shape the 2026-08-06 incident stomped when a
-// teammate's SessionStart fired from the sibling pane %2 of the same
-// session.
+// registerGuardedPrimary registers the primary alias on session $1 (socket
+// /s, incarnation 200) with NO stored pane_id — the unprovable-claim shape
+// of the 2026-08-06 incident: hookMayClaimIdentity's pane check
+// (`ag.PaneID == "" || ag.PaneID == c.PaneID`) treats an empty stored pane
+// as "anyone may claim", exactly what let a teammate's sibling-pane
+// SessionStart win the primary's own identity. It then gives the row a
+// manual label via the set_label op — the row shape the incident stomped.
 func registerGuardedPrimary(t *testing.T) {
 	t.Helper()
 	if _, err := callData("register_agent", map[string]any{
 		"alias": "primary", "socket_path": "/s", "session_id": "$1",
-		"session_created": int64(200), "pane_id": "%1",
+		"session_created": int64(200),
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1597,21 +1601,27 @@ func registerGuardedPrimary(t *testing.T) {
 }
 
 // teammateGateTmuxValues are the tmux stub answers shared by all three
-// teammate-gate regression tests: the primary's own session/pane identity,
-// so that (absent the gate) the pre-existing logic would resolve pane %2
-// onto the primary's tuple exactly as the incident did.
+// teammate-gate regression tests: the primary's own session identity, plus
+// a non-zero @muster_inbox so Stop's cheap gate doesn't short-circuit
+// before ever reaching the daemon — so that (absent the identity gate) the
+// pre-existing logic would resolve pane %2 onto the primary's tuple exactly
+// as the incident did.
 var teammateGateTmuxValues = map[string]string{
 	"#{session_id}":      "$1",
 	"#{session_created}": "200",
 	"#{session_name}":    "primary",
-	"#{pane_id}":         "%1", // the primary's pane is still alive
+	"@muster_inbox":      "1",
 }
 
 // TestHookTeammateSessionStartTouchesNothing is the 2026-08-06 incident as a
-// regression test: a primary registered on pane %1 of $1; a teammate's
+// regression test: a primary registered on session $1 with no stored pane
+// claim (unprovable, exactly like the incident row); a teammate's
 // SessionStart fires from pane %2 of the SAME session with a teamName-bearing
 // transcript. The row must be byte-for-byte untouched (pane, harness id,
-// label) and the roster must gain no alias.
+// label) and the roster must gain no alias. Without the gate this actually
+// stomps: hookMayClaimIdentity's empty-pane rule lets pane %2 win the
+// register, and the upsert overwrites PaneID/HarnessSessionID and clears the
+// manual label.
 func TestHookTeammateSessionStartTouchesNothing(t *testing.T) {
 	tp := writeTeammateTranscript(t)
 	calls := stubTeammateGateTmux(t, teammateGateTmuxValues)
@@ -1680,7 +1690,10 @@ func TestHookTeammateSessionEndTombstonesNothing(t *testing.T) {
 
 // TestHookTeammateStopEmitsNoWake is the Stop counterpart: with an unread
 // message waiting for the primary, the same teammate transcript's Stop must
-// neither print a wake decision nor drain the primary's unread count.
+// print no wake decision AND must not run stampHarnessLinks, which — absent
+// the gate — would stamp the teammate's harness session UUID onto the
+// primary's link-less alias (hookStop never marks mail read itself, so
+// unread count is not the vector here; the harness-id stamp is).
 func TestHookTeammateStopEmitsNoWake(t *testing.T) {
 	tp := writeTeammateTranscript(t)
 	calls := stubTeammateGateTmux(t, teammateGateTmuxValues)
@@ -1709,20 +1722,7 @@ func TestHookTeammateStopEmitsNoWake(t *testing.T) {
 	if len(*calls) != 0 {
 		t.Fatalf("a teammate Stop must make no tmux calls, got %v", *calls)
 	}
-
-	raw, err := callData("session_unread", map[string]any{
-		"socket_path": "/s", "session_id": "$1", "session_created": int64(200),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	var res struct {
-		Total int `json:"total"`
-	}
-	if err := json.Unmarshal(raw, &res); err != nil {
-		t.Fatal(err)
-	}
-	if res.Total != 1 {
-		t.Fatalf("the primary's unread count must not be drained, got total=%d", res.Total)
+	if ag := agentRowForTest(t, "primary"); ag.HarnessSessionID != "" {
+		t.Fatalf("a teammate Stop must not stamp its harness session id onto the primary, got %q", ag.HarnessSessionID)
 	}
 }

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -31,6 +31,12 @@ type agentFull struct {
 	PaneID      string `json:"pane_id"`
 	SessionID   string `json:"session_id"`
 	SessionName string `json:"session_name"`
+	// SessionCreated mirrors store.Agent.SessionCreated — cmdNudge uses it
+	// (with tmuxenv.IsSessionAlive) to tell a merely-stale pane row (session
+	// still alive, pane reaped underneath it) from a fully dead one, so it
+	// can refuse the dead-pane case with a remedy instead of a doomed
+	// send-keys.
+	SessionCreated int64 `json:"session_created"`
 	// HarnessSessionID mirrors agentRow's own copy (see store.Agent.HarnessSessionID)
 	// — stampHarnessLinks reads it via hookGetAgent to skip a row that already
 	// has a link.
@@ -503,6 +509,17 @@ func cmdNudge(args []string, out io.Writer) error {
 		return fmt.Errorf("no agent registered as %q", alias)
 	}
 	ag := res.Agent
+	// A stored pane can go stale between registration and nudge — most
+	// commonly a reaped teammate's pane, closed out from under a row that
+	// still names it. Refuse rather than guess: with teammate panes sharing
+	// the session, typing into whatever pane happens to be there next is
+	// worse than failing loudly (spec §3, no auto-retargeting). The row
+	// heals itself the next time that session starts/resumes and
+	// re-registers, or the operator can re-register from the live pane now.
+	if ag.SocketPath != "" && !tmuxenv.IsPaneAlive(ag.SocketPath, ag.PaneID) &&
+		tmuxenv.IsSessionAlive(ag.SocketPath, ag.SessionID, ag.SessionCreated) {
+		return fmt.Errorf("nudge %s: stored pane %s is gone but its session is alive — the row heals at the session's next start/resume (or re-register from the live pane); refusing to type into a guessed pane", ag.Alias, ag.PaneID)
+	}
 	// session_name is mutable — tmux lets an operator rename a session at any
 	// time — so the stored (registration-time) snapshot goes stale the
 	// moment that happens. Query the LIVE name at nudge time; fall back to

--- a/internal/humancli/humancli_test.go
+++ b/internal/humancli/humancli_test.go
@@ -330,6 +330,46 @@ func TestNudgeCommandResolvesAndNudges(t *testing.T) {
 	}
 }
 
+// TestNudgeDeadPaneRefusesWithRemedy proves nudge refuses to send-keys into
+// a stored pane that's gone when its session is still alive (a reaped
+// teammate's pane, or any stale pane row) — auto-retargeting to a guessed
+// pane would be worse than failing (spec §3), so cmdNudge must error with
+// the remedy instead of attempting a doomed send-keys.
+func TestNudgeDeadPaneRefusesWithRemedy(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "rev", "role": "reviewer", "model_type": "codex",
+		"socket_path": "/s", "pane_id": "%99", "session_id": "$1",
+		"session_created": 200,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var recorded [][]string
+	origNudge := nudgeRun
+	nudgeRun = func(args ...string) error { recorded = append(recorded, args); return nil }
+	t.Cleanup(func() { nudgeRun = origNudge })
+
+	origRun := tmuxenv.Run
+	// session_created probe answers 200 (matches registration → session
+	// alive); the pane_id probe for %99 answers "" (not in the map →
+	// hookRun's default) → pane gone.
+	tmuxenv.Run = hookRun(map[string]string{"#{session_created}": "200"})
+	t.Cleanup(func() { tmuxenv.Run = origRun })
+
+	var buf bytes.Buffer
+	err := Dispatch([]string{"nudge", "rev"}, &buf)
+	if err == nil {
+		t.Fatalf("expected an error nudging a dead stored pane, got nil (out=%q)", buf.String())
+	}
+	if !strings.Contains(err.Error(), "stored pane %99 is gone") || !strings.Contains(err.Error(), "heals at the session's next start") {
+		t.Fatalf("expected error to name the dead pane and the remedy, got %q", err.Error())
+	}
+	if len(recorded) != 0 {
+		t.Fatalf("expected NO send-keys call for a dead stored pane, got %v", recorded)
+	}
+}
+
 // TestNudgePrintsLiveSessionName proves nudge reports the session's CURRENT
 // tmux name, not the stale registration-time snapshot: session names are
 // mutable (a human can `tmux rename-session` any time), so a stored


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-08-06-teammate-identity-refusal-design.md (on dev).

Twice on 2026-08-06 a fleet teammate's hooks claimed a primary session's bus row (pane + harness id), breaking nudge and setting up mailbox stranding at the next resume. Root cause: muster had no concept of a teammate — every Claude session's hooks raced equally for the session's identity, and the pane-ownership guard only defends a provable claim.

- `harnessenv.IsTeammate`: bounded head-scan for a top-level `teamName` field (verified over 46 transcripts: every member carries it in the first lines; leads and primaries never do; empirically confirmed present in the transcript's FIRST write, so SessionStart is covered).
- `muster hook` gates ALL events at entry: a teammate session registers nothing, reclaims nothing, projects no name, tombstones nothing, stamps nothing. Fail-open on unreadable transcripts (hooks never block); explicit registration (MCP/CLI) deliberately untouched.
- Regression tests reproduce the incident byte-for-byte (unprovable-pane fixture; verified failing pre-gate via a neutered-gate run).
- `muster nudge` now refuses a dead stored pane with the remedy instead of a bare failure.

Review trail: 3 tasks, all task-reviewed; one review-caught fix (the initial regression tests were vacuous — they defended the provable-pane case v0.7.1 already guards; rebuilt on the incident's unprovable-claim shape). Final whole-branch review: Ready to merge; deferred follow-ups ledgered (legacy contrib script bypass, empty-pane message wording).

https://claude.ai/code/session_01ASmHovENGNfQ5qPaFSRApg