### PR TITLE
label: rename propagation reaches pi panes (native /name)

### DIFF
--- a/internal/humancli/label.go
+++ b/internal/humancli/label.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/schuettc/muster/internal/nudge"
 	"github.com/schuettc/muster/internal/tmuxenv"
@@ -160,7 +161,7 @@ func syncAgentName(out io.Writer, name, socket, sessionID string) {
 		return err
 	}}
 	for _, ag := range rows {
-		if ag.Departed || (ag.ModelType != "claude" && ag.ModelType != "cursor") || ag.SocketPath != socket ||
+		if ag.Departed || renameCommand(ag.ModelType) == "" || ag.SocketPath != socket ||
 			ag.SessionID != sessionID || ag.PaneID == "" {
 			continue
 		}
@@ -170,11 +171,27 @@ func syncAgentName(out io.Writer, name, socket, sessionID string) {
 		if !tmuxenv.IsSessionAlive(socket, ag.SessionID, ag.SessionCreated) {
 			continue
 		}
-		if _, err := typer.TypeLine(socket, ag.PaneID, ag.ModelType, "/rename "+name, true); err != nil {
-			_, _ = fmt.Fprintf(out, "warning: %s session rename failed (%v); run /rename %s in %s yourself\n", ag.ModelType, err, name, ag.ModelType)
+		if _, err := typer.TypeLine(socket, ag.PaneID, ag.ModelType, renameCommand(ag.ModelType)+name, true); err != nil {
+			_, _ = fmt.Fprintf(out, "warning: %s session rename failed (%v); run %s %s in %s yourself\n", ag.ModelType, err, strings.TrimSpace(renameCommand(ag.ModelType)), name, ag.ModelType)
 			return
 		}
 		_, _ = fmt.Fprintf(out, "renamed %s session to match (pane %s)\n", ag.ModelType, ag.PaneID)
 		return // one live supported harness per session; first match wins
 	}
+}
+
+// renameCommand is the slash command that sets a harness's own session
+// title, with its trailing space, or "" for a harness that has none (codex)
+// or that muster does not know — those panes are never typed into. pi gets
+// its NATIVE `/name`, not `/rename`: the pi harness extension's `/rename`
+// calls `muster become`, and `become` is what types this line, so typing
+// `/rename` at a pi pane would loop become → /rename → become.
+func renameCommand(modelType string) string {
+	switch modelType {
+	case "claude", "cursor":
+		return "/rename "
+	case "pi":
+		return "/name "
+	}
+	return ""
 }

--- a/internal/humancli/label.go
+++ b/internal/humancli/label.go
@@ -183,9 +183,9 @@ func syncAgentName(out io.Writer, name, socket, sessionID string) {
 // renameCommand is the slash command that sets a harness's own session
 // title, with its trailing space, or "" for a harness that has none (codex)
 // or that muster does not know — those panes are never typed into. pi gets
-// its NATIVE `/name`, not `/rename`: the pi harness extension's `/rename`
-// calls `muster become`, and `become` is what types this line, so typing
-// `/rename` at a pi pane would loop become → /rename → become.
+// its NATIVE `/name`. pi's harness extension has no rename command of its
+// own — it reacts to pi's `session_info_changed` event and calls
+// `become --no-inject`, so typing `/name` here propagates without looping.
 func renameCommand(modelType string) string {
 	switch modelType {
 	case "claude", "cursor":

--- a/internal/humancli/label_test.go
+++ b/internal/humancli/label_test.go
@@ -440,8 +440,8 @@ func TestLabelNoInjectSkipsRename(t *testing.T) {
 }
 
 // TestLabelRenamesLivePiPane: a pi session is renamed from the bus by typing
-// pi's NATIVE `/name` — not `/rename`, which the pi harness extension maps
-// onto `muster become` and would loop straight back here. Delayed submit,
+// pi's NATIVE `/name`; the pi harness extension reacts to the resulting
+// session_info_changed event with `become --no-inject`, so nothing loops. Delayed submit,
 // same as Cursor: the paste and the Enter are distinct tmux calls.
 func TestLabelRenamesLivePiPane(t *testing.T) {
 	startCLITestDaemon(t)

--- a/internal/humancli/label_test.go
+++ b/internal/humancli/label_test.go
@@ -438,3 +438,62 @@ func TestLabelNoInjectSkipsRename(t *testing.T) {
 		}
 	}
 }
+
+// TestLabelRenamesLivePiPane: a pi session is renamed from the bus by typing
+// pi's NATIVE `/name` — not `/rename`, which the pi harness extension maps
+// onto `muster become` and would loop straight back here. Delayed submit,
+// same as Cursor: the paste and the Enter are distinct tmux calls.
+func TestLabelRenamesLivePiPane(t *testing.T) {
+	startCLITestDaemon(t)
+	t.Setenv("TMUX", "/tmp/sock,1,0")
+	if _, err := callData("register_agent", map[string]any{
+		"alias": "worker", "socket_path": "/tmp/sock", "session_id": "$1",
+		"pane_id": "%5", "model_type": "pi", "session_created": 1700000000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var sent [][]string
+	prev := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		last := args[len(args)-1]
+		switch last {
+		case "#{session_id}":
+			return "$1", nil
+		case "#{pane_id}":
+			return "%5", nil
+		case "#{session_created}":
+			return "1700000000", nil
+		}
+		if len(args) > 2 && args[2] == "send-keys" {
+			sent = append(sent, append([]string(nil), args...))
+		}
+		return "", nil
+	}
+	t.Cleanup(func() { tmuxenv.Run = prev })
+
+	var buf bytes.Buffer
+	if err := cmdLabel([]string{"standard 2000"}, &buf); err != nil {
+		t.Fatalf("label: %v", err)
+	}
+	if len(sent) != 2 {
+		t.Fatalf("expected /name type + delayed Enter submit, got %v", sent)
+	}
+	if got := sent[0][len(sent[0])-1]; got != "/name standard 2000" {
+		t.Fatalf("typed %q, want %q — pi must get its native /name, never /rename", got, "/name standard 2000")
+	}
+	if sent[1][len(sent[1])-1] != "Enter" {
+		t.Fatalf("expected delayed Enter submit, got %v", sent[1])
+	}
+	if !strings.Contains(buf.String(), "renamed pi session") {
+		t.Fatalf("expected pi rename confirmation in output, got %q", buf.String())
+	}
+}
+
+func TestRenameCommandTable(t *testing.T) {
+	for model, want := range map[string]string{"claude": "/rename ", "cursor": "/rename ", "pi": "/name ", "codex": "", "": "", "station": ""} {
+		if got := renameCommand(model); got != want {
+			t.Errorf("renameCommand(%q) = %q, want %q", model, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Found by Phase 3 of the pi harness program: `muster become` / `muster label` could not rename a pi session from the bus and failed silently — `syncAgentName`'s gate only admitted `claude` and `cursor`, so a pi row never reached the typing step. (The nudge submit table already had `pi` since #117.)

Fix: the gate and the typed line route through `renameCommand(modelType)`: `/rename ` for claude and cursor, **`/name `** for pi (its native session-title command), `""` for codex and unknown harnesses (never typed into).

Why `/name` and not `/rename` for pi: the pi harness extension implements `/rename` as pi-title + tmux rename + `muster become`, and `become` is exactly what types this line — typing `/rename` at a pi pane would loop become → /rename → become. `/name` sets only the TUI title, which is all the outside-in direction needs.

Submit timing for pi is the paste-delay path (safe for either TUI kind). Tests: pi pane gets `/name <name>` then a distinct Enter; command-table test pins all four cases.