### PR TITLE
fix(ci): harden version-guard against git error paths

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -5,12 +5,13 @@ name: version-guard
 # This guard makes the knob impossible to forget: PRs targeting main must
 # change VERSION, or carry the `no-release` label (docs/CI-only changes).
 # labeled/unlabeled triggers re-run the check when the label is toggled,
-# no new push needed. dev-targeting PRs are exempt: VERSION is bumped at
-# promotion time.
+# no new push needed. edited catches a PR retargeted from dev to main,
+# which otherwise wouldn't re-run this until the next push. dev-targeting
+# PRs are exempt: VERSION is bumped at promotion time.
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
 permissions:
   contents: read
@@ -33,8 +34,14 @@ jobs:
               echo "no-release label present — skipping VERSION check."
               exit 0 ;;
           esac
-          if git diff --quiet "$BASE" HEAD -- VERSION; then
+          rc=0
+          git diff --quiet "$BASE" HEAD -- VERSION || rc=$?
+          if [ "$rc" -eq 0 ]; then
             echo "::error file=VERSION::VERSION is unchanged. Bump it (this PR releases on merge) or add the 'no-release' label."
             exit 1
+          elif [ "$rc" -ne 1 ]; then
+            echo "::error::git diff failed (rc=$rc) — cannot determine whether VERSION changed."
+            exit 1
           fi
-          echo "VERSION bumped: $(git show "$BASE":VERSION | tr -d ' \n') -> $(tr -d ' \n' < VERSION)"
+          old="$(git show "$BASE":VERSION)" || { echo "::error::cannot read VERSION at base $BASE"; exit 1; }
+          echo "VERSION bumped: $(printf %s "$old" | tr -d ' \n') -> $(tr -d ' \n' < VERSION)"


### PR DESCRIPTION
Follow-up to #98. Fixes a Critical review finding: `git diff --quiet` only distinguishes rc 0 from non-zero, so an rc >1 (bad revision, missing object) fell into the 'differences found' branch and the guard silently passed. The success echo also embedded a failing `git show` inside a command substitution, which under `set -e` does not trip errexit, so an unresolvable BASE printed a garbled 'VERSION bumped' line and exited 0. Now branches on the explicit exit code and checks `git show` separately so both error paths fail loudly.

Also adds `edited` to the trigger types so a PR retargeted from dev to main re-runs the guard without needing a new push.

This PR doesn't bump VERSION, so version-guard will fail until the no-release label is added — another live proof of the guard's failure branch.