### PR TITLE
Standing vs live broadcast: new sessions stop inheriting the backlog

### DIFF
--- a/docs/superpowers/plans/2026-08-30-standing-vs-live-broadcast.md
+++ b/docs/superpowers/plans/2026-08-30-standing-vs-live-broadcast.md
@@ -1,0 +1,208 @@
+# Standing vs Live Broadcast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a new session inheriting the entire broadcast backlog, and split broadcast into two behaviors: plain `--broadcast` is **live-only** (reaches sessions live at/after send; invisible to sessions that start later), and `--broadcast --standing` reaches every session that starts later, once, until it reads.
+
+**Architecture:** Two changes, both riding the existing watermark machinery. (1) `RegisterAgent`'s INSERT branch seeds `last_read_entry_id = MAX(entries.id)` so a first-seen alias starts caught-up — plain broadcast becomes live-only. (2) A `standing` bit on the broadcast thread plus a second, un-seeded watermark `last_read_standing_entry_id` on the agent: the unread computation picks the standing watermark for standing threads (0 for a new session → the standing backlog shows once) and the ordinary watermark for everything else. `MarkRead` advances both. The concern predicate is unchanged; only unread computation branches. Both stores (SQLite + DynamoDB) change together, gated by the conformance suite.
+
+**Tech Stack:** Go, pure-Go SQLite (`modernc.org/sqlite`), no cgo. Spec: `docs/superpowers/specs/2026-08-30-standing-vs-live-broadcast-design.md`.
+
+## Global Constraints
+
+- Work in the worktree `/Users/courtschuett/GitHub/worktrees/muster-standing-broadcast` on branch `feat/standing-vs-live-broadcast` (off `dev`). Never touch the primary clone.
+- The full gate is `just verify` (gofmt, golangci-lint, `go test -race`, build). Run it before the final commit; per-task, run the named package tests.
+- `CGO_ENABLED=0` must keep building. Add no dependencies.
+- stdout is sacred in mcp mode; no stray prints (all diagnostics to stderr — this plan adds none).
+- **Both stores or neither.** Every store-layer behavior change lands in `internal/store` AND `internal/dynamostore`, and is proven equal by a case in `internal/storetest/conformance.go`. A change that passes SQLite tests but not conformance is not done.
+- **Watermark invariants that must not regress:** the ON CONFLICT (re-register) branch never touches either watermark (a returning alias keeps read-state — `TestRegisterAgentRevivePreservesReadState` and siblings); `MarkRead` self-exclusion (`from_agent != alias`) is retained everywhere.
+- Standing is **message-broadcast-only**: `standing=1` requires `to_kind='broadcast'`; a standing task is rejected. `--standing` requires `--broadcast`.
+
+---
+
+### Task 1: Store schema, migration, and models
+
+**Files:**
+- Modify: `internal/store/schema.sql` (agents +`last_read_standing_entry_id`, threads +`standing`)
+- Modify: `internal/store/store.go:43-58` (append two `ALTER TABLE` migrations)
+- Modify: `internal/store/models.go` (`Agent.LastReadStandingEntryID int64`; `Thread.Standing bool`)
+- Test: `internal/store/store_test.go` (migration idempotency / column presence)
+
+**Interfaces:**
+- Produces: fresh DBs and migrated DBs both have `agents.last_read_standing_entry_id INTEGER NOT NULL DEFAULT 0` and `threads.standing INTEGER NOT NULL DEFAULT 0`. `Agent` carries `LastReadStandingEntryID`; `Thread` carries `Standing`. Later tasks read/write these.
+
+- [ ] **Step 1: Write the failing test** — a test that opens a store, inserts an agent + a broadcast thread, and asserts the two new columns exist with correct defaults (0 / false); and that `migrate()` is idempotent across two `Open`s on the same file.
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** — add the column to both `CREATE TABLE` blocks in `schema.sql`; append to the `alters` slice in `store.go`:
+  ```
+  `ALTER TABLE agents ADD COLUMN last_read_standing_entry_id INTEGER NOT NULL DEFAULT 0`,
+  `ALTER TABLE threads ADD COLUMN standing INTEGER NOT NULL DEFAULT 0`,
+  ```
+  Add `LastReadStandingEntryID int64` to `Agent` and `Standing bool` to `Thread` in `models.go` with a one-line comment on each (standing = replayed to future sessions until read; the standing watermark is un-seeded on register). No backfill needed — both default correctly for existing rows (pre-upgrade broadcasts become live-only; that is the intended migration, per spec).
+- [ ] **Step 4: Run the store package tests.**
+- [ ] **Step 5: Commit** — `store: add standing column + standing read watermark (schema+migration)`.
+
+---
+
+### Task 2: Store — seed new-session watermark; dual-advance MarkRead; standing-aware unread
+
+**Files:**
+- Modify: `internal/store/agents.go` — `RegisterAgent` INSERT (seed), column lists in `scanAgent`/`GetAgent`/`ListAgents`, `MarkRead` (dual advance), `UnreadCount` (branch)
+- Modify: `internal/store/threads.go` — `Inbox` unread CTE (branch), select `recent.standing`
+- Modify: `internal/store/poll.go` — `SessionUnread` (branch) if it computes unread there
+- Test: `internal/store/agents_test.go`, `internal/store/threads_test.go`
+
+**Interfaces:**
+- Consumes: Task 1 columns/fields.
+- Produces: (a) first INSERT seeds `last_read_entry_id = COALESCE((SELECT MAX(id) FROM entries),0)`, `last_read_standing_entry_id` left at 0; ON CONFLICT unchanged. (b) The unread predicate everywhere is:
+  ```sql
+  ((recent.standing = 1 AND e.id > COALESCE((SELECT last_read_standing_entry_id FROM agents WHERE alias=?),0))
+   OR (recent.standing = 0 AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?),0)))
+  AND e.from_agent != ?
+  ```
+  (join form uses `sess.*` columns). (c) `MarkRead` sets both watermarks to the snapshot max entry id in one tx. Later tasks and conformance rely on: a plain broadcast before register is hidden; a standing broadcast before register shows once then clears; both scoped forms respect project concern.
+
+- [ ] **Step 1: Write the failing tests** in `agents_test.go` / `threads_test.go`:
+  - `TestRegisterSeedsLiveWatermarkToMax`: create entries, then register a fresh alias → its `LastReadEntryID == max entry id`, `LastReadStandingEntryID == 0`.
+  - `TestNewSessionSkipsPlainBroadcastBacklog`: send a plain broadcast, THEN register a new alias → not in its inbox / unread 0.
+  - `TestNewSessionSeesStandingBroadcastOnce`: send a standing broadcast, THEN register → unread 1; `MarkRead`; unread 0; send a second standing broadcast → unread 1.
+  - `TestReviveKeepsBothWatermarks`: existing revive test extended to assert `LastReadStandingEntryID` is preserved across depart→re-register.
+  - `TestMarkReadAdvancesBothWatermarks`.
+- [ ] **Step 2: Run to verify they fail.**
+- [ ] **Step 3: Implement** — seed in the INSERT VALUES (add `last_read_entry_id` column with the `(SELECT COALESCE(MAX(id),0) FROM entries)` subselect; keep it OUT of the ON CONFLICT SET list). Add `last_read_standing_entry_id` to every agent column list + `scanAgent`. Branch the unread predicate in `Inbox`, `UnreadCount`, `SessionUnread`; add `recent.standing` (and the join form's `sess.last_read_standing_entry_id`) to the relevant CTEs; update every affected bind-arg list (the standing watermark subselect adds one bind per surface — update counts carefully).
+- [ ] **Step 4: Run the store package tests** (`go test ./internal/store/... -race`).
+- [ ] **Step 5: Commit** — `store: live-only default via register seed; standing watermark unread + MarkRead`.
+
+---
+
+### Task 3: Store — CreateThread persists `standing`; reject non-broadcast standing
+
+**Files:**
+- Modify: `internal/store/threads.go` — `CreateThread` (accept + persist `standing`; guard)
+- Modify: `internal/store/models.go` if a create-params struct carries the flag
+- Test: `internal/store/threads_test.go`
+
+**Interfaces:**
+- Produces: `CreateThread` writes `threads.standing`; returns an error if `standing && to_kind != 'broadcast'`. Daemon (Task 5) is the primary gate; this is defense in depth.
+
+- [ ] **Step 1: Write failing tests** — standing broadcast round-trips `Standing==true` via `GetThread`/`Threads`/`Inbox`; `CreateThread` with standing + non-broadcast target errors.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run store tests.**
+- [ ] **Step 5: Commit** — `store: CreateThread persists standing, rejects non-broadcast standing`.
+
+---
+
+### Task 4: DynamoDB store — mirror register seed, standing watermark, standing thread
+
+**Files:**
+- Modify: `internal/dynamostore/agents.go` — `RegisterAgent` seed live watermark to current max event id (first-insert only); persist/scan `last_read_standing_entry_id`
+- Modify: `internal/dynamostore/threads.go` — `unreadByThread`/`unreadFor`/`Inbox`/`UnreadCount`/`SessionUnread` branch on the thread's `standing` and the standing watermark; `MarkRead` advances both; persist `standing` on the thread item
+- Modify: `internal/dynamostore/store.go` if item marshalling lives there
+- Test: `internal/dynamostore/*_test.go` (mirrors of the store tests; keep any existing local-only harness gating)
+
+**Interfaces:**
+- Consumes: `store.Agent.LastReadStandingEntryID`, `store.Thread.Standing`.
+- Produces: DynamoDB behaves identically to SQLite for every case in Task 5's conformance additions. Note `unreadByThread(..., after int64)` currently takes ONE watermark — extend it to take both (or split standing vs non-standing entries and apply each), keeping the existing self-exclude semantics.
+
+- [ ] **Step 1: Write failing tests** (dynamostore mirrors, or rely on Task 5 conformance if that is the package's convention — check how dynamostore tests are structured first).
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement** — register seed uses the current max event/entry id; `unreadByThread` takes `liveAfter, standingAfter int64` and picks per entry by its thread's standing; `MarkRead` writes both `#last_read_entry_id` and `#last_read_standing_entry_id`; thread item carries `standing`.
+- [ ] **Step 4: Run dynamostore tests.**
+- [ ] **Step 5: Commit** — `dynamostore: mirror register seed + standing watermark + standing thread`.
+
+---
+
+### Task 5: Conformance — standing vs live across both stores
+
+**Files:**
+- Modify: `internal/storetest/conformance.go`
+- Test: runs via both `internal/store` and `internal/dynamostore` conformance entrypoints
+
+**Interfaces:**
+- Produces: the canonical cross-store contract. Cases (each asserted on both backends):
+  - fresh register seeds live watermark to max; plain broadcast sent before register is hidden.
+  - standing broadcast sent before register shows once, clears on MarkRead, a later standing broadcast reappears.
+  - plain broadcast sent AFTER register appears (live contract intact).
+  - revive preserves both watermarks.
+  - standing composes with project scope (same-project new alias sees it; other-project never does).
+  - `MarkRead` zeroes unread for both standing and live threads.
+
+- [ ] **Step 1: Add the cases.**
+- [ ] **Step 2: Run conformance against both stores** (the store-level `go test` and the dynamostore entrypoint / its local harness).
+- [ ] **Step 3: Commit** — `storetest: standing vs live broadcast conformance`.
+
+---
+
+### Task 6: Daemon — validate standing at send time
+
+**Files:**
+- Modify: `internal/daemon/daemon.go` — `send_message` op handler: pass `standing` through to `CreateThread`; reject `standing && to_kind != 'broadcast'` with a clear usage error; compose with existing project-scope validation
+- Test: `internal/daemon/broadcast_test.go` (or a new `standing_test.go`)
+
+**Interfaces:**
+- Consumes: op fields; `store.CreateThread` standing param.
+- Produces: a standing broadcast op creates a standing thread; standing + non-broadcast is rejected; live wake fan-out (`notifyForThread`) is UNCHANGED (standing does not alter who is badged live).
+
+- [ ] **Step 1: Write failing tests** — standing broadcast op → stored thread `Standing==true`; standing + `to_kind=agent` rejected; standing scoped broadcast to unknown project still rejected with known-projects error; wake fan-out identical for standing vs plain.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run daemon tests (`-race`).**
+- [ ] **Step 5: Commit** — `daemon: accept + validate standing broadcasts`.
+
+---
+
+### Task 7: MCP — `standing` param on send_message
+
+**Files:**
+- Modify: `internal/mcpserver/tools_messages.go` (schema + plumb `standing`)
+- Modify: `internal/mcpserver/call.go` if arg decoding is centralized
+- Test: `internal/mcpserver/*_test.go`
+
+**Interfaces:**
+- Produces: `send_message` accepts optional `standing` bool (default false), valid only with `to_kind=broadcast`; description explains the split (live now vs reaches future sessions until read; use for standing orders, not transient holds). No new tool.
+
+- [ ] **Step 1: Write failing test** — MCP `send_message` with `standing:true, to_kind:broadcast` stores a standing thread; with a non-broadcast target it errors.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement (schema + plumb + description).**
+- [ ] **Step 4: Run mcpserver tests.**
+- [ ] **Step 5: Commit** — `mcp: standing flag on send_message (broadcast-only)`.
+
+---
+
+### Task 8: CLI — `--standing` on `muster send --broadcast`
+
+**Files:**
+- Modify: `internal/humancli/humancli.go` / the `cmdSend` flag set + `registry.go` synopsis + `send` help
+- Test: `internal/humancli/send_broadcast_test.go`
+
+**Interfaces:**
+- Produces: `muster send --broadcast --standing "body"` (global standing); `--broadcast --standing --project <p>` (scoped standing); `--standing` without `--broadcast` is a usage error (mirrors `--project`). Multi-word unquoted body still joins and stays global unless `--project`.
+
+- [ ] **Step 1: Write failing tests** — the three cases above.
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run humancli tests.**
+- [ ] **Step 5: Commit** — `cli: --standing flag on send --broadcast`.
+
+---
+
+### Task 9: Display — mark standing in listings (optional polish)
+
+**Files:**
+- Modify: `internal/render/renderer.go`, `internal/station/*` — tag a standing broadcast (e.g. `broadcast (standing)` / a column marker)
+- Test: `internal/render/renderer_test.go`, `internal/station/*_test.go`
+
+- [ ] **Step 1: Write failing tests.**
+- [ ] **Step 2: Verify fail.**
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Run tests.**
+- [ ] **Step 5: Commit** — `render/station: surface standing broadcasts`.
+
+---
+
+### Task 10: Gate and end-to-end sanity
+
+- [ ] **Step 1: Run the full gate** — `just verify` (gofmt, golangci-lint, `go test -race ./...`, build). `CGO_ENABLED=0 go build ./...`.
+- [ ] **Step 2: End-to-end smoke on an isolated bus** (`MUSTER_HOME=$(mktemp -d)`): register agent A; `muster send --broadcast "live hold"`; `muster send --broadcast --standing "standing order"`; register a NEW agent B; assert B's inbox has ONLY the standing order (not the live hold); `muster inbox B` marks read; re-check unread 0.
+- [ ] **Step 3: Commit any gate fixes; final commit if dirty.** Then finish the branch per the finishing-a-development-branch skill (push + open PR against `dev` — the repo's default working base).

--- a/docs/superpowers/specs/2026-08-30-standing-vs-live-broadcast-design.md
+++ b/docs/superpowers/specs/2026-08-30-standing-vs-live-broadcast-design.md
@@ -1,0 +1,238 @@
+# Standing vs live broadcast
+
+**Date:** 2026-08-30
+**Status:** Draft
+
+## Problem
+
+Broadcast delivery is pull-by-watermark, and a brand-new session starts with
+its watermark at zero — so it inherits the **entire broadcast backlog** on
+first registration.
+
+The mechanism: a broadcast is a thread with `to_kind='broadcast'` (see
+[project-broadcast design](2026-07-22-project-broadcast-design.md)). An agent
+"concerns" it via the one canonical `threadConcerns` predicate, and whether it
+is *unread* is decided per-agent against a read watermark
+(`internal/store/threads.go`):
+
+```sql
+e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)
+```
+
+`RegisterAgent`'s INSERT branch (`internal/store/agents.go`) never sets
+`last_read_entry_id`, so a first-seen alias defaults to `0`. Every historical
+broadcast entry has `id > 0`, so all of them land in the new session's inbox.
+A *returning* alias keeps its watermark and correctly sees only what is new.
+
+This conflates two intents the operator actually has:
+
+| Intent | Wanted | Today |
+|---|---|---|
+| "Welcome / standing orders" — read this before you touch the repo | reaches sessions now **and** future ones | ✅ (the only behavior) |
+| "Hold while I refactor X" — transient, meaningless once the hold clears | reaches **only live** sessions; invisible to future ones | ❌ (does not exist) |
+
+Every broadcast today behaves like the first row. The transient case has no
+expression, and there is no way to stop the backlog from piling onto new
+sessions.
+
+## Decision
+
+Two changes, together:
+
+1. **New sessions start caught-up.** `RegisterAgent`'s INSERT branch seeds
+   `last_read_entry_id = MAX(entries.id)` at registration time. A first-seen
+   alias sees nothing sent before it existed — only broadcasts (and direct
+   mail) that arrive after it joins. Returning aliases (the ON CONFLICT
+   branch) are untouched, exactly as today. This makes plain broadcast
+   **live-only** by default and fixes the backlog complaint outright.
+
+2. **`--standing` broadcasts are exempt from that seed.** A standing broadcast
+   is delivered to every newly-registered session on start — even one that
+   joins long after the send — until that session reads it once. This is the
+   "welcome to the project" channel, preserved from the behavior step 1 would
+   otherwise remove.
+
+Standing is tracked with a **second watermark**, not a new per-message "seen"
+table: add `last_read_standing_entry_id` to the `agents` row, defaulting to
+`0` and — unlike `last_read_entry_id` — **not** seeded on register. The unread
+computation picks the watermark per thread:
+
+- standing broadcast entry is unread when `e.id > last_read_standing_entry_id`
+  (0 for a new session → the standing backlog shows once),
+- every other entry is unread when `e.id > last_read_entry_id`
+  (seeded to `MAX` on register → the ordinary backlog is skipped).
+
+`MarkRead` advances **both** watermarks to the max entry read, so a standing
+message badges a session once on start and then goes quiet, and a later
+standing broadcast (higher id) badges again.
+
+Standing is orthogonal to project scope: `--standing` composes with the
+existing global and `--project`-scoped forms.
+
+### Why a second watermark, not a `standing_seen(alias, thread_id)` set
+
+The set is more precise (per-message dismissal) but heavier: a new table, a
+join in every unread surface, and a bespoke set representation to model and
+prove equal in DynamoDB. The second watermark reuses the existing watermark
+machinery verbatim — one scalar column, the same `e.id > watermark` shape, the
+same `MarkRead` update — which is the only way to keep the SQLite and DynamoDB
+stores in lockstep cheaply (see conformance note below). Per-message dismissal
+is not a requirement here; "badge each new session once, then quiet" is.
+
+## Semantics
+
+- **Plain broadcast (`--broadcast`)** — live-only. Delivered to every session
+  live at (or after) send time via the existing wake fan-out and inbox concern;
+  a session that registers *later* never sees it, because its seeded watermark
+  is already past the entry.
+- **Standing broadcast (`--broadcast --standing`)** — delivered to live
+  sessions now (identical wake fan-out) **and** to any session that registers
+  later, once, until it reads. Both the global and `--project` scoped forms
+  support `--standing`.
+- **Send-time wake is unchanged.** `notifyForThread` fans out to concerning
+  live agents identically for standing and live broadcasts — standing only
+  changes what a *not-yet-registered* session finds in its inbox on start. No
+  daemon fan-out change is required.
+- **Concern is unchanged.** `threadConcerns` / `threadConcernsJoin` are not
+  touched; a standing broadcast concerns the same set (global, or the scoped
+  project). Only the *unread* computation branches on the standing flag.
+- **Standing is message-only.** `--standing` requires `--broadcast`; both
+  without the pairing are usage errors. A standing flag on a task broadcast is
+  rejected (standing tasks are out of scope — a task's lifecycle already gives
+  it persistence and an owner).
+- **Direct and role mail are unaffected** by the register-time seed in
+  practice: a first-seen alias has no prior direct/role mail by definition, so
+  seeding the watermark to `MAX` cannot hide anything addressed to it. The seed
+  only ever suppresses history that predates the session — which for a new
+  alias is exactly the broadcast backlog.
+
+## Migration
+
+On upgrade, pre-existing broadcast rows carry no standing flag (column
+defaults to 0), so they become **live-only for future sessions**: a session
+that starts after the upgrade will not replay them. There is no way to know
+retroactively which historical broadcasts were meant as standing orders, so
+this is accepted — re-send anything that must persist with `--standing`.
+Sessions already registered keep their existing watermark and are unaffected.
+
+The new `last_read_standing_entry_id` column is added with default `0` for all
+existing agent rows. Existing sessions therefore see standing broadcasts sent
+*after* the upgrade replay once (harmless, and correct — those are genuinely
+new standing orders). No historical standing broadcasts exist to replay.
+
+## Changes by component
+
+### Store (`internal/store`)
+
+- **Schema:** `agents` gains `last_read_standing_entry_id INTEGER NOT NULL
+  DEFAULT 0`; `threads` gains `standing INTEGER NOT NULL DEFAULT 0` (a
+  migration in the store's schema setup).
+- **`RegisterAgent` (`agents.go`):** the INSERT branch seeds
+  `last_read_entry_id = (SELECT COALESCE(MAX(id),0) FROM entries)`. The ON
+  CONFLICT branch is unchanged and must **not** touch either watermark, so a
+  returning alias keeps its read-state (the invariant the existing doc comment
+  and revive tests already guard). `last_read_standing_entry_id` is left at its
+  `0` default on INSERT — never seeded.
+- **Unread predicate:** every surface that counts unread entries branches on
+  the thread's `standing` flag:
+
+  ```sql
+  (recent.standing = 1 AND e.id > COALESCE(last_read_standing_entry_id, 0))
+  OR
+  (recent.standing = 0 AND e.id > COALESCE(last_read_entry_id, 0))
+  ```
+
+  applied in `Inbox()` (`threads.go`), `UnreadCount`, and `SessionUnread`
+  (`poll.go` / the session-join form). The `from_agent != alias` self-exclusion
+  is retained in all of them.
+- **`MarkRead` (`agents.go`):** set both `last_read_entry_id` and
+  `last_read_standing_entry_id` to the snapshot max entry id in the same
+  transaction that reads the count.
+- **`CreateThread`:** accept and persist the `standing` flag on broadcast
+  threads; reject `standing=1` for any `to_kind != 'broadcast'` (defense in
+  depth behind the daemon check).
+
+### DynamoDB store (`internal/dynamostore`) + conformance
+
+The hosted backend is a full peer of the SQLite store and
+`internal/storetest/conformance.go` is the gate that forces them to behave
+identically. Every store change above lands in `dynamostore` too: the agent
+item carries `last_read_standing_entry_id`, the thread item carries `standing`,
+register seeds the live watermark to the current max event id, `MarkRead`
+advances both, and the unread/inbox projections branch on `standing`. New
+conformance cases (below) run against **both** stores and are the definition of
+"done" for this layer.
+
+### Daemon (`internal/daemon/daemon.go`)
+
+- **Validation:** in the `send_message` op handler, reject `standing=1` unless
+  `to_kind=='broadcast'`, with a clear usage error. Standing composes with the
+  existing project-scope validation (a standing project broadcast is still
+  rejected if no non-departed agent is in that project).
+- **`notifyForThread`:** unchanged. Standing does not alter live wake fan-out.
+- **`targetOf` / journal:** no change — standing is a property of the thread,
+  not the target string; `broadcast` / `broadcast:<project>` render as today.
+  (Station/render surfacing of the standing flag is optional polish, below.)
+
+### MCP (`internal/mcpserver`)
+
+`send_message` gains an optional `standing` boolean (default false), valid only
+with `to_kind=broadcast`. The tool description explains the split: "a plain
+broadcast reaches every session live now; set `standing:true` to also reach
+sessions that start later, until they read it once — use it for standing orders
+like 'read CONTRACT.md before editing', not for transient holds." No new tool.
+
+### CLI (`internal/humancli`)
+
+- `muster send --broadcast --standing "body"` — standing global broadcast.
+- `muster send --broadcast --standing --project <p> "body"` — standing scoped.
+- `muster send --standing …` without `--broadcast` is a usage error, mirroring
+  `--project`. Help text and the `registry.go` synopsis document the flag and
+  when to reach for it.
+
+### Render / station (optional polish)
+
+`internal/render` and `internal/station` may mark a standing broadcast in
+listings (e.g. a `standing` tag beside `broadcast` / `broadcast:<project>`) so
+an operator can tell a standing thread from a live one at a glance. Not
+required for the feature to work; can follow.
+
+## Testing
+
+- **Store / conformance (both backends):**
+  - a first-seen alias registers with `last_read_entry_id = MAX(entries.id)`;
+    a broadcast sent *before* it registered is **not** in its inbox.
+  - a returning (departed→revived) alias keeps its prior watermark — the
+    existing revive test still passes.
+  - a **standing** broadcast sent before a new alias registers **is** in its
+    inbox once; after `MarkRead` it is gone; a later standing broadcast (higher
+    id) reappears.
+  - a plain (non-standing) broadcast sent before registration stays hidden;
+    one sent after registration appears — the live-only contract.
+  - standing composes with `--project`: a new same-project alias sees a
+    standing scoped broadcast; an other-project alias never does.
+  - `MarkRead` advances both watermarks; unread count is zero immediately after
+    for both standing and live threads.
+  - `TestThreadConcernsSessionJoinEquivalence` still passes (concern predicate
+    is unchanged); add standing thread shapes to the unread-branch fixtures.
+- **Daemon:** `standing=1` with a non-broadcast target is rejected; standing
+  scoped broadcast to an unknown/departed-only project is rejected with the
+  known-projects error; live wake fan-out badges the same live sessions for a
+  standing broadcast as for a plain one.
+- **CLI:** `--broadcast --standing` sends a standing broadcast; `--standing`
+  without `--broadcast` is a usage error; a multi-word unquoted body with
+  `--standing` still joins into the body and stays global unless `--project`.
+
+## Out of scope
+
+- Per-message dismissal / a `standing_seen` set (the second watermark is
+  sufficient for "badge each new session once").
+- Standing **tasks** — standing is message-broadcast-only.
+- Broadcast TTL/expiry and an operator "clear all broadcasts" command
+  (considered; weaker — a stale-but-unexpired hold still hits new sessions, and
+  a manual clear is easy to forget). The register-time seed makes both
+  unnecessary for the stated problem.
+- Retroactive classification of pre-upgrade broadcasts as standing (see
+  Migration).
+- Editing/withdrawing a standing broadcast after send (re-send or let read
+  quiet it; withdrawal can follow if needed).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -890,15 +890,18 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			}
 			toTarget = resolved
 		}
+		standing := boolArg(a, "standing")
 		if toKind == "broadcast" {
 			if err := d.validateBroadcastTarget(toTarget); err != nil {
 				return fail(err)
 			}
+		} else if standing {
+			return fail(fmt.Errorf("standing is broadcast-only"))
 		}
 		id, err := d.s.CreateThread(store.Thread{
 			Kind: "message", FromAgent: from, ToKind: toKind,
 			ToTarget: toTarget, Subject: str(a, "subject"), Ref: str(a, "ref"),
-			Intent: str(a, "intent"), OriginProject: d.senderProject(from),
+			Intent: str(a, "intent"), Standing: standing, OriginProject: d.senderProject(from),
 		}, str(a, "body"))
 		if err != nil {
 			return fail(err)

--- a/internal/daemon/standing_test.go
+++ b/internal/daemon/standing_test.go
@@ -1,0 +1,53 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+// A standing broadcast is accepted and the standing flag is persisted on the
+// thread; live wake fan-out is unchanged (the recipient is notified as for any
+// broadcast).
+func TestSendStandingBroadcastPersistsFlag(t *testing.T) {
+	n := &fakeNotifier{}
+	sock, s := startWithNotifierAndStore(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1", "session_created": 100})
+
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "broadcast", "standing": true, "subject": "order", "body": "read CONTRACT.md",
+	})
+	if !resp.OK {
+		t.Fatalf("standing broadcast should succeed: %s", resp.Error)
+	}
+	var out struct {
+		ThreadID int64 `json:"thread_id"`
+	}
+	decode(t, resp, &out)
+
+	th, _, err := s.GetThread(out.ThreadID)
+	if err != nil {
+		t.Fatalf("GetThread: %v", err)
+	}
+	if !th.Standing {
+		t.Fatal("daemon did not persist Standing on the broadcast thread")
+	}
+}
+
+// standing is broadcast-only: a standing flag on a directed (agent) message is
+// rejected at the daemon before any thread is created.
+func TestSendStandingRejectedOnNonBroadcast(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1", "session_created": 100})
+	call(t, sock, "register_agent", map[string]any{"alias": "web2", "project": "web", "socket_path": "/s", "session_id": "$2", "session_created": 100})
+
+	resp := call(t, sock, "send_message", map[string]any{
+		"from": "web1", "to_kind": "agent", "to_target": "web2", "standing": true, "body": "x",
+	})
+	if resp.OK {
+		t.Fatal("standing on a directed message must be rejected")
+	}
+	if !strings.Contains(resp.Error, "standing is broadcast-only") {
+		t.Fatalf("error should explain the constraint, got: %q", resp.Error)
+	}
+}

--- a/internal/dynamostore/agents.go
+++ b/internal/dynamostore/agents.go
@@ -112,7 +112,24 @@ func (s *Store) RegisterAgent(a store.Agent) error {
 	names["#registered_at"] = "registered_at"
 	values[":registered_at"] = attrN(now)
 
-	_, err := s.c.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+	// last_read_entry_id is seeded on FIRST insert to the highest entry id
+	// currently concerning this alias, so a brand-new session starts
+	// caught-up (plain broadcast is live-only) — the SQLite backend seeds the
+	// global MAX(entries.id); here readableThrough gives the concern-scoped
+	// equivalent, which is behaviourally identical for unread. if_not_exists
+	// preserves a returning alias's watermark, matching the SQLite upsert's
+	// untouched read-state. last_read_standing_entry_id is deliberately NOT
+	// seeded (absent reads as 0), so standing broadcasts replay to new
+	// sessions once.
+	seed, err := s.readableThrough(ctx, a, 0)
+	if err != nil {
+		return fmt.Errorf("dynamostore: register agent %q: seed watermark: %w", a.Alias, err)
+	}
+	expr += ", #last_read_entry_id = if_not_exists(#last_read_entry_id, :seed_watermark)"
+	names["#last_read_entry_id"] = "last_read_entry_id"
+	values[":seed_watermark"] = attrN(seed)
+
+	_, err = s.c.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName:                 aws.String(s.table),
 		Key:                       agentKey(a.Alias),
 		UpdateExpression:          aws.String(expr),
@@ -823,26 +840,27 @@ func agentKey(alias string) map[string]types.AttributeValue {
 
 func itemToAgent(item map[string]types.AttributeValue) store.Agent {
 	return store.Agent{
-		Alias:            strAttr(item, "alias"),
-		Role:             strAttr(item, "role"),
-		ModelType:        strAttr(item, "model_type"),
-		SocketPath:       strAttr(item, "socket_path"),
-		PaneID:           strAttr(item, "pane_id"),
-		SessionName:      strAttr(item, "session_name"),
-		SessionID:        strAttr(item, "session_id"),
-		SessionCreated:   numAttr(item, "session_created"),
-		DeviceID:         strAttr(item, "device_id"),
-		DeviceName:       strAttr(item, "device_name"),
-		HarnessSessionID: strAttr(item, "harness_session_id"),
-		TranscriptPath:   strAttr(item, "transcript_path"),
-		Project:          strAttr(item, "project"),
-		Label:            strAttr(item, "label"),
-		LabelManual:      boolAttr(item, "label_manual"),
-		RegisteredAt:     numAttr(item, "registered_at"),
-		LastSeen:         numAttr(item, "last_seen"),
-		LastReadEntryID:  numAttr(item, "last_read_entry_id"),
-		Departed:         boolAttr(item, "departed"),
-		SupersededBy:     strAttr(item, "superseded_by"),
+		Alias:                   strAttr(item, "alias"),
+		Role:                    strAttr(item, "role"),
+		ModelType:               strAttr(item, "model_type"),
+		SocketPath:              strAttr(item, "socket_path"),
+		PaneID:                  strAttr(item, "pane_id"),
+		SessionName:             strAttr(item, "session_name"),
+		SessionID:               strAttr(item, "session_id"),
+		SessionCreated:          numAttr(item, "session_created"),
+		DeviceID:                strAttr(item, "device_id"),
+		DeviceName:              strAttr(item, "device_name"),
+		HarnessSessionID:        strAttr(item, "harness_session_id"),
+		TranscriptPath:          strAttr(item, "transcript_path"),
+		Project:                 strAttr(item, "project"),
+		Label:                   strAttr(item, "label"),
+		LabelManual:             boolAttr(item, "label_manual"),
+		RegisteredAt:            numAttr(item, "registered_at"),
+		LastSeen:                numAttr(item, "last_seen"),
+		LastReadEntryID:         numAttr(item, "last_read_entry_id"),
+		LastReadStandingEntryID: numAttr(item, "last_read_standing_entry_id"),
+		Departed:                boolAttr(item, "departed"),
+		SupersededBy:            strAttr(item, "superseded_by"),
 	}
 }
 

--- a/internal/dynamostore/threads.go
+++ b/internal/dynamostore/threads.go
@@ -107,6 +107,7 @@ func threadMetaItem(t store.Thread, threadID, firstEntryID, now int64) map[strin
 		"ref":            attrS(t.Ref),
 		"status":         attrS(t.Status),
 		"intent":         attrS(t.Intent), // RAW; effectiveIntent applies on read
+		"standing":       attrBool(t.Standing),
 		"created_at":     attrN(now),
 		"updated_at":     attrN(now),
 		"origin_project": attrS(t.OriginProject),
@@ -165,6 +166,7 @@ func itemToThread(item map[string]types.AttributeValue) store.Thread {
 		Ref:           strAttr(item, "ref"),
 		Status:        strAttr(item, "status"),
 		Intent:        effectiveIntent(kind, strAttr(item, "intent")),
+		Standing:      boolAttr(item, "standing"),
 		CreatedAt:     numAttr(item, "created_at"),
 		UpdatedAt:     numAttr(item, "updated_at"),
 		OriginProject: strAttr(item, "origin_project"),
@@ -232,6 +234,9 @@ func (s *Store) queryAll(ctx context.Context, in *dynamodb.QueryInput) ([]map[st
 func (s *Store) CreateThread(t store.Thread, firstBody string) (int64, error) {
 	if !validIntent(t.Intent) {
 		return 0, fmt.Errorf("invalid intent %q", t.Intent)
+	}
+	if t.Standing && t.ToKind != "broadcast" {
+		return 0, fmt.Errorf("standing is broadcast-only, not %q", t.ToKind)
 	}
 	ctx := backgroundCtx()
 	now := clock.NowMillis()
@@ -690,15 +695,45 @@ func (s *Store) entriesAfter(ctx context.Context, parts []string, after int64) (
 //
 // Threads with no qualifying entry are absent from the result, so its length
 // is UnreadCount's answer.
-func unreadByThread(entries []store.Entry, concerning map[int64]bool, exclude map[string]bool, after int64) map[int64]int {
+func unreadByThread(entries []store.Entry, concerning, standing map[int64]bool, exclude map[string]bool, liveAfter, standingAfter int64) map[int64]int {
 	out := make(map[int64]int)
 	for _, e := range entries {
-		if e.ID <= after || !concerning[e.ThreadID] || exclude[e.FromAgent] {
+		if !concerning[e.ThreadID] || exclude[e.FromAgent] {
+			continue
+		}
+		after := liveAfter
+		if standing[e.ThreadID] {
+			after = standingAfter
+		}
+		if e.ID <= after {
 			continue
 		}
 		out[e.ThreadID]++
 	}
 	return out
+}
+
+// standingSet is the subset of thread ids marked standing, from the same
+// metadata items concerns() returned — so the unread branch can pick the
+// standing watermark for a standing broadcast and the live one for the rest.
+func standingSet(threads map[int64]map[string]types.AttributeValue) map[int64]bool {
+	out := make(map[int64]bool)
+	for id, item := range threads {
+		if boolAttr(item, "standing") {
+			out[id] = true
+		}
+	}
+	return out
+}
+
+// unreadFloor is the lower of the two watermarks: entriesAfter must fetch from
+// here so a standing entry below the live watermark but above the (un-seeded,
+// lower) standing watermark is still considered.
+func unreadFloor(a store.Agent) int64 {
+	if a.LastReadStandingEntryID < a.LastReadEntryID {
+		return a.LastReadStandingEntryID
+	}
+	return a.LastReadEntryID
 }
 
 // unreadFor gathers everything Inbox and UnreadCount need, so the two cannot
@@ -722,11 +757,11 @@ func (s *Store) unreadFor(ctx context.Context, alias string) (map[int64]map[stri
 	if err != nil {
 		return nil, nil, err
 	}
-	entries, err := s.entriesAfter(ctx, parts, agent.LastReadEntryID)
+	entries, err := s.entriesAfter(ctx, parts, unreadFloor(agent))
 	if err != nil {
 		return nil, nil, err
 	}
-	return threads, unreadByThread(entries, idSet(threads), map[string]bool{alias: true}, agent.LastReadEntryID), nil
+	return threads, unreadByThread(entries, idSet(threads), standingSet(threads), map[string]bool{alias: true}, agent.LastReadEntryID, agent.LastReadStandingEntryID), nil
 }
 
 func idSet(threads map[int64]map[string]types.AttributeValue) map[int64]bool {
@@ -823,11 +858,12 @@ func (s *Store) MarkRead(alias string) error {
 		TableName: aws.String(s.table),
 		Key:       agentKey(alias),
 		UpdateExpression: aws.String(
-			"SET #last_read_entry_id = :id, #last_read_at = :now"),
+			"SET #last_read_entry_id = :id, #last_read_standing_entry_id = :id, #last_read_at = :now"),
 		ConditionExpression: aws.String("attribute_exists(pk)"),
 		ExpressionAttributeNames: map[string]string{
-			"#last_read_entry_id": "last_read_entry_id",
-			"#last_read_at":       "last_read_at",
+			"#last_read_entry_id":          "last_read_entry_id",
+			"#last_read_standing_entry_id": "last_read_standing_entry_id",
+			"#last_read_at":                "last_read_at",
 		},
 		ExpressionAttributeValues: map[string]types.AttributeValue{
 			":id":  attrN(watermark),
@@ -928,11 +964,11 @@ func (s *Store) SessionUnread(deviceID, socketPath, sessionID string, sessionCre
 		if err != nil {
 			return 0, 0, err
 		}
-		entries, err := s.entriesAfter(ctx, parts, a.LastReadEntryID)
+		entries, err := s.entriesAfter(ctx, parts, unreadFloor(a))
 		if err != nil {
 			return 0, 0, err
 		}
-		for id := range unreadByThread(entries, idSet(threads), aliases, a.LastReadEntryID) {
+		for id := range unreadByThread(entries, idSet(threads), standingSet(threads), aliases, a.LastReadEntryID, a.LastReadStandingEntryID) {
 			unread[id] = threads[id]
 		}
 	}

--- a/internal/dynamostore/threads_test.go
+++ b/internal/dynamostore/threads_test.go
@@ -98,7 +98,7 @@ func TestUnreadByThread(t *testing.T) {
 		{ID: 9, ThreadID: 12, FromAgent: "peer"}, // thread does not concern me
 		{ID: 4, ThreadID: 11, FromAgent: "peer"}, // exactly at watermark, excluded
 	}
-	got := unreadByThread(entries, concerning, map[string]bool{"me": true}, 4)
+	got := unreadByThread(entries, concerning, nil, map[string]bool{"me": true}, 4, 4)
 	want := map[int64]int{10: 1, 11: 2}
 	if len(got) != len(want) {
 		t.Fatalf("unreadByThread = %v, want %v", got, want)
@@ -110,6 +110,25 @@ func TestUnreadByThread(t *testing.T) {
 	}
 }
 
+// TestUnreadByThreadStandingUsesStandingWatermark: a standing thread's entries
+// are judged against the standing watermark, not the live one, so a new
+// session (live watermark high, standing watermark 0) still sees the standing
+// backlog while skipping the live one.
+func TestUnreadByThreadStandingUsesStandingWatermark(t *testing.T) {
+	concerning := map[int64]bool{10: true, 11: true}
+	standing := map[int64]bool{11: true}
+	entries := []store.Entry{
+		{ID: 3, ThreadID: 10, FromAgent: "peer"},  // live, below live watermark -> skipped
+		{ID: 3, ThreadID: 11, FromAgent: "peer"},  // standing, above standing watermark -> counts
+		{ID: 12, ThreadID: 10, FromAgent: "peer"}, // live, above live watermark -> counts
+	}
+	got := unreadByThread(entries, concerning, standing, map[string]bool{"me": true}, 5, 0)
+	want := map[int64]int{10: 1, 11: 1}
+	if len(got) != len(want) || got[10] != 1 || got[11] != 1 {
+		t.Fatalf("unreadByThread = %v, want %v", got, want)
+	}
+}
+
 // TestUnreadByThreadExcludesEverySessionAlias covers SessionUnread's actor
 // exclusion: a session's own writes under EITHER alias never make its own
 // threads unread.
@@ -118,7 +137,7 @@ func TestUnreadByThreadExcludesEverySessionAlias(t *testing.T) {
 		{ID: 2, ThreadID: 1, FromAgent: "a1"},
 		{ID: 3, ThreadID: 1, FromAgent: "a2"},
 	}
-	got := unreadByThread(entries, map[int64]bool{1: true}, map[string]bool{"a1": true, "a2": true}, 0)
+	got := unreadByThread(entries, map[int64]bool{1: true}, nil, map[string]bool{"a1": true, "a2": true}, 0, 0)
 	if len(got) != 0 {
 		t.Fatalf("unreadByThread = %v, want empty — sibling aliases are one actor", got)
 	}

--- a/internal/humancli/humancli.go
+++ b/internal/humancli/humancli.go
@@ -341,7 +341,7 @@ func validateIntent(intent string) error {
 // sendFlagVals holds cmdSend's parsed flag pointers.
 type sendFlagVals struct {
 	from, subject, ref, intent, project *string
-	role, broadcast                     *bool
+	role, broadcast, standing           *bool
 }
 
 // newSendFlagsWithVals declares send's flags and returns both the FlagSet
@@ -358,6 +358,7 @@ func newSendFlagsWithVals() (*flag.FlagSet, sendFlagVals) {
 	v.role = fs.Bool("role", false, "treat target as a role")
 	v.broadcast = fs.Bool("broadcast", false, "send to everyone")
 	v.project = fs.String("project", "", "with --broadcast: send only to this project's agents")
+	v.standing = fs.Bool("standing", false, "with --broadcast: also reach sessions that start later, until they read it (standing orders)")
 	v.intent = fs.String("intent", "", "message intent: fyi, reply-requested, or action-requested")
 	return fs, v
 }
@@ -387,6 +388,9 @@ func cmdSend(args []string, out io.Writer) error {
 	if *v.project != "" && !*v.broadcast {
 		return fmt.Errorf("--project requires --broadcast")
 	}
+	if *v.standing && !*v.broadcast {
+		return fmt.Errorf("--standing requires --broadcast")
+	}
 	toKind, toTarget := "agent", ""
 	switch {
 	case *v.broadcast:
@@ -397,7 +401,7 @@ func cmdSend(args []string, out io.Writer) error {
 	var body string
 	if *v.broadcast {
 		if len(rest) < 1 {
-			return fmt.Errorf("usage: muster send --broadcast [--project <p>] <body> [--intent fyi|reply-requested|action-requested]")
+			return fmt.Errorf("usage: muster send --broadcast [--project <p>] [--standing] <body> [--intent fyi|reply-requested|action-requested]")
 		}
 		toTarget = *v.project
 		body = strings.Join(rest, " ")
@@ -424,6 +428,7 @@ func cmdSend(args []string, out io.Writer) error {
 	raw, err := callData("send_message", map[string]any{
 		"from": fromAlias, "to_kind": toKind, "to_target": toTarget,
 		"subject": *v.subject, "ref": *v.ref, "body": body, "intent": *v.intent,
+		"standing": *v.standing,
 	})
 	if err != nil {
 		return err
@@ -440,7 +445,7 @@ func cmdSend(args []string, out io.Writer) error {
 
 // sendBoolFlags are cmdSend's flags that take no value, needed so
 // splitFlagsAndPositional knows not to consume the following token as a value.
-var sendBoolFlags = map[string]bool{"role": true, "broadcast": true}
+var sendBoolFlags = map[string]bool{"role": true, "broadcast": true, "standing": true}
 
 // splitFlagsAndPositional separates args into flag.FlagSet-parseable tokens
 // and positional arguments, regardless of whether flags appear before or

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -91,7 +91,7 @@ func init() {
 	Registry = []Command{
 		{
 			Name:     "send",
-			Synopsis: `send <target> "body" [--from <alias>] [--subject <s>] [--ref <r>] [--role] [--broadcast [--project <p>]] [--intent fyi|reply-requested|action-requested]`,
+			Synopsis: `send <target> "body" [--from <alias>] [--subject <s>] [--ref <r>] [--role] [--broadcast [--project <p>] [--standing]] [--intent fyi|reply-requested|action-requested]`,
 			Summary:  "Send a message to an agent, role, or everyone.",
 			Help: `target is an alias, a label, or a "project:label" pair, resolved the same
 way for every muster surface (send, nudge, inbox, tasks). --role treats
@@ -99,9 +99,12 @@ target as a role name instead of an agent; --broadcast ignores target and
 sends to every registered agent (target is then omitted: 'muster send
 --broadcast "body"'). With --project, the broadcast reaches only agents
 registered under that exact project (the daemon rejects unknown projects and
-lists the known ones). --intent tags the message for the recipient's
-inbox/hook rendering: fyi (default, no action implied), reply-requested, or
-action-requested.`,
+lists the known ones). A plain broadcast is live-only: it reaches sessions
+live now and is invisible to sessions that start later. --standing (broadcast
+only) also reaches sessions that start later, once, until they read it — use
+it for durable standing orders, not transient holds. --intent tags the
+message for the recipient's inbox/hook rendering: fyi (default, no action
+implied), reply-requested, or action-requested.`,
 			Group:    GroupTalk,
 			NewFlags: newSendFlags,
 			Run:      cmdSend,

--- a/internal/humancli/send_broadcast_test.go
+++ b/internal/humancli/send_broadcast_test.go
@@ -61,6 +61,30 @@ func TestSendBroadcastUnquotedBodyStaysGlobal(t *testing.T) {
 	}
 }
 
+func TestSendBroadcastStandingFlag(t *testing.T) {
+	s := startTestDaemon(t)
+	var buf bytes.Buffer
+	if err := cmdSend([]string{"--broadcast", "--standing", "read", "CONTRACT.md", "--from", "tester"}, &buf); err != nil {
+		t.Fatalf("standing broadcast send: %v", err)
+	}
+	ths, err := s.Threads(10)
+	if err != nil || len(ths) != 1 {
+		t.Fatalf("threads: %v (%d)", err, len(ths))
+	}
+	if ths[0].ToKind != "broadcast" || ths[0].ToTarget != "" || !ths[0].Standing {
+		t.Fatalf("want standing global broadcast, got kind=%s target=%q standing=%v", ths[0].ToKind, ths[0].ToTarget, ths[0].Standing)
+	}
+}
+
+func TestSendStandingWithoutBroadcastErrors(t *testing.T) {
+	startTestDaemon(t)
+	var buf bytes.Buffer
+	err := cmdSend([]string{"--standing", "web:label", "hello"}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "--standing requires --broadcast") {
+		t.Fatalf("want '--standing requires --broadcast' error, got %v", err)
+	}
+}
+
 func TestSendBroadcastUnknownProjectSurfacesDaemonError(t *testing.T) {
 	startTestDaemon(t)
 	if _, err := callData("register_agent", map[string]any{"alias": "w1", "project": "web", "model_type": "claude"}); err != nil {

--- a/internal/mcpserver/call.go
+++ b/internal/mcpserver/call.go
@@ -179,6 +179,7 @@ type ThreadView struct {
 	Subject    string `json:"subject" jsonschema:"the thread subject"`
 	Ref        string `json:"ref" jsonschema:"a pointer to the work (repo/branch/endpoint/file)"`
 	Status     string `json:"status" jsonschema:"task status, empty for messages"`
+	Standing   bool   `json:"standing,omitempty" jsonschema:"true if this is a standing broadcast (also delivered to sessions that start later, until read)"`
 	CreatedAt  int64  `json:"created_at" jsonschema:"creation time (unix ms)"`
 	UpdatedAt  int64  `json:"updated_at" jsonschema:"last-update time (unix ms)"`
 	LastFrom   string `json:"last_from" jsonschema:"who wrote the thread's most recent entry"`

--- a/internal/mcpserver/tools_messages.go
+++ b/internal/mcpserver/tools_messages.go
@@ -19,6 +19,7 @@ type SendMessageIn struct {
 	Ref      string `json:"ref,omitempty" jsonschema:"optional pointer to the work (repo/branch/endpoint/file)"`
 	Body     string `json:"body" jsonschema:"the message body"`
 	Intent   string `json:"intent,omitempty" jsonschema:"fyi | reply-requested | action-requested; mark FYIs so recipients' drains stay cheap — an FYI doesn't demand a reply. Leave empty when the message's urgency is unspecified."`
+	Standing bool   `json:"standing,omitempty" jsonschema:"broadcast-only: a plain broadcast reaches only sessions live now; set standing=true to ALSO reach sessions that start later, once, until they read it. Use for durable standing orders (e.g. 'read CONTRACT.md before editing'), NOT for transient holds — those should stay live-only so they evaporate for future sessions."`
 }
 
 // ThreadIDOut is the output of send_message and task_create.
@@ -74,6 +75,7 @@ func sendMessageHandler(_ context.Context, _ *mcp.CallToolRequest, in SendMessag
 	raw, err := callDaemon("send_message", map[string]any{
 		"from": in.From, "to_kind": in.ToKind, "to_target": in.ToTarget,
 		"subject": in.Subject, "ref": in.Ref, "body": in.Body, "intent": in.Intent,
+		"standing": in.Standing,
 	})
 	if err != nil {
 		return nil, ThreadIDOut{}, err
@@ -172,7 +174,7 @@ func getThreadHandler(_ context.Context, _ *mcp.CallToolRequest, in GetThreadIn)
 // registerMessageTools registers send_message, reply, get_inbox, and
 // get_thread on srv.
 func registerMessageTools(srv *mcp.Server) {
-	mcp.AddTool(srv, &mcp.Tool{Name: "send_message", Description: "Send a message to another agent (to_kind=agent), a role (to_kind=role), or many agents at once (to_kind=broadcast). A broadcast with empty to_target reaches every agent on the bus; set to_target to a project name to reach only that project's agents. Set intent to fyi/reply-requested/action-requested so the recipient's inbox and drain reflect what you actually need back."}, sendMessageHandler)
+	mcp.AddTool(srv, &mcp.Tool{Name: "send_message", Description: "Send a message to another agent (to_kind=agent), a role (to_kind=role), or many agents at once (to_kind=broadcast). A broadcast with empty to_target reaches every agent on the bus; set to_target to a project name to reach only that project's agents. A plain broadcast is live-only (reaches sessions live now, invisible to sessions that start later); set standing=true to also reach future sessions once, until read — for durable standing orders, not transient holds. Set intent to fyi/reply-requested/action-requested so the recipient's inbox and drain reflect what you actually need back."}, sendMessageHandler)
 	mcp.AddTool(srv, &mcp.Tool{Name: "reply", Description: "Append a reply to an existing thread (message or task). Reply only when the sender needs something from you; never reply just to acknowledge an ack or a closure — the last word is free. For a closing note that needs nothing back, set fyi=true so the entry lands without waking anyone."}, replyHandler)
 	mcp.AddTool(srv, &mcp.Tool{Name: "get_inbox", Description: "Read the threads that concern an agent — addressed to it (directly, by role, or broadcast) or originated by it, so replies on threads it started show up here — newest first. Rows carry last_from and an unread count — unread > 0 means entries you have not seen; read those threads with get_thread before reporting their state."}, getInboxHandler)
 	mcp.AddTool(srv, &mcp.Tool{Name: "get_thread", Description: "Fetch a single thread and all its entries in order."}, getThreadHandler)

--- a/internal/mcpserver/tools_messages_test.go
+++ b/internal/mcpserver/tools_messages_test.go
@@ -53,6 +53,50 @@ func TestSendMessageAndInbox(t *testing.T) {
 	}
 }
 
+// TestSendStandingBroadcastSurfacesStandingOnRead: a standing broadcast is
+// accepted via the MCP tool, and get_thread reports Standing=true so an agent
+// can tell a standing order from a transient one.
+func TestSendStandingBroadcastSurfacesStandingOnRead(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callDaemon("register_agent", map[string]any{
+		"alias": "backend", "model_type": "claude",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, sendOut, err := sendMessageHandler(context.Background(), nil, SendMessageIn{
+		From: "backend", ToKind: "broadcast", Standing: true,
+		Subject: "order", Body: "read CONTRACT.md before editing",
+	})
+	if err != nil || sendOut.ThreadID == 0 {
+		t.Fatalf("standing broadcast: err=%v out=%+v", err, sendOut)
+	}
+	_, thr, err := getThreadHandler(context.Background(), nil, GetThreadIn(sendOut))
+	if err != nil {
+		t.Fatalf("get_thread: %v", err)
+	}
+	if !thr.Thread.Standing {
+		t.Fatalf("ThreadView should surface Standing=true, got %+v", thr.Thread)
+	}
+}
+
+// TestSendStandingRejectedOnDirectedMessage: standing is broadcast-only, and
+// the MCP tool surfaces the daemon's rejection.
+func TestSendStandingRejectedOnDirectedMessage(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callDaemon("register_agent", map[string]any{"alias": "backend", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callDaemon("register_agent", map[string]any{"alias": "consumer", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := sendMessageHandler(context.Background(), nil, SendMessageIn{
+		From: "backend", ToKind: "agent", ToTarget: "consumer", Standing: true, Body: "x",
+	})
+	if err == nil {
+		t.Fatal("standing on a directed message must be rejected")
+	}
+}
+
 // TestGetInboxSendsCallerProof covers the regression this task closes: an
 // MCP get_inbox must send the caller's tmux/harness proof so the daemon's
 // callerOwns check (spec 2026-08-21 §3.2, daemon commit 7f17f35) can move the

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -21,8 +21,8 @@ import (
 func (s *Store) RegisterAgent(a Agent) error {
 	now := clock.NowMillis()
 	_, err := s.db.Exec(`
-INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, departed, superseded_by, registered_at, last_seen)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, '', ?, ?)
+INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, departed, superseded_by, registered_at, last_seen, last_read_entry_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, '', ?, ?, (SELECT COALESCE(MAX(id), 0) FROM entries))
 ON CONFLICT(alias) DO UPDATE SET
     role=excluded.role,
     model_type=excluded.model_type,
@@ -49,7 +49,7 @@ ON CONFLICT(alias) DO UPDATE SET
 // agents included: their rows are history, not gone (see DepartAgent).
 func (s *Store) ListAgents() ([]Agent, error) {
 	rows, err := s.db.Query(`
-SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed, superseded_by
+SELECT alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, registered_at, last_seen, last_read_entry_id, last_read_standing_entry_id, departed, superseded_by
 FROM agents ORDER BY alias`)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ FROM agents ORDER BY alias`)
 	var out []Agent
 	for rows.Next() {
 		var a Agent
-		if err := rows.Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.DeviceID, &a.DeviceName, &a.HarnessSessionID, &a.TranscriptPath, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed, &a.SupersededBy); err != nil {
+		if err := rows.Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.DeviceID, &a.DeviceName, &a.HarnessSessionID, &a.TranscriptPath, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.LastReadStandingEntryID, &a.Departed, &a.SupersededBy); err != nil {
 			return nil, err
 		}
 		out = append(out, a)
@@ -75,7 +75,7 @@ func (s *Store) GetAgent(alias string) (Agent, bool, error) {
 
 // agentColumns is the exact column list every single-row agent scan uses —
 // GetAgent and FindConversation alike — so the two can never drift apart.
-const agentColumns = `alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, registered_at, last_seen, last_read_entry_id, departed, superseded_by`
+const agentColumns = `alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, registered_at, last_seen, last_read_entry_id, last_read_standing_entry_id, departed, superseded_by`
 
 // scanOneAgent runs a `SELECT <agentColumns> FROM agents ` + where query with
 // args and scans the single resulting row. ok is false (not an error) when
@@ -84,7 +84,7 @@ const agentColumns = `alias, role, model_type, socket_path, pane_id, session_nam
 func (s *Store) scanOneAgent(where string, args ...any) (Agent, bool, error) {
 	var a Agent
 	err := s.db.QueryRow(`SELECT `+agentColumns+` FROM agents `+where, args...).
-		Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.DeviceID, &a.DeviceName, &a.HarnessSessionID, &a.TranscriptPath, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.Departed, &a.SupersededBy)
+		Scan(&a.Alias, &a.Role, &a.ModelType, &a.SocketPath, &a.PaneID, &a.SessionName, &a.SessionID, &a.SessionCreated, &a.DeviceID, &a.DeviceName, &a.HarnessSessionID, &a.TranscriptPath, &a.Project, &a.Label, &a.LabelManual, &a.RegisteredAt, &a.LastSeen, &a.LastReadEntryID, &a.LastReadStandingEntryID, &a.Departed, &a.SupersededBy)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Agent{}, false, nil
 	}
@@ -262,9 +262,10 @@ SELECT COUNT(*) FROM threads
 WHERE `+threadConcerns+`
   AND EXISTS (SELECT 1 FROM entries e
               WHERE e.thread_id = threads.id
-                AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)
+                AND ((threads.standing = 1 AND e.id > COALESCE((SELECT last_read_standing_entry_id FROM agents WHERE alias=?), 0))
+                  OR (threads.standing = 0 AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)))
                 AND e.from_agent != ?)`,
-		alias, alias, alias, alias, alias, alias).Scan(&n)
+		alias, alias, alias, alias, alias, alias, alias).Scan(&n)
 	return n, err
 }
 
@@ -286,7 +287,7 @@ func (s *Store) MarkRead(alias string) error {
 	if err := tx.QueryRow(`SELECT COALESCE(MAX(id), 0) FROM entries`).Scan(&maxID); err != nil {
 		return err
 	}
-	if _, err := tx.Exec(`UPDATE agents SET last_read_entry_id=?, last_read_at=? WHERE alias=?`, maxID, now, alias); err != nil {
+	if _, err := tx.Exec(`UPDATE agents SET last_read_entry_id=?, last_read_standing_entry_id=?, last_read_at=? WHERE alias=?`, maxID, maxID, now, alias); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -353,8 +354,8 @@ func (s *Store) Become(from, to string) error {
 	}
 	now := clock.NowMillis()
 	res, err := tx.Exec(`
-INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, departed, registered_at, last_seen, last_read_entry_id, last_read_at)
-SELECT ?, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, 0, ?, ?, last_read_entry_id, last_read_at
+INSERT INTO agents (alias, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, departed, registered_at, last_seen, last_read_entry_id, last_read_standing_entry_id, last_read_at)
+SELECT ?, role, model_type, socket_path, pane_id, session_name, session_id, session_created, device_id, device_name, harness_session_id, transcript_path, project, label, label_manual, 0, ?, ?, last_read_entry_id, last_read_standing_entry_id, last_read_at
 FROM agents WHERE alias=?`, to, now, now, from)
 	if err != nil {
 		return err
@@ -446,12 +447,12 @@ FROM agents WHERE alias=?`, to, now, now, from)
 func (s *Store) SessionUnread(deviceID, socketPath, sessionID string, sessionCreated int64) (total, action int, err error) {
 	err = s.db.QueryRow(`
 WITH RECURSIVE sess AS (
-  SELECT alias, last_read_entry_id, superseded_by FROM agents
+  SELECT alias, last_read_entry_id, last_read_standing_entry_id, superseded_by FROM agents
   WHERE device_id = ?3 AND socket_path = ?1 AND session_id = ?2 AND ?2 != ''
     AND (?1 = '' OR (session_created = ?4 AND ?4 != 0))
     AND (departed = 0 OR superseded_by != '')
   UNION
-  SELECT a.alias, a.last_read_entry_id, a.superseded_by
+  SELECT a.alias, a.last_read_entry_id, a.last_read_standing_entry_id, a.superseded_by
   FROM agents a JOIN sess ON a.superseded_by = sess.alias
 )
 SELECT
@@ -461,7 +462,8 @@ FROM threads
 JOIN sess ON `+threadConcernsJoin+`
 WHERE EXISTS (SELECT 1 FROM entries e
               WHERE e.thread_id = threads.id
-                AND e.id > sess.last_read_entry_id
+                AND ((threads.standing = 1 AND e.id > sess.last_read_standing_entry_id)
+                  OR (threads.standing = 0 AND e.id > sess.last_read_entry_id))
                 AND e.from_agent NOT IN (SELECT alias FROM sess))`,
 		socketPath, sessionID, deviceID, sessionCreated).Scan(&total, &action)
 	return total, action, err

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -68,6 +68,14 @@ type Agent struct {
 	// agent's inbox was read. Supersedes the wall-clock last_read_at for
 	// unread math; last_read_at is retained internally for display only.
 	LastReadEntryID int64 `json:"last_read_entry_id"`
+	// LastReadStandingEntryID is the entry-ID read watermark for STANDING
+	// broadcasts only. Unlike LastReadEntryID it is NOT seeded on first
+	// register (it stays 0), so a brand-new session sees every standing
+	// broadcast once regardless of when it was sent; MarkRead advances it
+	// alongside LastReadEntryID, so a standing order badges a session once
+	// then goes quiet. See RegisterAgent's seed and the standing branch in
+	// the unread predicate (Inbox/UnreadCount/SessionUnread).
+	LastReadStandingEntryID int64 `json:"last_read_standing_entry_id"`
 	// Departed is true once this agent has been deregistered (see
 	// Store.DepartAgent) — a tombstone, not a delete: identity, project,
 	// label, and read-state (LastReadEntryID/last_read_at) all survive.
@@ -108,9 +116,15 @@ type Thread struct {
 	// effectiveIntent in threads.go), never the raw stored value: one
 	// vocabulary everywhere a Thread is read, so an old task row (stored
 	// intent "") reads as action-requested consistently across all three.
-	Intent    string `json:"intent"`
-	CreatedAt int64  `json:"created_at"`
-	UpdatedAt int64  `json:"updated_at"`
+	Intent string `json:"intent"`
+	// Standing marks a broadcast that is replayed to sessions which register
+	// AFTER it was sent, once, until they read it (the standing watermark,
+	// not the seeded live watermark, decides its unread state). Only
+	// meaningful for to_kind='broadcast'; CreateThread rejects standing on
+	// any other target. A plain (non-standing) broadcast is live-only.
+	Standing  bool  `json:"standing"`
+	CreatedAt int64 `json:"created_at"`
+	UpdatedAt int64 `json:"updated_at"`
 	// OriginProject is the SENDER's registered project at thread-creation
 	// time (iteration-4 orphan-thread fix): the daemon resolves the sender's
 	// agent record when it calls CreateThread and stamps its Project here —

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS agents (
     label_manual  INTEGER NOT NULL DEFAULT 0,
     last_read_at  INTEGER NOT NULL DEFAULT 0,
     last_read_entry_id INTEGER NOT NULL DEFAULT 0,
+    last_read_standing_entry_id INTEGER NOT NULL DEFAULT 0, -- read watermark for STANDING broadcasts only; NOT seeded on register (stays 0) so a new session sees standing orders once; advanced by MarkRead alongside last_read_entry_id
     departed      INTEGER NOT NULL DEFAULT 0, -- 1 = deregistered (tombstoned): identity/project/label/read-state all preserved; see store.migrate and Store.DepartAgent
     superseded_by TEXT NOT NULL DEFAULT '', -- non-empty on a departed row claimed away via Become: names the alias that now carries this identity forward, so resume reclaim never resurrects a retired seed (see Store.Become, hookSessionStartResume). Cleared on re-register (RegisterAgent's upsert): a revived/re-registered alias is no longer superseded.
     registered_at INTEGER NOT NULL,
@@ -30,6 +31,7 @@ CREATE TABLE IF NOT EXISTS threads (
     ref        TEXT NOT NULL DEFAULT '',
     status     TEXT,                          -- NULL for messages
     intent     TEXT NOT NULL DEFAULT '',       -- '' | fyi | reply-requested | action-requested
+    standing   INTEGER NOT NULL DEFAULT 0,      -- 1 = broadcast replayed to sessions registering after send (until read); broadcast-only. Plain broadcast is live-only.
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
     origin_project TEXT NOT NULL DEFAULT ''    -- sender's registered project at creation time ('' = unregistered sender); see store.migrate's backfill for pre-existing rows

--- a/internal/store/standing_test.go
+++ b/internal/store/standing_test.go
@@ -1,0 +1,167 @@
+package store
+
+import "testing"
+
+func bcast(t *testing.T, s *Store, standing bool, body string) {
+	t.Helper()
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", Standing: standing}, body); err != nil {
+		t.Fatalf("CreateThread: %v", err)
+	}
+}
+
+func maxEntryID(t *testing.T, s *Store) int64 {
+	t.Helper()
+	var id int64
+	if err := s.DB().QueryRow(`SELECT COALESCE(MAX(id),0) FROM entries`).Scan(&id); err != nil {
+		t.Fatalf("maxEntryID: %v", err)
+	}
+	return id
+}
+
+func TestRegisterSeedsLiveWatermarkToMax(t *testing.T) {
+	s := newTestStore(t)
+	bcast(t, s, false, "a")
+	bcast(t, s, false, "b")
+	want := maxEntryID(t, s)
+	if err := s.RegisterAgent(Agent{Alias: "newbie"}); err != nil {
+		t.Fatal(err)
+	}
+	a, ok, err := s.GetAgent("newbie")
+	if err != nil || !ok {
+		t.Fatalf("GetAgent: ok=%v err=%v", ok, err)
+	}
+	if a.LastReadEntryID != want {
+		t.Fatalf("live watermark = %d, want %d (seeded to max)", a.LastReadEntryID, want)
+	}
+	if a.LastReadStandingEntryID != 0 {
+		t.Fatalf("standing watermark = %d, want 0 (never seeded)", a.LastReadStandingEntryID)
+	}
+}
+
+func TestNewSessionSkipsPlainBroadcastBacklog(t *testing.T) {
+	s := newTestStore(t)
+	bcast(t, s, false, "old hold") // sent BEFORE newbie exists
+	if err := s.RegisterAgent(Agent{Alias: "newbie"}); err != nil {
+		t.Fatal(err)
+	}
+	n, err := s.UnreadCount("newbie")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("plain broadcast backlog leaked to new session: unread=%d, want 0", n)
+	}
+}
+
+func TestNewSessionSeesStandingBroadcastOnce(t *testing.T) {
+	s := newTestStore(t)
+	bcast(t, s, true, "standing order") // sent BEFORE newbie exists
+	if err := s.RegisterAgent(Agent{Alias: "newbie"}); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("newbie"); n != 1 {
+		t.Fatalf("standing broadcast should reach new session: unread=%d, want 1", n)
+	}
+	if err := s.MarkRead("newbie"); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("newbie"); n != 0 {
+		t.Fatalf("after MarkRead standing should be quiet: unread=%d, want 0", n)
+	}
+	bcast(t, s, true, "second standing order")
+	if n, _ := s.UnreadCount("newbie"); n != 1 {
+		t.Fatalf("later standing broadcast should reappear: unread=%d, want 1", n)
+	}
+}
+
+func TestPlainBroadcastAfterRegisterIsLive(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "live"}); err != nil {
+		t.Fatal(err)
+	}
+	bcast(t, s, false, "hold now") // sent AFTER register
+	if n, _ := s.UnreadCount("live"); n != 1 {
+		t.Fatalf("live session must receive a live broadcast: unread=%d, want 1", n)
+	}
+}
+
+func TestMarkReadAdvancesBothWatermarks(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.RegisterAgent(Agent{Alias: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	bcast(t, s, false, "live")
+	bcast(t, s, true, "standing")
+	want := maxEntryID(t, s)
+	if err := s.MarkRead("a"); err != nil {
+		t.Fatal(err)
+	}
+	got, _, _ := s.GetAgent("a")
+	if got.LastReadEntryID != want || got.LastReadStandingEntryID != want {
+		t.Fatalf("MarkRead watermarks = live %d / standing %d, want both %d", got.LastReadEntryID, got.LastReadStandingEntryID, want)
+	}
+}
+
+func TestReviveKeepsBothWatermarks(t *testing.T) {
+	s := newTestStore(t)
+	bcast(t, s, false, "x")
+	if err := s.RegisterAgent(Agent{Alias: "back"}); err != nil {
+		t.Fatal(err)
+	}
+	bcast(t, s, true, "standing")
+	if err := s.MarkRead("back"); err != nil {
+		t.Fatal(err)
+	}
+	want := maxEntryID(t, s)
+	if err := s.DepartAgent("back"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "back"}); err != nil { // revive
+		t.Fatal(err)
+	}
+	got, _, _ := s.GetAgent("back")
+	if got.LastReadEntryID != want || got.LastReadStandingEntryID != want {
+		t.Fatalf("revive must preserve watermarks: live %d / standing %d, want both %d", got.LastReadEntryID, got.LastReadStandingEntryID, want)
+	}
+}
+
+func TestCreateThreadRejectsNonBroadcastStanding(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "sender", ToKind: "agent", ToTarget: "x", Standing: true}, "b"); err == nil {
+		t.Fatal("standing on a non-broadcast target must be rejected")
+	}
+}
+
+func TestStandingRoundTrips(t *testing.T) {
+	s := newTestStore(t)
+	id, err := s.CreateThread(Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", Standing: true}, "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	th, _, err := s.GetThread(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !th.Standing {
+		t.Fatal("GetThread lost Standing")
+	}
+}
+
+func TestStandingComposesWithProjectScope(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", ToTarget: "web", Standing: true}, "web only"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "in-web", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "in-api", Project: "api"}); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("in-web"); n != 1 {
+		t.Fatalf("same-project new session should see scoped standing: unread=%d, want 1", n)
+	}
+	if n, _ := s.UnreadCount("in-api"); n != 0 {
+		t.Fatalf("other-project session must not see scoped standing: unread=%d, want 0", n)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -56,6 +56,8 @@ func migrate(db *sql.DB) error {
 		`ALTER TABLE agents ADD COLUMN superseded_by TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE agents ADD COLUMN device_name TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE agents ADD COLUMN transcript_path TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE agents ADD COLUMN last_read_standing_entry_id INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE threads ADD COLUMN standing INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, ddl := range alters {
 		if _, err := db.Exec(ddl); err != nil && !strings.Contains(err.Error(), "duplicate column name") {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -63,6 +63,24 @@ func TestOpenMigrationIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestSchemaHasStandingColumns(t *testing.T) {
+	s := newTestStore(t)
+	for _, c := range []struct{ table, col string }{
+		{"agents", "last_read_standing_entry_id"},
+		{"threads", "standing"},
+	} {
+		var n int
+		if err := s.DB().QueryRow(
+			`SELECT count(*) FROM pragma_table_info(?) WHERE name=?`, c.table, c.col,
+		).Scan(&n); err != nil {
+			t.Fatalf("pragma %s: %v", c.table, err)
+		}
+		if n != 1 {
+			t.Fatalf("%s.%s missing (found %d)", c.table, c.col, n)
+		}
+	}
+}
+
 func TestMigrateNormalizesSocketPaths(t *testing.T) {
 	home := t.TempDir()
 	if r, err := filepath.EvalSymlinks(home); err == nil {

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -35,6 +35,9 @@ func (s *Store) CreateThread(t Thread, firstBody string) (int64, error) {
 	if !validIntent(t.Intent) {
 		return 0, fmt.Errorf("invalid intent %q", t.Intent)
 	}
+	if t.Standing && t.ToKind != "broadcast" {
+		return 0, fmt.Errorf("standing is broadcast-only, not %q", t.ToKind)
+	}
 	now := clock.NowMillis()
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -43,9 +46,9 @@ func (s *Store) CreateThread(t Thread, firstBody string) (int64, error) {
 	defer func() { _ = tx.Rollback() }()
 
 	res, err := tx.Exec(`
-INSERT INTO threads (kind, from_agent, to_kind, to_target, subject, ref, status, intent, created_at, updated_at, origin_project)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		t.Kind, t.FromAgent, t.ToKind, t.ToTarget, t.Subject, t.Ref, nullable(t.Status), t.Intent, now, now, t.OriginProject)
+INSERT INTO threads (kind, from_agent, to_kind, to_target, subject, ref, status, intent, standing, created_at, updated_at, origin_project)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.Kind, t.FromAgent, t.ToKind, t.ToTarget, t.Subject, t.Ref, nullable(t.Status), t.Intent, t.Standing, now, now, t.OriginProject)
 	if err != nil {
 		return 0, err
 	}
@@ -97,7 +100,7 @@ VALUES (?, ?, ?, ?, ?)`, threadID, fromAgent, body, nullable(statusChange), now)
 func scanThread(row interface{ Scan(...any) error }) (Thread, error) {
 	var t Thread
 	var status sql.NullString
-	err := row.Scan(&t.ID, &t.Kind, &t.FromAgent, &t.ToKind, &t.ToTarget, &t.Subject, &t.Ref, &status, &t.Intent, &t.CreatedAt, &t.UpdatedAt, &t.OriginProject)
+	err := row.Scan(&t.ID, &t.Kind, &t.FromAgent, &t.ToKind, &t.ToTarget, &t.Subject, &t.Ref, &status, &t.Intent, &t.Standing, &t.CreatedAt, &t.UpdatedAt, &t.OriginProject)
 	if status.Valid {
 		t.Status = status.String
 	}
@@ -111,7 +114,7 @@ func scanThread(row interface{ Scan(...any) error }) (Thread, error) {
 // they compute eff_intent inside their own "recent" CTE instead — but all
 // three agree on the same effectiveIntent fragment (models.go, spec §2
 // ledger note).
-const threadColsEffectiveIntent = `id, kind, from_agent, to_kind, to_target, subject, ref, status, ` + effectiveIntent + ` AS intent, created_at, updated_at, origin_project`
+const threadColsEffectiveIntent = `id, kind, from_agent, to_kind, to_target, subject, ref, status, ` + effectiveIntent + ` AS intent, standing, created_at, updated_at, origin_project`
 
 // effectiveIntent is the ONE canonical SQL fragment for a thread's operative
 // intent (spec §2): a task is a request for action, including every
@@ -229,18 +232,19 @@ WITH recent AS (
 unread AS (
     SELECT e.thread_id, COUNT(*) AS n
     FROM entries e
-    WHERE e.thread_id IN (SELECT id FROM recent)
-      AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)
+    JOIN recent r ON r.id = e.thread_id
+    WHERE ((r.standing = 1 AND e.id > COALESCE((SELECT last_read_standing_entry_id FROM agents WHERE alias=?), 0))
+        OR (r.standing = 0 AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)))
       AND e.from_agent != ?
     GROUP BY e.thread_id
 )
 SELECT recent.id, recent.kind, recent.from_agent, recent.to_kind, recent.to_target,
-       recent.subject, recent.ref, recent.status, recent.eff_intent,
+       recent.subject, recent.ref, recent.status, recent.eff_intent, recent.standing,
        recent.created_at, recent.updated_at, recent.origin_project,
        le.from_agent, le.created_at, last.n, COALESCE(unread.n, 0)
 FROM recent`+threadLastEntryJoin+`
 LEFT JOIN unread ON unread.thread_id = recent.id
-ORDER BY recent.updated_at DESC`, alias, alias, alias, alias, alias, alias)
+ORDER BY recent.updated_at DESC`, alias, alias, alias, alias, alias, alias, alias)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +254,7 @@ ORDER BY recent.updated_at DESC`, alias, alias, alias, alias, alias, alias)
 		var t Thread
 		var status sql.NullString
 		if err := rows.Scan(&t.ID, &t.Kind, &t.FromAgent, &t.ToKind, &t.ToTarget,
-			&t.Subject, &t.Ref, &status, &t.Intent,
+			&t.Subject, &t.Ref, &status, &t.Intent, &t.Standing,
 			&t.CreatedAt, &t.UpdatedAt, &t.OriginProject,
 			&t.LastFrom, &t.LastAt, &t.EntryCount, &t.Unread); err != nil {
 			return nil, err
@@ -295,7 +299,7 @@ WITH recent AS (
     LIMIT ?
 ),`+threadLastEntryCTE+`
 SELECT recent.id, recent.kind, recent.from_agent, recent.to_kind, recent.to_target,
-       recent.subject, recent.ref, recent.status, recent.eff_intent,
+       recent.subject, recent.ref, recent.status, recent.eff_intent, recent.standing,
        recent.created_at, recent.updated_at, recent.origin_project,
        le.from_agent, le.created_at, last.n
 FROM recent`+threadLastEntryJoin+`
@@ -309,7 +313,7 @@ ORDER BY recent.updated_at DESC, recent.id DESC`, limit)
 		var t Thread
 		var status sql.NullString
 		if err := rows.Scan(&t.ID, &t.Kind, &t.FromAgent, &t.ToKind, &t.ToTarget,
-			&t.Subject, &t.Ref, &status, &t.Intent,
+			&t.Subject, &t.Ref, &status, &t.Intent, &t.Standing,
 			&t.CreatedAt, &t.UpdatedAt, &t.OriginProject,
 			&t.LastFrom, &t.LastAt, &t.EntryCount); err != nil {
 			return nil, err

--- a/internal/storetest/conformance.go
+++ b/internal/storetest/conformance.go
@@ -106,6 +106,13 @@ var cases = []conformanceCase{
 	{"ScopedBroadcastReachesItsProjectOnly", testScopedBroadcastProjectOnly},
 	{"ScopedBroadcastConcernsADepartedAgentsProject", testScopedBroadcastDeparted},
 
+	// Standing vs live broadcast.
+	{"NewSessionSkipsPlainBroadcastBacklog", testNewSessionSkipsBacklog},
+	{"NewSessionSeesStandingBroadcastOnceThenQuiet", testNewSessionStandingOnce},
+	{"StandingBroadcastRoundTrips", testStandingRoundTrips},
+	{"StandingBroadcastComposesWithProjectScope", testStandingScoped},
+	{"StandingRejectedOnNonBroadcastTarget", testStandingRejectedNonBroadcast},
+
 	// Session-scoped unread.
 	{"SessionUnreadCountsDistinctThreads", testSessionUnreadDistinct},
 	{"SessionUnreadExcludesSiblingAuthors", testSessionUnreadSiblingAuthors},
@@ -1237,6 +1244,75 @@ func testScopedBroadcastDeparted(t *testing.T, s store.API) {
 	}
 	if len(in) != 1 {
 		t.Fatalf("departed ghost's inbox = %d threads, want 1", len(in))
+	}
+}
+
+// testNewSessionSkipsBacklog: a plain broadcast sent BEFORE an alias first
+// registers must not land as unread on it — a new session starts caught-up.
+func testNewSessionSkipsBacklog(t *testing.T, s store.API) {
+	mustThread(t, s, store.Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast"}, "old hold")
+	mustRegister(t, s, store.Agent{Alias: "newbie"})
+	if n, err := s.UnreadCount("newbie"); err != nil || n != 0 {
+		t.Fatalf("plain broadcast backlog leaked: unread=%d (%v), want 0", n, err)
+	}
+	// A plain broadcast sent AFTER register is still live for it.
+	mustThread(t, s, store.Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast"}, "live hold")
+	if n, err := s.UnreadCount("newbie"); err != nil || n != 1 {
+		t.Fatalf("live broadcast after register: unread=%d (%v), want 1", n, err)
+	}
+}
+
+// testNewSessionStandingOnce: a standing broadcast sent BEFORE an alias first
+// registers reaches it once; MarkRead quiets it; a later standing broadcast
+// reappears.
+func testNewSessionStandingOnce(t *testing.T, s store.API) {
+	mustThread(t, s, store.Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", Standing: true}, "standing order")
+	mustRegister(t, s, store.Agent{Alias: "newbie"})
+	if n, err := s.UnreadCount("newbie"); err != nil || n != 1 {
+		t.Fatalf("standing broadcast should reach new session: unread=%d (%v), want 1", n, err)
+	}
+	if err := s.MarkRead("newbie"); err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+	if n, err := s.UnreadCount("newbie"); err != nil || n != 0 {
+		t.Fatalf("standing should be quiet after MarkRead: unread=%d (%v), want 0", n, err)
+	}
+	mustThread(t, s, store.Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", Standing: true}, "second standing order")
+	if n, err := s.UnreadCount("newbie"); err != nil || n != 1 {
+		t.Fatalf("later standing broadcast should reappear: unread=%d (%v), want 1", n, err)
+	}
+}
+
+// testStandingRoundTrips: the standing flag survives write and read.
+func testStandingRoundTrips(t *testing.T, s store.API) {
+	id := mustThread(t, s, store.Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", Standing: true}, "b")
+	th, _, err := s.GetThread(id)
+	if err != nil {
+		t.Fatalf("GetThread: %v", err)
+	}
+	if !th.Standing {
+		t.Fatal("GetThread lost Standing")
+	}
+}
+
+// testStandingScoped: a standing scoped broadcast reaches a new same-project
+// session and never an other-project one.
+func testStandingScoped(t *testing.T, s store.API) {
+	mustThread(t, s, store.Thread{Kind: "message", FromAgent: "sender", ToKind: "broadcast", ToTarget: "web", Standing: true}, "web only")
+	mustRegister(t, s, store.Agent{Alias: "in-web", Project: "web"})
+	mustRegister(t, s, store.Agent{Alias: "in-api", Project: "api"})
+	if n, err := s.UnreadCount("in-web"); err != nil || n != 1 {
+		t.Fatalf("same-project new session should see scoped standing: unread=%d (%v), want 1", n, err)
+	}
+	if n, err := s.UnreadCount("in-api"); err != nil || n != 0 {
+		t.Fatalf("other-project session must not see scoped standing: unread=%d (%v), want 0", n, err)
+	}
+}
+
+// testStandingRejectedNonBroadcast: standing is broadcast-only.
+func testStandingRejectedNonBroadcast(t *testing.T, s store.API) {
+	if _, err := s.CreateThread(store.Thread{Kind: "message", FromAgent: "sender", ToKind: "agent", ToTarget: "x", Standing: true}, "b"); err == nil {
+		t.Fatal("standing on a non-broadcast target must be rejected")
 	}
 }
 


### PR DESCRIPTION
## What & why

A brand-new session inherits the **entire broadcast backlog** on first start: broadcast delivery is pull-by-watermark, and a first-seen alias registers with `last_read_entry_id = 0`, so every past broadcast (id > 0) lands as unread. Transient chatter and one-off holds pile onto every new session.

This splits broadcast into two behaviors:

- **Plain `--broadcast` is now live-only** — reaches sessions live at/after send; invisible to sessions that start later. Fixes the backlog pile-up by seeding a new session's watermark to `MAX(entries.id)` on first register.
- **`--broadcast --standing`** — reaches every session that starts later, once, until it reads. The "welcome / standing orders" channel, tracked by a second, un-seeded watermark (`last_read_standing_entry_id`).

`muster send --broadcast "hold while I refactor X"` evaporates for future sessions; `muster send --broadcast --standing "read CONTRACT.md before editing"` greets every new and future session.

Spec: `docs/superpowers/specs/2026-08-30-standing-vs-live-broadcast-design.md`
Plan: `docs/superpowers/plans/2026-08-30-standing-vs-live-broadcast.md`

## Mechanism

- New column `agents.last_read_standing_entry_id` (un-seeded, default 0) + `threads.standing`.
- Unread computation branches per thread: standing threads judged against the standing watermark, everything else against the live watermark. `MarkRead` advances both. Concern predicate is unchanged.
- Both stores change together (SQLite + DynamoDB), gated by the cross-backend conformance suite.
- Standing is broadcast-only and message-only — rejected on any other target (daemon + both stores).

## Migration

Pre-upgrade broadcasts carry no standing flag, so they become **live-only for future sessions** (there is no way to know which were meant to persist — re-send important ones with `--standing`). Existing sessions keep their watermark and are unaffected.

## Testing

- Store + DynamoDB + cross-backend conformance (new standing-vs-live cases), daemon, MCP, and CLI unit tests.
- `just verify` green (fmt, lint, `go test -race`, cross-compile, aws-free); `just verify-dynamo` green (both backends).
- End-to-end smoke on an isolated bus via the real binary: a new session skips the live backlog, receives the standing order once, and gets both new live and new standing broadcasts after joining.

## Deferred (optional)

Task 9 (render/station surfacing a `standing` marker) — standing isn't encoded in the journal target string, so it would need extra plumbing; the feature is complete without it. `ThreadView`/`get_inbox`/`get_thread` already expose `standing` to agents.
