### PR TITLE
feat(become): type /rename into the live agent pane after a claim, add --no-inject

### DIFF
--- a/internal/humancli/become.go
+++ b/internal/humancli/become.go
@@ -12,17 +12,18 @@ import (
 // newBecomeFlagsWithVals declares become's flags and returns typed access to
 // their values — shared by cmdBecome (real parsing) and newBecomeFlags
 // (registry help/man rendering).
-func newBecomeFlagsWithVals() (fs *flag.FlagSet, from *string) {
+func newBecomeFlagsWithVals() (fs *flag.FlagSet, from *string, noInject *bool) {
 	fs = flag.NewFlagSet("become", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	from = fs.String("from", "", "the alias to claim from, required when this session has more than one live alias")
-	return fs, from
+	noInject = fs.Bool("no-inject", false, "skip typing /rename into the live agent pane (for callers whose name ALREADY came from the harness side, e.g. the statusline promoting a /rename)")
+	return fs, from, noInject
 }
 
 // newBecomeFlags builds become's flag.FlagSet for registry-driven help/man
 // rendering.
 func newBecomeFlags() *flag.FlagSet {
-	fs, _ := newBecomeFlagsWithVals()
+	fs, _, _ := newBecomeFlagsWithVals()
 	return fs
 }
 
@@ -33,8 +34,8 @@ func newBecomeFlags() *flag.FlagSet {
 // alias; a split identity (more than one) requires --from so the claim never
 // guesses which one is being renamed.
 func cmdBecome(args []string, out io.Writer) error {
-	fs, from := newBecomeFlagsWithVals()
-	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{})
+	fs, from, noInject := newBecomeFlagsWithVals()
+	flagArgs, rest := splitFlagsAndPositional(args, map[string]bool{"no-inject": true})
 	if err := fs.Parse(flagArgs); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return HelpFor("become", out)
@@ -80,6 +81,16 @@ func cmdBecome(args []string, out io.Writer) error {
 	}
 	if err := json.Unmarshal(raw, &res); err != nil {
 		return err
+	}
+	// The claim landed, and the cloned row keeps the seed's pane and model —
+	// so the harness session name follows in the SAME gesture (syncAgentName,
+	// shared with label): prefix-T delegates its whole rename here, and the
+	// injected name is the full claimed alias (e.g. <project>/<work>).
+	// --no-inject is for names that already came from the harness side (the
+	// statusline promoting a /rename the agent itself typed) — re-injecting
+	// would loop the same text back into the pane.
+	if !*noInject {
+		syncAgentName(out, to, c.SocketPath, c.SessionID)
 	}
 	_, err = fmt.Fprintf(out, "you are now '%s' (was '%s') — %d unread thread(s)\n", to, fromAlias, res.Unread)
 	return err

--- a/internal/humancli/become_test.go
+++ b/internal/humancli/become_test.go
@@ -100,6 +100,113 @@ func TestBecomeRejectsEmptyAlias(t *testing.T) {
 	}
 }
 
+// TestBecomeRenamesLiveClaudePane: prefix-T delegates the whole rename to
+// become (dotfiles session-identity spec 2026-08-08), so a successful claim
+// must also type "/rename <name>" into this session's registered live
+// Claude pane — the tmux name, the bus alias, and the harness session name
+// move as ONE identity. The injected name is the FULL claimed alias
+// (<project>/<work>), never a bare work segment: an operator may be
+// troubleshooting "error" in several projects at once.
+func TestBecomeRenamesLiveClaudePane(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%5")
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$1",
+		"pane_id": "%5", "model_type": "claude", "session_created": 1700000000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var sent [][]string
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		last := args[len(args)-1]
+		switch last {
+		case "#{session_id}":
+			return "$1", nil
+		case "#{pane_id}":
+			return "%5", nil // pane-alive probe answers: alive
+		case "#{session_created}":
+			return "1700000000", nil // matches the row's recorded incarnation
+		}
+		if len(args) > 2 && args[2] == "send-keys" {
+			sent = append(sent, append([]string(nil), args...))
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"become", "dotfiles/error"}, &buf); err != nil {
+		t.Fatalf("become: %v", err)
+	}
+	if len(sent) != 2 {
+		t.Fatalf("expected /rename type + Enter submit, got %v", sent)
+	}
+	if got := sent[0][len(sent[0])-1]; got != "/rename dotfiles/error" {
+		t.Fatalf("typed %q, want %q", got, "/rename dotfiles/error")
+	}
+	if sent[1][len(sent[1])-1] != "Enter" {
+		t.Fatalf("expected Enter submit, got %v", sent[1])
+	}
+	if !strings.Contains(buf.String(), "renamed claude session") {
+		t.Fatalf("expected rename confirmation in output, got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "you are now 'dotfiles/error'") {
+		t.Fatalf("expected claim summary in output, got %q", buf.String())
+	}
+}
+
+// TestBecomeNoInjectSkipsRename: --no-inject claims the alias but never
+// touches the pane — for callers whose name ALREADY came from the harness
+// side (the statusline promoting a name that originated from a /rename the
+// agent itself typed): re-injecting it would loop the same text back into a
+// live pane. This is the flag statusline.sh has called since the
+// session-identity plan; before this test the flag didn't parse at all and
+// every such call silently failed, stranding the bus alias on rename.
+func TestBecomeNoInjectSkipsRename(t *testing.T) {
+	startTestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	t.Setenv("TMUX_PANE", "%5")
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "muster-2", "socket_path": "/tmp/sock", "session_id": "$1",
+		"pane_id": "%5", "model_type": "claude", "session_created": 1700000000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var sent [][]string
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		last := args[len(args)-1]
+		switch last {
+		case "#{session_id}":
+			return "$1", nil
+		case "#{pane_id}":
+			return "%5", nil
+		case "#{session_created}":
+			return "1700000000", nil
+		}
+		if len(args) > 2 && args[2] == "send-keys" {
+			sent = append(sent, append([]string(nil), args...))
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"become", "--no-inject", "dotfiles/error"}, &buf); err != nil {
+		t.Fatalf("become --no-inject: %v", err)
+	}
+	if len(sent) != 0 {
+		t.Fatalf("--no-inject must never type into the pane, got %v", sent)
+	}
+	if ag, ok, _ := hookGetAgent("dotfiles/error"); !ok || ag.Departed {
+		t.Fatalf("claim must still land with --no-inject, got %+v (ok=%v)", ag, ok)
+	}
+}
+
 // TestBecomeToExistsErrorHasNoPrefixStutter is finding F3, live rig:
 // `muster become` on an already-claimed name used to print "become: become:
 // alias ..." — the daemon's own error text for this guard baked in a

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -238,12 +238,17 @@ from tmux (internal/tmuxenv) so other commands can address it.`,
 		},
 		{
 			Name:     "become",
-			Synopsis: "become <name> [--from <alias>]",
+			Synopsis: "become <name> [--from <alias>] [--no-inject]",
 			Summary:  "Claim a durable name for this session.",
 			Help: `Claim this session's real name: a new alias inherits this session's
 identity and inbox watermark, and the tmux-seeded alias retires — route
 traffic by a name the work deserves. --from selects which of this session's
-live aliases to claim from; required when the session has more than one.`,
+live aliases to claim from; required when the session has more than one.
+When a live Claude Code or Cursor agent is registered in this session, also
+types /rename <name> into its pane so the harness session name follows the
+claim. --no-inject skips that typing — for callers whose name ALREADY came
+from the harness side (e.g. the statusline promoting a name that originated
+from a /rename), where re-typing it would loop text into a live pane.`,
 			Group:    GroupIdentity,
 			NewFlags: newBecomeFlags,
 			Run:      cmdBecome,


### PR DESCRIPTION
## Summary
- Prefix-T delegates its whole rename to `become` (dotfiles session-identity spec 2026-08-08): tmux name, bus alias, and harness session name are ONE identity. The claim landed but the pane injection never existed, so the Claude session name silently kept its old name after every prefix-T rename. A successful claim now types `/rename <full-alias>` (e.g. `<project>/<work>`, never a bare work segment) into this session's registered live Claude/Cursor pane, reusing `label`'s `syncAgentName` gates unchanged: roster row on this exact session tuple, live pane, live incarnation, claude/cursor only, best-effort.
- Adds `--no-inject`, which the dotfiles statusline has passed since the session-identity plan — the unknown flag made every promote-side `become` fail silently, stranding the bus alias on `/rename` (surfaces as tab titles like `@error` on a renamed session).

## Test plan
- [x] `TestBecomeRenamesLiveClaudePane` — claim + `/rename dotfiles/error` typed + Enter submitted + both confirmations printed
- [x] `TestBecomeNoInjectSkipsRename` — flag parses, claim lands, zero send-keys
- [x] existing become/label suites unchanged and green
- [x] `just verify` (fmt-check, lint, race tests, build, cross, aws-free)