### PR TITLE
ci: sign and notarize macOS binaries in the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,11 @@ name: release
 # all with sha256 checksums. Every binary
 # is stamped with this release's version/commit via -ldflags -X into
 # internal/version. A merge that doesn't bump VERSION releases nothing.
-# macOS binaries are re-signed and notarized locally afterwards via
-# contrib/release-sign.sh <tag>.
+# macOS binaries are signed and notarized IN THIS JOB, which is why it runs on
+# a macOS runner: codesign and notarytool exist nowhere else. Go cross-compiles
+# the linux targets from here with CGO_ENABLED=0, so every published artifact
+# still comes from one build. contrib/release-sign.sh remains for repairing an
+# already-published release by hand.
 #
 # workflow_dispatch does two things, chosen by whether `tag` is given:
 #   - tag set    -> rebuild assets for that EXISTING release (backfill/repair).
@@ -33,7 +36,11 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
+    # The signing secrets live in a protected environment rather than plain
+    # repository secrets, so a workflow run has to be for this environment to
+    # see the Developer ID certificate at all.
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - name: Resolve tag and mode
@@ -84,20 +91,67 @@ jobs:
       - name: Checkout the tag (asset-rebuild mode only)
         if: steps.rel.outputs.skip == 'false' && steps.rel.outputs.create == 'false'
         run: git fetch --tags && git checkout "${{ steps.rel.outputs.tag }}"
-      - name: Build and package all targets
+      - name: Import the Developer ID certificate
         if: steps.rel.outputs.skip == 'false'
+        env:
+          P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+          P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
         run: |
           set -euo pipefail
+          # Fail rather than publish unsigned macOS binaries. An unsigned
+          # binary is quarantined by Gatekeeper on download and refuses to run,
+          # which reads to whoever downloads it as a broken build; no release
+          # is better than that.
+          [ -n "$P12" ] || { echo "::error::APPLE_DEVELOPER_ID_P12 is unset — refusing to publish unsigned macOS binaries."; exit 1; }
+          kc="$RUNNER_TEMP/build.keychain-db"
+          kcpw="$(uuidgen)"
+          security create-keychain -p "$kcpw" "$kc"
+          security set-keychain-settings -lut 21600 "$kc"
+          security unlock-keychain -p "$kcpw" "$kc"
+          printf %s "$P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$kc" -P "$P12_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$RUNNER_TEMP/cert.p12"
+          # Without this, codesign blocks on a GUI keychain prompt that never
+          # comes and the job hangs until it times out.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$kcpw" "$kc" >/dev/null
+          security list-keychains -d user -s "$kc" $(security list-keychains -d user | tr -d '"')
+          identity="$(security find-identity -v -p codesigning "$kc" \
+            | sed -n 's/.*"\(Developer ID Application:[^"]*\)".*/\1/p' | head -1)"
+          [ -n "$identity" ] || { echo "::error::no Developer ID Application identity in the imported certificate."; exit 1; }
+          echo "MUSTER_KEYCHAIN=$kc" >> "$GITHUB_ENV"
+          echo "MUSTER_SIGN_IDENTITY=$identity" >> "$GITHUB_ENV"
+          echo "signing as: $identity"
+
+      - name: Build and package all targets
+        if: steps.rel.outputs.skip == 'false'
+        env:
+          NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+          NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          [ -n "$NOTARY_KEY" ] || { echo "::error::APPLE_NOTARY_KEY is unset — cannot notarize."; exit 1; }
+          printf %s "$NOTARY_KEY" | base64 --decode > "$RUNNER_TEMP/notary.p8"
           tag="${{ steps.rel.outputs.tag }}"
           version="${tag#v}"
           commit="$(git rev-parse --short HEAD)"
           ldflags="-s -w -X github.com/schuettc/muster/internal/version.version=${version} -X github.com/schuettc/muster/internal/version.commit=${commit}"
+          # Sign every darwin binary as it is built. --options runtime is the
+          # hardened runtime, which notarization requires; without it the
+          # submission is rejected rather than merely unsigned.
+          sign() {
+            case "$1" in
+              *_darwin_*) codesign --sign "$MUSTER_SIGN_IDENTITY" --options runtime \
+                            --timestamp --force "$1" ;;
+            esac
+          }
           for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
             goos="${target%/*}"; goarch="${target#*/}"
             out="muster_${goos}_${goarch}"
             CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
               go build -trimpath -ldflags "$ldflags" -o "dist/${out}/muster" ./cmd/muster
-            tar -C "dist/${out}" -czf "dist/${out}.tar.gz" muster
+            sign "dist/${out}/muster"
           done
           # muster-deploy, the hosted backend's installer. Shipped SEPARATELY
           # from the device tarballs above, not inside them: it links the AWS
@@ -109,7 +163,32 @@ jobs:
             out="muster-deploy_${goos}_${goarch}"
             CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
               go build -trimpath -ldflags "$ldflags" -o "dist/${out}/muster-deploy" ./cmd/muster-deploy
-            tar -C "dist/${out}" -czf "dist/${out}.tar.gz" muster-deploy
+            sign "dist/${out}/muster-deploy"
+          done
+
+          # Notarize all four signed darwin binaries in ONE submission. Apple
+          # takes minutes per submission, and four sequential round trips would
+          # dominate the job. Bare executables cannot be stapled — stapler only
+          # works on bundles, dmgs and pkgs — so Gatekeeper verifies these
+          # online, exactly as it did when this was a local step.
+          ditto -c -k --keepParent dist "$RUNNER_TEMP/notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --key "$RUNNER_TEMP/notary.p8" \
+            --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER_ID" \
+            --wait --timeout 30m | tee "$RUNNER_TEMP/notary.log"
+          grep -q "status: Accepted" "$RUNNER_TEMP/notary.log" || {
+            echo "::error::notarization did not return Accepted"
+            xcrun notarytool log "$(awk '/id:/{print $2; exit}' "$RUNNER_TEMP/notary.log")" \
+              --key "$RUNNER_TEMP/notary.p8" --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER_ID" || true
+            exit 1
+          }
+
+          # Tar only after signing and notarization, so the archives contain
+          # the signed binaries rather than the originals.
+          for target in darwin/arm64 darwin/amd64 linux/amd64 linux/arm64; do
+            goos="${target%/*}"; goarch="${target#*/}"
+            tar -C "dist/muster_${goos}_${goarch}" -czf "dist/muster_${goos}_${goarch}.tar.gz" muster
+            tar -C "dist/muster-deploy_${goos}_${goarch}" -czf "dist/muster-deploy_${goos}_${goarch}.tar.gz" muster-deploy
           done
           # The Lambda artifact for the optional hosted backend
           # (contrib/cloudformation/muster-backend.yaml). Three things about
@@ -148,3 +227,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ steps.rel.outputs.tag }}" dist/*.tar.gz dist/*.zip dist/checksums.txt --clobber --repo "$GITHUB_REPOSITORY"
+
+      - name: Destroy the signing material
+        # always(), because a failed build must not leave a usable Developer ID
+        # certificate or an App Store Connect key behind on the runner.
+        if: always()
+        run: |
+          rm -f "$RUNNER_TEMP/notary.p8" "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/notarize.zip"
+          [ -n "${MUSTER_KEYCHAIN:-}" ] && security delete-keychain "$MUSTER_KEYCHAIN" || true


### PR DESCRIPTION
Moves macOS signing and notarization into the release job, so it stops being a manual step run from a laptop after every release.

## Why, beyond convenience

`contrib/release-sign.sh` **rebuilt** darwin from the tag locally and replaced CI's assets. So what people downloaded was compiled on one machine while CI's build of the same commit was discarded. Signing in CI collapses that to a single build of every artifact.

It is also the step most likely to be skipped on a release cut in a hurry, and an unsigned macOS binary fails in a way that reads as a broken build rather than a missing signature.

## How

The job moves to `macos-latest` — `codesign` and `notarytool` exist nowhere else. Go cross-compiles the linux targets from there with `CGO_ENABLED=0`, so this is a runner change rather than a restructure.

Notarization is **one** submission covering all four darwin binaries; Apple takes minutes per submission and four sequential round trips would dominate the job. Bare executables cannot be stapled, so Gatekeeper verifies online exactly as it did before.

## Safety

The certificate and App Store Connect key come from a protected `release` environment restricted to `main` and `dev`, so a workflow run on any other branch cannot read them. They are written to a throwaway keychain and destroyed in an `always()` step, so a failed build leaves nothing usable on the runner. A missing certificate **fails the job** rather than quietly publishing unsigned binaries.

## Verified before pushing

- The `sign()` case pattern was `*/darwin_*`, which needs a literal `/darwin_` and matched **none** of the `dist/muster_darwin_arm64/...` paths — it would have signed nothing and shipped four unsigned binaries. Now `*_darwin_*`.
- Built and signed locally with the real certificate: both darwin binaries come out with the Developer ID and the `0x10000(runtime)` flag required for notarization; linux untouched.
- Replayed the `security import` step verbatim against the actual `.p12` in a throwaway keychain — imports with an empty passphrase and yields the same identity SHA-1 that signed v0.11.0.

`contrib/release-sign.sh` stays for repairing an already-published release by hand.
