### PR TITLE
feat: adopt tools-common (uniform version + muster update self-update)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,8 @@ jobs:
           tag="${{ steps.rel.outputs.tag }}"
           version="${tag#v}"
           commit="$(git rev-parse --short HEAD)"
-          ldflags="-s -w -X github.com/schuettc/muster/internal/version.version=${version} -X github.com/schuettc/muster/internal/version.commit=${commit}"
+          date="$(date -u +%Y-%m-%d)"
+          ldflags="-s -w -X github.com/schuettc/muster/internal/version.version=${version} -X github.com/schuettc/muster/internal/version.commit=${commit} -X github.com/schuettc/muster/internal/version.date=${date}"
           # Sign every darwin binary as it is built. --options runtime is the
           # hardened runtime, which notarization requires; without it the
           # submission is rejected rather than merely unsigned.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/muesli/termenv v0.16.0
+	github.com/schuettc/tools-common v0.1.0
 	modernc.org/sqlite v1.53.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/schuettc/tools-common v0.1.0 h1:a4SovSnGSqzpTRj8XX1eK0lTrl3+2Mw9oixZSbQdZ1c=
+github.com/schuettc/tools-common v0.1.0/go.mod h1:0JSstEbB+vc5PLi3PA5d2VU9FkyROMYTiNpRU8UwYFM=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -419,6 +419,19 @@ session: every internal error is swallowed.`,
 			Run:   func(args []string, out io.Writer) error { return cmdHook(args, os.Stdin, out) },
 		},
 		{
+			Name:     "update",
+			Synopsis: "update",
+			Summary:  "Update muster to the latest release.",
+			Help: `Self-updates the running muster binary in place from the family download
+standard (muster.tools/dl): fetches the latest published release for this
+OS/arch, verifies its checksum, and atomically replaces this executable.
+Prints "muster is already the latest" and does nothing when the running
+version is current. Shared with the rest of the .tools family via
+tools-common, so every family binary self-updates the same way.`,
+			Group: GroupPlumbing,
+			Run:   cmdUpdate,
+		},
+		{
 			Name:     "debug",
 			Synopsis: "debug <op> [key=value ...]",
 			Summary:  "Send a raw op to the daemon (dev tool).",

--- a/internal/humancli/registry_test.go
+++ b/internal/humancli/registry_test.go
@@ -17,7 +17,7 @@ var wantCommandNames = []string{
 	"send", "nudge", "reply",
 	"agents", "inbox", "tasks", "thread", "events", "watch", "station",
 	"register", "become", "deregister", "label", "whereami", "device", "gc",
-	"serve", "mcp", "channel", "lambda", "hook", "debug",
+	"serve", "mcp", "channel", "lambda", "hook", "update", "debug",
 }
 
 // mainOwnedCommands are the Registry names cmd/muster's main() dispatches

--- a/internal/humancli/update.go
+++ b/internal/humancli/update.go
@@ -1,0 +1,45 @@
+package humancli
+
+import (
+	"fmt"
+	"io"
+
+	tools "github.com/schuettc/tools-common"
+
+	"github.com/schuettc/muster/internal/version"
+)
+
+// cmdUpdate is the registry Run entry point for `muster update`. It honors the
+// help convention every other command follows before doing any work.
+func cmdUpdate(args []string, out io.Writer) error {
+	if helpRequested(args) {
+		return HelpFor("update", out)
+	}
+	return runUpdate(out)
+}
+
+// runUpdate self-updates muster in place from the family download standard
+// (muster.tools/dl), via the shared tools-common self-update. Both the
+// informational stream and the result line go to out; muster's other
+// commands print to a single writer, so this stays consistent with them.
+func runUpdate(out io.Writer) error {
+	app := tools.New(tools.Config{
+		Name:   "muster",
+		Domain: "muster.tools",
+		Version: tools.Version{
+			Number: version.Version(),
+			Commit: version.Commit(),
+			Date:   version.Date(),
+		},
+	})
+	updated, newVer, err := app.SelfUpdate(out, out)
+	if err != nil {
+		return err
+	}
+	if updated {
+		_, err = fmt.Fprintf(out, "muster updated to %s\n", newVer)
+	} else {
+		_, err = fmt.Fprintf(out, "muster is already the latest (%s)\n", version.Version())
+	}
+	return err
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,10 +5,13 @@
 // three copies scattered across main packages.
 package version
 
-// version and commit are overwritten at build time via:
+import tools "github.com/schuettc/tools-common"
+
+// version, commit, and date are overwritten at build time via:
 //
 //	-ldflags "-X github.com/schuettc/muster/internal/version.version=$(cat VERSION) \
-//	          -X github.com/schuettc/muster/internal/version.commit=$(git rev-parse --short HEAD)"
+//	          -X github.com/schuettc/muster/internal/version.commit=$(git rev-parse --short HEAD) \
+//	          -X github.com/schuettc/muster/internal/version.date=$(date -u +%Y-%m-%d)"
 //
 // A plain `go build` / `go run` (no ldflags — local dev, `go test`, an
 // unstamped checkout) leaves them at these defaults, so `muster version`
@@ -16,6 +19,7 @@ package version
 var (
 	version = "dev"
 	commit  = "none"
+	date    = ""
 )
 
 // Version returns the stamped version ("dev" if the binary wasn't built with
@@ -25,9 +29,15 @@ func Version() string { return version }
 // Commit returns the stamped short commit hash ("none" if unstamped).
 func Commit() string { return commit }
 
+// Date returns the stamped build date ("" if unstamped).
+func Date() string { return date }
+
 // Line formats muster's canonical one-line version banner, e.g.
-// "muster 0.6.0 (a1b2c3d)". This is the single formatting function so both
+// "muster 0.6.0 (a1b2c3d, 2026-01-02)". The FORMAT is delegated to the
+// shared tools-common module so every .tools-family binary renders its
+// version identically (elides an empty commit/date); only the "muster "
+// prefix is muster's own. This is the single formatting function so both
 // `muster version` and `muster --version` render identically.
 func Line() string {
-	return "muster " + version + " (" + commit + ")"
+	return "muster " + tools.Version{Number: version, Commit: commit, Date: date}.String()
 }

--- a/justfile
+++ b/justfile
@@ -6,7 +6,8 @@ set shell := ["bash", "-uc"]
 # build`, `just verify`, and a release build report the same thing.
 version := `cat VERSION`
 commit := `git rev-parse --short HEAD 2>/dev/null || echo none`
-ldflags := "-X github.com/schuettc/muster/internal/version.version=" + version + " -X github.com/schuettc/muster/internal/version.commit=" + commit
+date := `date -u +%Y-%m-%d`
+ldflags := "-X github.com/schuettc/muster/internal/version.version=" + version + " -X github.com/schuettc/muster/internal/version.commit=" + commit + " -X github.com/schuettc/muster/internal/version.date=" + date
 
 # Format code.
 fmt:


### PR DESCRIPTION
Partial, additive adoption of github.com/schuettc/tools-common@v0.1.0 — ONLY the identical parts. internal/version.Line() now delegates format to tools.Version{Number,Commit,Date}.String() (adds a date field; justfile + release.yml stamp -X …version.date). New 'muster update' command (internal/humancli/update.go) self-updates from muster.tools/dl via tools.App.SelfUpdate, registered as a normal Registry command in GroupPlumbing (help/man/-h auto-cover it). cmd/muster/main.go serve/mcp/lambda/channel switch UNTOUCHED — update flows through the default→humancli.Dispatch path. gofmt/vet clean, go test 23 ok, build ok.