### PR TITLE
docs: CI signs darwin assets; pick versions from tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,18 @@ the release line. Never develop on `main` — do feature work in a git worktree 
 when the promotion PR merges to `main`, the release workflow tags `v<VERSION>`,
 creates the GitHub release with generated notes, and attaches cross-compiled
 binaries (darwin/linux × arm64/amd64) with checksums. A merge to `main` that
-doesn't bump `VERSION` releases nothing. Afterwards, run
-`contrib/release-sign.sh v<VERSION>` from a Mac to sign + notarize the darwin
-assets in place (CI attaches unsigned ones).
+doesn't bump `VERSION` releases nothing. The darwin binaries are signed and
+notarized by the release job itself, which is why that job runs on a macOS
+runner, and it fails rather than publishing anything unsigned — so a green
+release needs no manual signing step. `contrib/release-sign.sh v<VERSION>`
+remains only for repairing an already-published release by hand.
+
+Pick the next version from the TAGS, not from `dev`'s `VERSION` file. The
+release commit bumps `VERSION` on `main` only, so until someone back-merges,
+`dev` still shows the version before the last release and a feature branch cut
+from it will propose a number that is already tagged — v0.14.0 was chosen this
+way after v0.13.0 had shipped. CI's `version-guard` catches the collision, but
+only once the PR is open.
 
 ## Architecture (the mental model)
 


### PR DESCRIPTION
Two corrections to CLAUDE.md's release section, both found while releasing v0.14.0.

**Signing.** CLAUDE.md said CI attaches unsigned darwin assets and told the reader to run `contrib/release-sign.sh` from a Mac afterwards. That has not been true since the release job moved to a macOS runner: it signs and notarizes in the job and hard-fails rather than publishing unsigned. Verified against the published v0.14.0 asset — Developer ID authority, hardened runtime, `spctl` reports `source=Notarized Developer ID`. The stale line caused this session to hand the operator a manual step that was not needed. The script keeps its real purpose, repairing an already-published release by hand, and the workflow's own header comment already said so.

**Version choice.** The release commit bumps `VERSION` on `main` only, so until a back-merge lands, `dev` still reads the version before the last release. A branch cut from `dev` therefore proposes a number that is already tagged — which is exactly what happened here: the branch was written as 0.13.0 after v0.13.0 had already shipped, and became 0.14.0. `version-guard` catches it, but only once the PR is open.