### PR TITLE
harnessenv: accept AGENT_SESSION_ID (harness-neutral session id)

### DIFF
--- a/internal/harnessenv/harnessenv.go
+++ b/internal/harnessenv/harnessenv.go
@@ -5,7 +5,8 @@
 // when the operator launched from a pane, so tmuxenv.CaptureEnv comes back
 // empty. Identity then comes from what the harness DOES provide: every hook's
 // stdin payload carries session_id and cwd, and the process environment
-// carries $CLAUDE_CODE_SESSION_ID and a working directory. Like tmuxenv,
+// carries $CLAUDE_CODE_SESSION_ID (or, for harness-neutral runtimes such as
+// pi, $AGENT_SESSION_ID) and a working directory. Like tmuxenv,
 // this package is the single canonical capture path for that identity —
 // callers must not read those variables directly.
 package harnessenv
@@ -39,10 +40,18 @@ type Capture struct {
 }
 
 // FromEnv captures identity from the process environment: the harness
-// session UUID and the working directory.
+// session UUID and the working directory. Claude Code exports its UUID as
+// CLAUDE_CODE_SESSION_ID; harness-neutral runtimes (pi, via its harness
+// extension) export AGENT_SESSION_ID instead and must never set the Claude
+// variable, because downstream this package's answer is what decides whether
+// a paneless session IS a Claude session. Claude's wins when both are set.
 func FromEnv() Capture {
 	cwd, _ := os.Getwd()
-	return Capture{SessionID: os.Getenv("CLAUDE_CODE_SESSION_ID"), CWD: cwd}
+	id := os.Getenv("CLAUDE_CODE_SESSION_ID")
+	if id == "" {
+		id = os.Getenv("AGENT_SESSION_ID")
+	}
+	return Capture{SessionID: id, CWD: cwd}
 }
 
 // FromHookPayload captures identity from a hook's stdin payload (Claude Code

--- a/internal/harnessenv/harnessenv_test.go
+++ b/internal/harnessenv/harnessenv_test.go
@@ -170,3 +170,24 @@ func TestIsTeammateFailOpenAndBounded(t *testing.T) {
 		t.Fatal("teamName beyond line 30 must not match (bounded scan)")
 	}
 }
+
+// A harness-neutral runtime (pi) exports AGENT_SESSION_ID and never the
+// Claude variable; FromEnv must accept it so `muster register` and every
+// CLI identity path work for pi, not only the hook-payload path.
+func TestFromEnvAcceptsAgentSessionID(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("AGENT_SESSION_ID", "pi-uuid")
+	if got := FromEnv().SessionID; got != "pi-uuid" {
+		t.Fatalf("SessionID = %q, want pi-uuid", got)
+	}
+}
+
+// When both are present the Claude variable wins — existing behavior for
+// Claude sessions is untouched by the fallback.
+func TestFromEnvClaudeVariableWins(t *testing.T) {
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "claude-uuid")
+	t.Setenv("AGENT_SESSION_ID", "pi-uuid")
+	if got := FromEnv().SessionID; got != "claude-uuid" {
+		t.Fatalf("SessionID = %q, want claude-uuid", got)
+	}
+}


### PR DESCRIPTION
`harnessenv.FromEnv` read exactly one variable, `CLAUDE_CODE_SESSION_ID`, so a pi session — which exports `AGENT_SESSION_ID` and must never set the Claude variable (this package's answer is what decides whether a paneless session is Claude) — registered via `muster register` or any CLI identity path carried no harness link: resume-reclaim, the Stop-hook link repair, and paneless identity silently never fired for it.

Now `AGENT_SESSION_ID` is the fallback when the Claude variable is unset; Claude's wins when both are present, so Claude sessions are unchanged. Same one-line shape as galley's session-id patch (galley PR #193), so the pair is coherent across the two channel servers.

Found while reviewing the pi harness extension's muster calls (bus thread #307).