### PR TITLE
Standing orders: keyed, retractable per-project convention (v2)

### DIFF
--- a/docs/superpowers/plans/2026-08-31-standing-orders.md
+++ b/docs/superpowers/plans/2026-08-31-standing-orders.md
@@ -1,0 +1,112 @@
+# Standing orders — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A dedicated, keyed, retractable per-project standing-order concept on top of the shipped standing-broadcast transport: `muster standing set/retract/list`, superseding by `(project, key)` instead of appending.
+
+**Architecture:** A standing order IS a standing broadcast thread carrying an identity (`standing_key`) and a lifecycle (`standing_retracted`). `set` is idempotent create-or-replace by `(project, key)` in one transaction (retract prior live order under the key, then create the replacement). `retract` marks the current order retracted. `list` returns live (non-retracted) orders. The shipped standing-watermark delivery + scoped-broadcast validation are reused verbatim; the only new unread rule is a `standing_retracted = 0` guard on the standing branch. Both stores change together, gated by conformance.
+
+**Tech Stack:** Go, pure-Go SQLite, no cgo. Spec: `docs/superpowers/specs/2026-08-31-standing-orders-convention-design.md`.
+
+## Global Constraints
+
+- Worktree `/Users/courtschuett/GitHub/worktrees/muster-standing-orders`, branch `feat/standing-orders` (off `dev`). Never touch the primary clone.
+- Gate: `just verify` (fmt, lint, `go test -race`, cross-compile, aws-free) + `just verify-dynamo` (both backends). Per-task, run the named package tests.
+- `CGO_ENABLED=0` must keep building; add no deps beyond what's present.
+- **Both stores or neither.** Every store behavior change lands in `internal/store` AND `internal/dynamostore`, proven equal by `internal/storetest/conformance.go`.
+- Do not regress the shipped v1 behavior: un-keyed `--standing` broadcasts (`standing_key=''`) stay append-only and are never returned by `list`; the register seed / standing watermark / `MarkRead` dual-advance are unchanged.
+- Identity is `(to_target, standing_key)` among **live** (`standing_retracted=0`) standing broadcast rows. `--key` defaults to `invariants`.
+
+---
+
+### Task 1: Store schema, migration, models
+
+**Files:** `internal/store/schema.sql`, `internal/store/store.go` (migrations), `internal/store/models.go`.
+
+- [ ] **Step 1:** Test asserts `threads.standing_key` and `threads.standing_retracted` exist with defaults `''` / `0`, migration idempotent.
+- [ ] **Step 2:** Verify fail.
+- [ ] **Step 3:** Add both columns to the `threads` CREATE TABLE and to the `alters` slice: `ALTER TABLE threads ADD COLUMN standing_key TEXT NOT NULL DEFAULT ''` and `ALTER TABLE threads ADD COLUMN standing_retracted INTEGER NOT NULL DEFAULT 0`. Add `StandingKey string` + `StandingRetracted bool` to `Thread` (one-line comments: order identity within project / lifecycle tombstone; broadcast-only).
+- [ ] **Step 4/5:** Store tests; commit `store: standing_key + standing_retracted columns`.
+
+---
+
+### Task 2: Store — standing-order verbs + retracted unread guard
+
+**Files:** `internal/store/threads.go` (new `SetStandingOrder`, `RetractStandingOrder`, `ListStandingOrders`; unread branch guard in `Inbox`/`UnreadCount`), `internal/store/agents.go` (`SessionUnread` guard), `internal/store/models.go` (a `StandingOrder` result struct), `internal/store/api.go` if there's an interface.
+
+**Interfaces:**
+- `SetStandingOrder(project, key, from, body string) (int64, error)` — one tx: `UPDATE threads SET standing_retracted=1 WHERE to_kind='broadcast' AND standing=1 AND to_target=? AND standing_key=? AND standing_retracted=0`, then insert a thread (`kind=message, from_agent=from, to_kind=broadcast, to_target=project, standing=1, standing_key=key, origin_project=<sender's>`) + its first entry (body). Returns new thread id. `key` defaults handled by callers (daemon/CLI), but empty `key` is rejected here (a keyed order must have a key).
+- `RetractStandingOrder(project, key string) (bool, error)` — sets `standing_retracted=1` on the live order under `(project,key)`; returns whether a row changed; idempotent (absent/already-retracted → false, nil).
+- `ListStandingOrders(project string) ([]StandingOrder, error)` — live orders for the project (`standing=1 AND standing_key!='' AND standing_retracted=0 AND to_target=project`), each `{Key, Body, From, CreatedAt}` (Body = the order's first entry), sorted by key.
+- **Unread guard:** the standing branch in `Inbox`, `UnreadCount`, `SessionUnread` gains `AND recent.standing_retracted = 0` (join form: `r.`/`sess.` as appropriate) so a retracted order greets no future session and never re-surfaces as unread. Un-keyed standing broadcasts (retracted=0) unaffected.
+
+- [ ] **Step 1:** Tests — set creates a listable order; second set under same key replaces (list shows one, new body; a NEW session sees only the new order unread); retract drops from list and from a new session's unread; retract idempotent; empty key rejected; un-keyed standing broadcast never in list; a session that already read an order is unaffected by a later retract.
+- [ ] **Step 2:** Verify fail.
+- [ ] **Step 3:** Implement.
+- [ ] **Step 4/5:** Store tests (`-race`); commit `store: SetStandingOrder/RetractStandingOrder/ListStandingOrders + retracted unread guard`.
+
+---
+
+### Task 3: DynamoDB store — mirror verbs + retracted guard
+
+**Files:** `internal/dynamostore/threads.go`, item builders (`standing_key`/`standing_retracted` on the thread item + `itemToThread`), `SetStandingOrder`/`RetractStandingOrder`/`ListStandingOrders`, and the `standing_retracted=0` guard in `unreadByThread`/`standingSet` filtering.
+
+**Interfaces:** identical semantics to Task 2. For set's atomic retract-then-create, use a `TransactWriteItems` (retract prior via a conditional update if present + put the new thread meta + first entry) or the store's existing thread-create transaction extended with a preceding retract; keep it a single logical operation. `standingSet` (from v1) must exclude retracted rows so the unread branch never counts a retracted order.
+
+- [ ] **Step 1:** dynamostore mirror tests (or rely on Task 4 conformance per package convention).
+- [ ] **Step 2:** Verify fail.
+- [ ] **Step 3:** Implement.
+- [ ] **Step 4/5:** `just verify-dynamo`; commit `dynamostore: mirror standing-order verbs + retracted guard`.
+
+---
+
+### Task 4: Conformance — standing-order lifecycle across both stores
+
+**Files:** `internal/storetest/conformance.go`.
+
+Cases (both backends): set → listable + greets a new same-project session once; second set same key → replaces (one listed, new body, new session sees only the new); retract → gone from list + gone from a new session's unread; retract idempotent; empty key rejected; scope validation is the daemon's job (not here) but `Set`/`Retract`/`List` on a bare store work by project string; un-keyed standing broadcast never listed; other-project session never sees a scoped order; a session that read an order before retract is unaffected.
+
+- [ ] **Steps:** add cases; run both stores; commit `storetest: standing-order lifecycle conformance`.
+
+---
+
+### Task 5: Daemon — standing_set / standing_retract / standing_list ops
+
+**Files:** `internal/daemon/daemon.go`.
+
+- `standing_set`: args `from`, `project`, `key` (default `invariants` if empty), `body`. Reuse `validateBroadcastTarget(project)` (reject unknown project with known-projects error). Call `SetStandingOrder`; journal a `standing` event; `notifyForThread` on the new thread (live sessions in the project get it now, exactly like a scoped standing broadcast).
+- `standing_retract`: args `project`, `key` (default `invariants`). Validate project. Call `RetractStandingOrder`; journal.
+- `standing_list`: args `project`. Return `ListStandingOrders`.
+
+- [ ] Tests: set creates a listable/greeting order; retract stops greeting; list returns live only; unknown project rejected on set/retract; default key applied when omitted. Commit `daemon: standing_set/retract/list ops`.
+
+---
+
+### Task 6: MCP — standing tools
+
+**Files:** `internal/mcpserver/tools_messages.go` (or a new `tools_standing.go`), registration.
+
+- `standing_set` (from, project, key?, body), `standing_retract` (project, key?), `standing_list` (project) → `[]StandingOrderView`. Descriptions frame this as the durable per-project convention (set/replace/retract/list), distinct from ad-hoc `send_message --standing`. `standing_list --json` is the audit seam the onboarding skill reads.
+
+- [ ] Tests + commit `mcp: standing set/retract/list tools`.
+
+---
+
+### Task 7: CLI — `muster standing` command group
+
+**Files:** `internal/humancli/` (new `standing.go`), `registry.go` (register `standing` in an appropriate group), help/synopsis.
+
+- `muster standing <project> [--json]` — list (default verb when only a project is given).
+- `muster standing set <project> [--key <k>] "body" [--from <alias>]`.
+- `muster standing retract <project> [--key <k>]`.
+- `--key` defaults to `invariants`. Help explains the convention + audit use.
+
+- [ ] Tests: set/list/retract round-trip through the CLI; `--json` shape; default key. Commit `cli: muster standing set/retract/list`.
+
+---
+
+### Task 8: Gate + end-to-end + PR
+
+- [ ] `just verify` + `just verify-dynamo` green.
+- [ ] E2E on an isolated bus via the real binary: `standing set web --key invariants "rules"`; register a new session in `web` → it sees the order once; `standing list web --json` shows it; `standing set web --key invariants "rules v2"` → list shows one (v2); a newer session sees only v2; `standing retract web` → list empty + a newer session sees nothing.
+- [ ] Finish the branch per finishing-a-development-branch: push + open PR against `dev`; ping muster thread 346 (tool-standards) with the spec path + PR link for review.

--- a/docs/superpowers/specs/2026-08-31-standing-orders-convention-design.md
+++ b/docs/superpowers/specs/2026-08-31-standing-orders-convention-design.md
@@ -93,6 +93,15 @@ defaults above — no backfill.
 - **`set` is idempotent by `(project, key)`**, in one transaction: retract the
   prior live order under that key (if any), then create the replacement standing
   broadcast. Convergent on re-run; a text change replaces rather than stacks.
+- **`set` RE-GREETS already-registered sessions with the updated order**, not
+  only future ones — the property that makes this a "current invariants"
+  convention rather than a set-once greeting. The replacement is a new standing
+  entry with an id above the retracted one, so a session that already read the
+  prior order has its standing watermark below the new id and the updated order
+  surfaces as unread on its next inbox check — and only the updated order (the
+  retracted prior is filtered). This is what lets a project fix a WRONG
+  invariant mid-flight and have every running session get the correction.
+  (Asserted by `StandingOrderSetReGreetsAnAlreadyReadSession` on both stores.)
 - **`retract` is idempotent**: retracting an absent or already-retracted order is
   a no-op success, so an onboarding/audit skill can retract without first checking.
 - **`list`** returns the live (non-retracted) standing orders for a project —

--- a/docs/superpowers/specs/2026-08-31-standing-orders-convention-design.md
+++ b/docs/superpowers/specs/2026-08-31-standing-orders-convention-design.md
@@ -1,0 +1,160 @@
+# Standing orders — a keyed, retractable convention
+
+**Date:** 2026-08-31
+**Status:** Draft (v2 follow-up to [standing-vs-live-broadcast](2026-08-30-standing-vs-live-broadcast-design.md))
+
+## Problem
+
+[Standing-vs-live broadcast](2026-08-30-standing-vs-live-broadcast-design.md)
+(shipped, PR #124) gave broadcast a durable arm: `muster send --broadcast
+--standing` reaches sessions that start later, once, until they read. That is
+the right **transport**, but it is the wrong **shape** for the standardization
+program's actual need, which `tool-standards` stated precisely (thread 346):
+
+- A project's standing orders are **one durable statement per project**
+  (its invariants), authored at project setup — not a growing pile of threads.
+- A standing broadcast is **append-only**: "update the invariants" means send a
+  new one, but the old one still greets never-seen sessions until they read it,
+  and there is **no retract at all**. Stale orders accumulate and rot — the same
+  failure mode as the four copied `release.yml` blocks the family is trying to
+  kill.
+- Standing orders that cannot be **listed** are write-only and drift. The
+  onboarding skill must both SET a project's orders and VERIFY they are present
+  and current — both need a machine-readable listing.
+
+So append-only standing broadcasts cannot be the convention surface. This spec
+adds a dedicated, keyed, retractable concept on top of the shipped machinery.
+
+## Decision
+
+A **standing order** is a broadcast thread carrying a `(project, key)` identity
+and a lifecycle, addressed and delivered exactly like a standing broadcast — so
+it inherits the shipped standing-watermark delivery unchanged — but managed by
+a dedicated verb family that **supersedes by key** instead of appending:
+
+```
+muster standing set <project> [--key <k>] "body"   # idempotent create-or-replace
+muster standing retract <project> [--key <k>]       # stop greeting new sessions
+muster standing <project> [--json]                  # list what greets a new session
+```
+
+`--key` defaults to `invariants` (the one-order-per-project common case; a
+project may hold several orders under distinct keys). `set` is idempotent by
+`(project, key)`: it retracts any prior live order under that key in the same
+transaction and creates the replacement, so a re-run with unchanged text
+converges and a re-run with new text replaces. `retract` marks the current
+order under `(project, key)` retracted; a retracted order greets no future
+session and drops out of `list`.
+
+This is a distinct durable concept, **not** annotated broadcasts and not a new
+mechanism: the delivery path, the register-time seed, and the standing
+watermark are all reused verbatim. What is new is identity (`project` + `key`)
+and lifecycle (supersede / retract) on top of a standing broadcast thread.
+
+### Why reuse standing broadcast threads rather than a new table
+
+The shipped standing broadcast already delivers "reaches future sessions once,
+until read" correctly across both stores, gated by conformance. A separate
+`standing_orders` table would re-derive that delivery — including the
+register-time seed, the two-store parity, and the watermark math — for no new
+capability. A standing order **is** a standing broadcast with an identity and a
+lifecycle; modelling it as one keeps a single delivery path and a single set of
+conformance guarantees. (`tool-standards` confirmed this shape in thread 346.)
+
+## Data model
+
+Two additive columns on `threads`, both broadcast-only and both defaulting to
+the current append-only behavior so every existing standing broadcast is
+unaffected:
+
+- `standing_key TEXT NOT NULL DEFAULT ''` — the order's key within its project.
+  Empty on every ordinary standing broadcast (an un-keyed, append-only standing
+  message stays exactly as shipped). Non-empty only on orders created by
+  `standing set`.
+- `standing_retracted INTEGER NOT NULL DEFAULT 0` — 1 once retracted (by
+  `retract`, or by `set` superseding the prior order under the same key).
+
+The order's `to_target` is the project scope (reusing the existing scoped
+broadcast machinery); `standing = 1` as today. Identity is
+`(to_target, standing_key)` among live (`standing_retracted = 0`) standing
+broadcast rows.
+
+Both stores (`internal/store` + `internal/dynamostore`) carry the columns;
+conformance asserts the lifecycle below on both. Migration is additive with the
+defaults above — no backfill.
+
+## Semantics
+
+- **Delivery is unchanged.** A live keyed standing order is a standing broadcast:
+  a session that registers later gets it once, until read, via the standing
+  watermark. `retract` (setting `standing_retracted = 1`) removes it from the
+  concern/unread computation for **future** sessions — the retracted row stops
+  greeting new sessions. A session that already read it is unaffected either way.
+- **`set` is idempotent by `(project, key)`**, in one transaction: retract the
+  prior live order under that key (if any), then create the replacement standing
+  broadcast. Convergent on re-run; a text change replaces rather than stacks.
+- **`retract` is idempotent**: retracting an absent or already-retracted order is
+  a no-op success, so an onboarding/audit skill can retract without first checking.
+- **`list`** returns the live (non-retracted) standing orders for a project —
+  `(key, body, from, created_at)` — sorted by key. `--json` is the audit/verify
+  seam the onboarding skill reads. A retracted order never appears.
+- **Scope validation** reuses scoped-broadcast validation: `set`/`retract` on a
+  project with no non-departed agents is rejected with the known-projects error,
+  exactly as `send --broadcast --project`.
+- **The un-keyed `send --broadcast --standing` stays** as the ad-hoc primitive
+  (empty `standing_key`, append-only) — it is the low-level transport; the keyed
+  verb family is the durable convention layered on it. `list` ignores un-keyed
+  standing broadcasts (they are messages, not managed orders).
+
+## Retraction and the read watermark — the one subtlety
+
+Retract must stop greeting **future** sessions and must not resurrect as unread
+for anyone. Because unread is judged by the standing watermark, a retracted
+order simply must be excluded from the concern/unread predicate when
+`standing_retracted = 1` — a one-clause addition to the standing branch, applied
+identically in `Inbox`/`UnreadCount`/`SessionUnread` and their DynamoDB
+counterparts. No watermark is moved on retract; the row is filtered, not
+rewritten, so a session that had already read it sees no change and a session
+that never saw it never will.
+
+## Surfaces
+
+- **Store:** the two columns; `SetStandingOrder(project, key, from, body)` (the
+  transactional retract-prior-then-create), `RetractStandingOrder(project, key)`,
+  `ListStandingOrders(project) []StandingOrder`. The unread predicate gains the
+  `standing_retracted = 0` guard on its standing branch.
+- **DynamoDB store:** mirror of all three, plus the retracted guard in the
+  unread branch; conformance cases below run on both.
+- **Daemon:** `standing_set`, `standing_retract`, `standing_list` ops, each
+  reusing scoped-broadcast validation. `set`/`retract` journal an event so the
+  bus tail shows the lifecycle.
+- **MCP:** `standing_set` / `standing_retract` / `standing_list` tools (the
+  onboarding skill drives these), described as the durable per-project
+  convention, distinct from ad-hoc `send_message` broadcasts.
+- **CLI:** the `muster standing` command group above.
+- **Conformance (both stores):** `set` creates a listable order; a second `set`
+  under the same key replaces (list shows one, the new body; a newly-registered
+  session sees only the new one); `retract` drops it from `list` and from a new
+  session's unread; retract is idempotent; scope validation rejects unknown
+  projects; an un-keyed standing broadcast never appears in `list`.
+
+## Onboarding-skill contract (informational)
+
+`tool-standards` will add a "set the project standing orders" step to the
+`tools-family-onboarding` skill: at project setup, `standing set <project> --key
+invariants "<golden rules>"`; on audit, `standing <project> --json` to verify
+presence and currency. The initial `.tools` payload (from thread 346): shared
+clone — git fetch+rebase before any push; coordinate before touching a
+load-bearing tool (branch target + collisions); HUMAN-ONLY guardrail-blocked
+steps (gh secret set / editing a CI workflow to add role-assumption / curl|sh);
+read `tools-ops/docs/superpowers/specs/2026-08-30-family-tools-standard.md` + the
+onboarding skill.
+
+## Out of scope
+
+- History/versioning of superseded orders (retract is a tombstone, not a log).
+- Per-key delivery ordering or priority.
+- Cross-project / global standing orders (a standing order is per-project by
+  construction; the global un-keyed `send --broadcast --standing` covers the
+  rare global case).
+- Editing an order's key in place (retract + set under the new key).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -809,6 +809,16 @@ func (d *Daemon) logEvent(e store.Event) { _ = d.s.AppendEvent(e) }
 // or a lookup error) — an unregistered sender's thread simply carries no
 // origin project, exactly like every other best-effort roster lookup in this
 // file (e.g. register/deregister's own discarded GetAgent error).
+// standingKeyOrDefault applies the default standing-order key when the caller
+// omits one: standing orders are near-always the project's single set of
+// invariants, so an empty key means `invariants`.
+func standingKeyOrDefault(key string) string {
+	if key == "" {
+		return "invariants"
+	}
+	return key
+}
+
 func (d *Daemon) senderProject(alias string) string {
 	ag, found, err := d.s.GetAgent(alias)
 	if err != nil || !found {
@@ -935,6 +945,39 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 		d.logEvent(store.Event{Kind: "task", Agent: from, Target: targetOf(toKind, toTarget), ThreadID: id, Detail: str(a, "subject")})
 		d.notifyForThread(id, from)
 		return ok(map[string]any{"thread_id": id})
+	case "standing_set":
+		from := str(a, "from")
+		project := str(a, "project")
+		key := standingKeyOrDefault(str(a, "key"))
+		if err := d.validateBroadcastTarget(project); err != nil {
+			return fail(err)
+		}
+		id, err := d.s.SetStandingOrder(project, key, from, str(a, "body"))
+		if err != nil {
+			return fail(err)
+		}
+		d.logEvent(store.Event{Kind: "send", Agent: from, Target: targetOf("broadcast", project), ThreadID: id, Detail: "standing order: " + key})
+		d.notifyForThread(id, from)
+		return ok(map[string]any{"thread_id": id})
+	case "standing_retract":
+		from := str(a, "from")
+		project := str(a, "project")
+		key := standingKeyOrDefault(str(a, "key"))
+		if err := d.validateBroadcastTarget(project); err != nil {
+			return fail(err)
+		}
+		changed, err := d.s.RetractStandingOrder(project, key)
+		if err != nil {
+			return fail(err)
+		}
+		d.logEvent(store.Event{Kind: "standing", Agent: from, Target: targetOf("broadcast", project), Detail: "retract standing order: " + key})
+		return ok(map[string]any{"changed": changed})
+	case "standing_list":
+		orders, err := d.s.ListStandingOrders(str(a, "project"))
+		if err != nil {
+			return fail(err)
+		}
+		return ok(map[string]any{"orders": orders})
 	case "task_claim":
 		// `by` is an actor alias and lands verbatim in entries.from_agent —
 		// expanded and existence-checked BEFORE the write, never after (see

--- a/internal/daemon/idem.go
+++ b/internal/daemon/idem.go
@@ -34,6 +34,7 @@ var writeOps = map[string]bool{
 	"register_agent": true, "deregister_agent": true, "purge_agent": true,
 	"send_message": true, "task_create": true, "reply": true,
 	"task_claim": true, "task_transition": true,
+	"standing_set": true, "standing_retract": true,
 	"kv_set": true, "log_event": true, "set_label": true,
 	"prune_events": true, "get_inbox": true,
 	// become is a CAS (it refuses an existing target), so it needs a key for
@@ -70,6 +71,11 @@ var badgeOps = map[string]bool{
 	"register_agent": true, "deregister_agent": true, "purge_agent": true,
 	"send_message": true, "task_create": true, "reply": true,
 	"task_claim": true, "task_transition": true, "get_inbox": true,
+	// standing_set calls notifyForThread (the project's live sessions get the
+	// order now, exactly like a scoped standing broadcast). standing_retract is
+	// absent on purpose: it reaches no badge sink — a live session's stale count
+	// recomputes on its next natural poll/get_inbox.
+	"standing_set": true,
 	// become calls reconcileBadge: the claimed identity inherits the seed's
 	// waiting mail, so the badge on its session has to be recomputed. Without
 	// this, a claim in remote mode would leave the badge showing the pre-claim

--- a/internal/daemon/idem_test.go
+++ b/internal/daemon/idem_test.go
@@ -320,6 +320,7 @@ func TestGetInboxIsIdempotencyProtected(t *testing.T) {
 var readOps = map[string]bool{
 	"list_agents": true, "session_aliases": true, "session_unread": true,
 	"get_thread": true, "list_threads": true, "kv_get": true,
+	"standing_list": true,
 	// device_poll reads a watermark and answers with it; the watermark lives
 	// on the POLLING DEVICE (the daemon's own loop variable), never in the
 	// store, so two identical polls are indistinguishable to the bus.

--- a/internal/daemon/standing_orders_test.go
+++ b/internal/daemon/standing_orders_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/store"
+)
+
+// standing_set creates a listable, greeting order; standing_list returns it;
+// standing_retract stops it greeting and drops it from the list. Unknown
+// projects are rejected on set/retract; the key defaults to invariants.
+func TestStandingOrderOpsLifecycle(t *testing.T) {
+	n := &fakeNotifier{}
+	sock, s := startWithNotifierAndStore(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1", "session_created": 100})
+
+	// set with an omitted key defaults to invariants.
+	if resp := call(t, sock, "standing_set", map[string]any{"from": "web1", "project": "web", "body": "rebase before push"}); !resp.OK {
+		t.Fatalf("standing_set: %s", resp.Error)
+	}
+	orders, _ := s.ListStandingOrders("web")
+	if len(orders) != 1 || orders[0].Key != "invariants" || orders[0].Body != "rebase before push" {
+		t.Fatalf("after set, orders = %+v", orders)
+	}
+
+	// list op returns it.
+	resp := call(t, sock, "standing_list", map[string]any{"project": "web"})
+	if !resp.OK {
+		t.Fatalf("standing_list: %s", resp.Error)
+	}
+	var listed struct {
+		Orders []store.StandingOrder `json:"orders"`
+	}
+	decode(t, resp, &listed)
+	if len(listed.Orders) != 1 || listed.Orders[0].Body != "rebase before push" {
+		t.Fatalf("standing_list orders = %+v", listed.Orders)
+	}
+
+	// retract stops greeting and empties the list.
+	if resp := call(t, sock, "standing_retract", map[string]any{"from": "web1", "project": "web"}); !resp.OK {
+		t.Fatalf("standing_retract: %s", resp.Error)
+	}
+	if orders, _ := s.ListStandingOrders("web"); len(orders) != 0 {
+		t.Fatalf("after retract, orders = %+v, want none", orders)
+	}
+}
+
+func TestStandingSetRejectsUnknownProject(t *testing.T) {
+	n := &fakeNotifier{}
+	sock := startWithNotifier(t, n)
+	call(t, sock, "register_agent", map[string]any{"alias": "web1", "project": "web", "socket_path": "/s", "session_id": "$1", "session_created": 100})
+
+	resp := call(t, sock, "standing_set", map[string]any{"from": "web1", "project": "wbe", "body": "x"})
+	if resp.OK {
+		t.Fatal("standing_set to an unknown project must be rejected")
+	}
+	if !strings.Contains(resp.Error, `no registered agents in project "wbe"`) {
+		t.Fatalf("error should name the project, got: %q", resp.Error)
+	}
+}

--- a/internal/dynamostore/threads.go
+++ b/internal/dynamostore/threads.go
@@ -96,29 +96,31 @@ func threadKey(id int64) map[string]types.AttributeValue {
 // there would be up to 500 round trips per poll.
 func threadMetaItem(t store.Thread, threadID, firstEntryID, now int64) map[string]types.AttributeValue {
 	return map[string]types.AttributeValue{
-		"pk":             attrS(pkThread(threadID)),
-		"sk":             attrN(metaSK),
-		"id":             attrN(threadID),
-		"kind":           attrS(t.Kind),
-		"from_agent":     attrS(t.FromAgent),
-		"to_kind":        attrS(t.ToKind),
-		"to_target":      attrS(t.ToTarget),
-		"subject":        attrS(t.Subject),
-		"ref":            attrS(t.Ref),
-		"status":         attrS(t.Status),
-		"intent":         attrS(t.Intent), // RAW; effectiveIntent applies on read
-		"standing":       attrBool(t.Standing),
-		"created_at":     attrN(now),
-		"updated_at":     attrN(now),
-		"origin_project": attrS(t.OriginProject),
-		"entry_count":    attrN(1),
-		"last_entry_id":  attrN(firstEntryID),
-		"last_from":      attrS(t.FromAgent),
-		"last_at":        attrN(now),
-		"gsi1pk":         attrS(rcpt(t.ToKind, t.ToTarget)),
-		"gsi1sk":         attrN(metaSK),
-		"gsi2pk":         attrS(threadsPartition),
-		"gsi2sk":         attrN(threadID),
+		"pk":                 attrS(pkThread(threadID)),
+		"sk":                 attrN(metaSK),
+		"id":                 attrN(threadID),
+		"kind":               attrS(t.Kind),
+		"from_agent":         attrS(t.FromAgent),
+		"to_kind":            attrS(t.ToKind),
+		"to_target":          attrS(t.ToTarget),
+		"subject":            attrS(t.Subject),
+		"ref":                attrS(t.Ref),
+		"status":             attrS(t.Status),
+		"intent":             attrS(t.Intent), // RAW; effectiveIntent applies on read
+		"standing":           attrBool(t.Standing),
+		"standing_key":       attrS(t.StandingKey),
+		"standing_retracted": attrBool(t.StandingRetracted),
+		"created_at":         attrN(now),
+		"updated_at":         attrN(now),
+		"origin_project":     attrS(t.OriginProject),
+		"entry_count":        attrN(1),
+		"last_entry_id":      attrN(firstEntryID),
+		"last_from":          attrS(t.FromAgent),
+		"last_at":            attrN(now),
+		"gsi1pk":             attrS(rcpt(t.ToKind, t.ToTarget)),
+		"gsi1sk":             attrN(metaSK),
+		"gsi2pk":             attrS(threadsPartition),
+		"gsi2sk":             attrN(threadID),
 	}
 }
 
@@ -157,19 +159,21 @@ func entryItem(threadID, entryID int64, fromAgent, body, statusChange string, no
 func itemToThread(item map[string]types.AttributeValue) store.Thread {
 	kind := strAttr(item, "kind")
 	return store.Thread{
-		ID:            numAttr(item, "id"),
-		Kind:          kind,
-		FromAgent:     strAttr(item, "from_agent"),
-		ToKind:        strAttr(item, "to_kind"),
-		ToTarget:      strAttr(item, "to_target"),
-		Subject:       strAttr(item, "subject"),
-		Ref:           strAttr(item, "ref"),
-		Status:        strAttr(item, "status"),
-		Intent:        effectiveIntent(kind, strAttr(item, "intent")),
-		Standing:      boolAttr(item, "standing"),
-		CreatedAt:     numAttr(item, "created_at"),
-		UpdatedAt:     numAttr(item, "updated_at"),
-		OriginProject: strAttr(item, "origin_project"),
+		ID:                numAttr(item, "id"),
+		Kind:              kind,
+		FromAgent:         strAttr(item, "from_agent"),
+		ToKind:            strAttr(item, "to_kind"),
+		ToTarget:          strAttr(item, "to_target"),
+		Subject:           strAttr(item, "subject"),
+		Ref:               strAttr(item, "ref"),
+		Status:            strAttr(item, "status"),
+		Intent:            effectiveIntent(kind, strAttr(item, "intent")),
+		Standing:          boolAttr(item, "standing"),
+		StandingKey:       strAttr(item, "standing_key"),
+		StandingRetracted: boolAttr(item, "standing_retracted"),
+		CreatedAt:         numAttr(item, "created_at"),
+		UpdatedAt:         numAttr(item, "updated_at"),
+		OriginProject:     strAttr(item, "origin_project"),
 	}
 }
 
@@ -719,11 +723,113 @@ func unreadByThread(entries []store.Entry, concerning, standing map[int64]bool, 
 func standingSet(threads map[int64]map[string]types.AttributeValue) map[int64]bool {
 	out := make(map[int64]bool)
 	for id, item := range threads {
-		if boolAttr(item, "standing") {
+		// A retracted standing order is filtered from the standing branch so it
+		// greets no future session (matches the SQLite standing_retracted=0
+		// guard); such an entry then matches neither unread branch.
+		if boolAttr(item, "standing") && !boolAttr(item, "standing_retracted") {
 			out[id] = true
 		}
 	}
 	return out
+}
+
+// retractOrders marks every live standing order under (project, key) retracted
+// and returns how many changed. Shared by SetStandingOrder (supersede prior)
+// and RetractStandingOrder. There is normally 0 or 1.
+func (s *Store) retractOrders(ctx context.Context, project, key string) (int, error) {
+	items, err := s.queryAll(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(s.table),
+		IndexName:              aws.String(gsi1Name),
+		KeyConditionExpression: aws.String("gsi1pk = :pk AND gsi1sk = :meta"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": attrS(rcpt("broadcast", project)), ":meta": attrN(metaSK),
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("dynamostore: standing orders for %q: %w", project, err)
+	}
+	n := 0
+	for _, item := range items {
+		if !boolAttr(item, "standing") || boolAttr(item, "standing_retracted") || strAttr(item, "standing_key") != key {
+			continue
+		}
+		id := numAttr(item, "id")
+		if _, err := s.c.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:                 aws.String(s.table),
+			Key:                       map[string]types.AttributeValue{"pk": attrS(pkThread(id)), "sk": attrN(metaSK)},
+			UpdateExpression:          aws.String("SET #r = :true"),
+			ExpressionAttributeNames:  map[string]string{"#r": "standing_retracted"},
+			ExpressionAttributeValues: map[string]types.AttributeValue{":true": attrBool(true)},
+		}); err != nil {
+			return n, fmt.Errorf("dynamostore: retract standing order %d: %w", id, err)
+		}
+		n++
+	}
+	return n, nil
+}
+
+// SetStandingOrder create-or-replaces the standing order under (project, key):
+// retract any prior live order, then create a new standing broadcast carrying
+// body. Mirrors the SQLite store (see its doc comment).
+func (s *Store) SetStandingOrder(project, key, from, body string) (int64, error) {
+	if project == "" {
+		return 0, fmt.Errorf("standing order requires a project")
+	}
+	if key == "" {
+		return 0, fmt.Errorf("standing order requires a key")
+	}
+	ctx := backgroundCtx()
+	if _, err := s.retractOrders(ctx, project, key); err != nil {
+		return 0, err
+	}
+	origin := ""
+	if a, ok, err := s.agentByAlias(ctx, from); err == nil && ok {
+		origin = a.Project
+	}
+	return s.CreateThread(store.Thread{
+		Kind: "message", FromAgent: from, ToKind: "broadcast", ToTarget: project,
+		Standing: true, StandingKey: key, OriginProject: origin,
+	}, body)
+}
+
+// RetractStandingOrder retracts the live order under (project, key); idempotent.
+func (s *Store) RetractStandingOrder(project, key string) (bool, error) {
+	n, err := s.retractOrders(backgroundCtx(), project, key)
+	return n > 0, err
+}
+
+// ListStandingOrders returns the live keyed standing orders for a project,
+// sorted by key; ad-hoc un-keyed standing broadcasts are excluded.
+func (s *Store) ListStandingOrders(project string) ([]store.StandingOrder, error) {
+	ctx := backgroundCtx()
+	items, err := s.queryAll(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(s.table),
+		IndexName:              aws.String(gsi1Name),
+		KeyConditionExpression: aws.String("gsi1pk = :pk AND gsi1sk = :meta"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": attrS(rcpt("broadcast", project)), ":meta": attrN(metaSK),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dynamostore: list standing orders for %q: %w", project, err)
+	}
+	out := []store.StandingOrder{}
+	for _, item := range items {
+		if !boolAttr(item, "standing") || boolAttr(item, "standing_retracted") || strAttr(item, "standing_key") == "" {
+			continue
+		}
+		id := numAttr(item, "id")
+		body := ""
+		if _, entries, err := s.GetThread(id); err == nil && len(entries) > 0 {
+			body = entries[0].Body
+		}
+		out = append(out, store.StandingOrder{
+			Key: strAttr(item, "standing_key"), From: strAttr(item, "from_agent"),
+			ThreadID: id, CreatedAt: numAttr(item, "created_at"), Body: body,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out, nil
 }
 
 // unreadFloor is the lower of the two watermarks: entriesAfter must fetch from

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -139,6 +139,29 @@ when a session has no muster MCP connection.`,
 			Run:      cmdReply,
 		},
 		{
+			Name:     "standing",
+			Synopsis: `standing <project> [--json] | standing set <project> [--key <k>] "body" [--from <alias>] | standing retract <project> [--key <k>]`,
+			Summary:  "Manage a project's durable standing orders (its invariants).",
+			Help: `A standing order is a project's durable instruction that every session should
+read on start (e.g. its invariants / golden rules). Unlike an ad-hoc
+'send --broadcast --standing' it is KEYED and REPLACEABLE, so it stays a single
+current statement rather than a growing pile.
+
+  standing <project> [--json]              list the project's live orders
+  standing set <project> [--key k] "body"  create or REPLACE the order under a key
+  standing retract <project> [--key k]     retract it
+
+--key defaults to 'invariants' (the project's single set of rules). set is
+idempotent by (project, key) and RE-GREETS every session with the updated text —
+running sessions and future ones alike — until each reads it, so a mid-flight
+correction reaches everyone. retract stops it greeting new sessions and drops it
+from the list; a session that already read it is unaffected. --json on the list
+form is the audit/verify seam.`,
+			Group:    GroupTalk,
+			NewFlags: newStandingFlags,
+			Run:      cmdStanding,
+		},
+		{
 			Name:     "agents",
 			Synopsis: "agents",
 			Summary:  "List registered agents, grouped by project, with live status.",

--- a/internal/humancli/registry_test.go
+++ b/internal/humancli/registry_test.go
@@ -14,7 +14,7 @@ import (
 // Keep this in sync with CLAUDE.md's package-map/usage line and
 // cmd/muster/main.go's routing comment.
 var wantCommandNames = []string{
-	"send", "nudge", "reply",
+	"send", "nudge", "reply", "standing",
 	"agents", "inbox", "tasks", "thread", "events", "watch", "station",
 	"register", "become", "deregister", "label", "whereami", "device", "gc",
 	"serve", "mcp", "channel", "lambda", "hook", "update", "debug",

--- a/internal/humancli/standing.go
+++ b/internal/humancli/standing.go
@@ -1,0 +1,127 @@
+package humancli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/schuettc/muster/internal/store"
+)
+
+// standingBoolFlags: only --json takes no value; --key/--from are value flags.
+var standingBoolFlags = map[string]bool{"json": true}
+
+func newStandingFlagsWithVals() (*flag.FlagSet, *bool, *string, *string) {
+	fs := flag.NewFlagSet("standing", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut := fs.Bool("json", false, "with the list form: print the orders as JSON (the audit/verify seam)")
+	key := fs.String("key", "", "the order's key within the project (default 'invariants')")
+	from := fs.String("from", "human", "authoring/retracting agent alias (set/retract)")
+	return fs, jsonOut, key, from
+}
+
+func newStandingFlags() *flag.FlagSet {
+	fs, _, _, _ := newStandingFlagsWithVals()
+	return fs
+}
+
+// cmdStanding manages a project's keyed standing orders:
+//
+//	muster standing <project> [--json]              list live orders
+//	muster standing set <project> [--key k] "body"  create-or-replace
+//	muster standing retract <project> [--key k]     retract
+func cmdStanding(args []string, out io.Writer) error {
+	fs, jsonOut, key, from := newStandingFlagsWithVals()
+	flagArgs, rest := splitFlagsAndPositional(args, standingBoolFlags)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("standing", out)
+		}
+		return err
+	}
+	if len(rest) == 0 {
+		return fmt.Errorf("usage: muster standing <project> [--json] | set <project> [--key k] \"body\" | retract <project> [--key k]")
+	}
+
+	switch rest[0] {
+	case "set":
+		if len(rest) < 3 {
+			return fmt.Errorf("usage: muster standing set <project> [--key <k>] \"body\" [--from <alias>]")
+		}
+		project := rest[1]
+		body := strings.Join(rest[2:], " ")
+		raw, err := callData("standing_set", map[string]any{
+			"from": expandAlias(*from, rosterAliasExists()), "project": project, "key": *key, "body": body,
+		})
+		if err != nil {
+			return err
+		}
+		var res struct {
+			ThreadID int64 `json:"thread_id"`
+		}
+		if err := json.Unmarshal(raw, &res); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(out, "standing order set (thread %d)\n", res.ThreadID)
+		return err
+	case "retract":
+		if len(rest) < 2 {
+			return fmt.Errorf("usage: muster standing retract <project> [--key <k>]")
+		}
+		raw, err := callData("standing_retract", map[string]any{
+			"from": expandAlias(*from, rosterAliasExists()), "project": rest[1], "key": *key,
+		})
+		if err != nil {
+			return err
+		}
+		var res struct {
+			Changed bool `json:"changed"`
+		}
+		if err := json.Unmarshal(raw, &res); err != nil {
+			return err
+		}
+		if res.Changed {
+			_, err = fmt.Fprintln(out, "standing order retracted")
+		} else {
+			_, err = fmt.Fprintln(out, "no live standing order to retract")
+		}
+		return err
+	default:
+		// Bare project: list.
+		return standingList(rest[0], *jsonOut, out)
+	}
+}
+
+func standingList(project string, jsonOut bool, out io.Writer) error {
+	raw, err := callData("standing_list", map[string]any{"project": project})
+	if err != nil {
+		return err
+	}
+	var res struct {
+		Orders []store.StandingOrder `json:"orders"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return err
+	}
+	if jsonOut {
+		b, err := json.MarshalIndent(res.Orders, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(out, string(b))
+		return err
+	}
+	if len(res.Orders) == 0 {
+		_, err = fmt.Fprintf(out, "no standing orders for %q\n", project)
+		return err
+	}
+	for _, o := range res.Orders {
+		if _, err := fmt.Fprintf(out, "[%s] %s\n", o.Key, o.Body); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/humancli/standing_test.go
+++ b/internal/humancli/standing_test.go
@@ -1,0 +1,65 @@
+package humancli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/store"
+)
+
+func TestStandingCLIRoundTrip(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "web1", "project": "web", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// set (default key)
+	var buf bytes.Buffer
+	if err := cmdStanding([]string{"set", "web", "rebase", "before", "push", "--from", "web1"}, &buf); err != nil {
+		t.Fatalf("standing set: %v", err)
+	}
+	if !strings.Contains(buf.String(), "standing order set") {
+		t.Fatalf("set output = %q", buf.String())
+	}
+
+	// list --json
+	buf.Reset()
+	if err := cmdStanding([]string{"web", "--json"}, &buf); err != nil {
+		t.Fatalf("standing list: %v", err)
+	}
+	var orders []store.StandingOrder
+	if err := json.Unmarshal(buf.Bytes(), &orders); err != nil {
+		t.Fatalf("list --json not valid JSON: %v (%s)", err, buf.String())
+	}
+	if len(orders) != 1 || orders[0].Key != "invariants" || orders[0].Body != "rebase before push" {
+		t.Fatalf("list = %+v", orders)
+	}
+
+	// retract
+	buf.Reset()
+	if err := cmdStanding([]string{"retract", "web", "--from", "web1"}, &buf); err != nil {
+		t.Fatalf("standing retract: %v", err)
+	}
+	if !strings.Contains(buf.String(), "retracted") {
+		t.Fatalf("retract output = %q", buf.String())
+	}
+
+	// list is now empty
+	buf.Reset()
+	if err := cmdStanding([]string{"web"}, &buf); err != nil {
+		t.Fatalf("standing list: %v", err)
+	}
+	if !strings.Contains(buf.String(), "no standing orders") {
+		t.Fatalf("empty list output = %q", buf.String())
+	}
+}
+
+func TestStandingSetTooFewArgs(t *testing.T) {
+	startTestDaemon(t)
+	var buf bytes.Buffer
+	if err := cmdStanding([]string{"set", "web"}, &buf); err == nil {
+		t.Fatal("standing set without a body must error")
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -22,6 +22,7 @@ func Run(ctx context.Context) error {
 func registerAll(srv *mcp.Server) {
 	registerRegistryTools(srv)
 	registerMessageTools(srv)
+	registerStandingTools(srv)
 	registerTaskTools(srv)
 	registerKVTools(srv)
 }

--- a/internal/mcpserver/tools_standing.go
+++ b/internal/mcpserver/tools_standing.go
@@ -1,0 +1,103 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// StandingSetIn is the input to standing_set.
+type StandingSetIn struct {
+	From    string `json:"from" jsonschema:"the authoring agent's alias"`
+	Project string `json:"project" jsonschema:"the project whose standing orders to set (an agent must be registered under it)"`
+	Key     string `json:"key,omitempty" jsonschema:"the order's key within the project; defaults to 'invariants' (the project's single set of golden rules). Use distinct keys only for genuinely separate standing orders."`
+	Body    string `json:"body" jsonschema:"the standing order text — the durable instruction every session in the project should read on start"`
+}
+
+// StandingRetractIn is the input to standing_retract.
+type StandingRetractIn struct {
+	From    string `json:"from" jsonschema:"the retracting agent's alias"`
+	Project string `json:"project" jsonschema:"the project whose standing order to retract"`
+	Key     string `json:"key,omitempty" jsonschema:"the order's key; defaults to 'invariants'"`
+}
+
+// StandingListIn is the input to standing_list.
+type StandingListIn struct {
+	Project string `json:"project" jsonschema:"the project whose live standing orders to list"`
+}
+
+// StandingOrderView is one live standing order in a standing_list result.
+type StandingOrderView struct {
+	Key       string `json:"key" jsonschema:"the order's key within its project"`
+	Body      string `json:"body" jsonschema:"the standing order text"`
+	From      string `json:"from" jsonschema:"who authored it"`
+	ThreadID  int64  `json:"thread_id" jsonschema:"the underlying thread id"`
+	CreatedAt int64  `json:"created_at" jsonschema:"when it was authored (unix ms)"`
+}
+
+// StandingChangedOut is the output of standing_retract.
+type StandingChangedOut struct {
+	Changed bool `json:"changed" jsonschema:"true if a live order was retracted; false if there was nothing to retract (idempotent)"`
+}
+
+// StandingListOut is the output of standing_list.
+type StandingListOut struct {
+	Orders []StandingOrderView `json:"orders" jsonschema:"the project's live standing orders, sorted by key"`
+}
+
+func standingSetHandler(_ context.Context, _ *mcp.CallToolRequest, in StandingSetIn) (*mcp.CallToolResult, ThreadIDOut, error) {
+	if err := requireRegisteredFrom(in.From); err != nil {
+		return nil, ThreadIDOut{}, err
+	}
+	raw, err := callDaemon("standing_set", map[string]any{
+		"from": in.From, "project": in.Project, "key": in.Key, "body": in.Body,
+	})
+	if err != nil {
+		return nil, ThreadIDOut{}, err
+	}
+	var out ThreadIDOut
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, ThreadIDOut{}, err
+	}
+	return nil, out, nil
+}
+
+func standingRetractHandler(_ context.Context, _ *mcp.CallToolRequest, in StandingRetractIn) (*mcp.CallToolResult, StandingChangedOut, error) {
+	if err := requireRegisteredFrom(in.From); err != nil {
+		return nil, StandingChangedOut{}, err
+	}
+	raw, err := callDaemon("standing_retract", map[string]any{
+		"from": in.From, "project": in.Project, "key": in.Key,
+	})
+	if err != nil {
+		return nil, StandingChangedOut{}, err
+	}
+	var out StandingChangedOut
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, StandingChangedOut{}, err
+	}
+	return nil, out, nil
+}
+
+func standingListHandler(_ context.Context, _ *mcp.CallToolRequest, in StandingListIn) (*mcp.CallToolResult, StandingListOut, error) {
+	raw, err := callDaemon("standing_list", map[string]any{"project": in.Project})
+	if err != nil {
+		return nil, StandingListOut{}, err
+	}
+	var out StandingListOut
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, StandingListOut{}, err
+	}
+	return nil, out, nil
+}
+
+// registerStandingTools registers the standing-orders convention surface: the
+// durable, keyed, per-project standing orders a session should read on start —
+// distinct from an ad-hoc send_message broadcast. This is the onboarding
+// skill's primary surface (set at project setup, verify via standing_list).
+func registerStandingTools(srv *mcp.Server) {
+	mcp.AddTool(srv, &mcp.Tool{Name: "standing_set", Description: "Create or REPLACE a project's standing order (its durable invariants) under a key (default 'invariants'). Idempotent by (project, key): a new set replaces the prior order rather than stacking, and RE-GREETS every session — those running now and those that start later — with the updated text, until each reads it. Use this for a project's golden rules that every session must read on start; use send_message with standing for ad-hoc one-off standing messages."}, standingSetHandler)
+	mcp.AddTool(srv, &mcp.Tool{Name: "standing_retract", Description: "Retract a project's standing order under a key (default 'invariants') so it greets no future session and drops from standing_list. Idempotent — retracting an absent order is a no-op. A session that already read the order is unaffected."}, standingRetractHandler)
+	mcp.AddTool(srv, &mcp.Tool{Name: "standing_list", Description: "List a project's live standing orders (key, body, author) — the audit/verify seam: read this to check what greets a new session in the project, and whether the invariants are present and current."}, standingListHandler)
+}

--- a/internal/mcpserver/tools_standing_test.go
+++ b/internal/mcpserver/tools_standing_test.go
@@ -1,0 +1,60 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+)
+
+// standing_set creates a listable order; standing_list returns it; a second
+// set under the same key replaces it; standing_retract clears it.
+func TestStandingToolsLifecycle(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callDaemon("register_agent", map[string]any{"alias": "web1", "project": "web", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, out, err := standingSetHandler(context.Background(), nil, StandingSetIn{
+		From: "web1", Project: "web", Body: "rebase before push",
+	}); err != nil || out.ThreadID == 0 {
+		t.Fatalf("standing_set: err=%v out=%+v", err, out)
+	}
+
+	_, list, err := standingListHandler(context.Background(), nil, StandingListIn{Project: "web"})
+	if err != nil {
+		t.Fatalf("standing_list: %v", err)
+	}
+	if len(list.Orders) != 1 || list.Orders[0].Key != "invariants" || list.Orders[0].Body != "rebase before push" {
+		t.Fatalf("standing_list = %+v", list.Orders)
+	}
+
+	// Replace under the default key.
+	if _, _, err := standingSetHandler(context.Background(), nil, StandingSetIn{
+		From: "web1", Project: "web", Body: "rebase before push (v2)",
+	}); err != nil {
+		t.Fatalf("standing_set replace: %v", err)
+	}
+	_, list, _ = standingListHandler(context.Background(), nil, StandingListIn{Project: "web"})
+	if len(list.Orders) != 1 || list.Orders[0].Body != "rebase before push (v2)" {
+		t.Fatalf("after replace, list = %+v", list.Orders)
+	}
+
+	// Retract.
+	_, chg, err := standingRetractHandler(context.Background(), nil, StandingRetractIn{From: "web1", Project: "web"})
+	if err != nil || !chg.Changed {
+		t.Fatalf("standing_retract: err=%v changed=%v", err, chg.Changed)
+	}
+	_, list, _ = standingListHandler(context.Background(), nil, StandingListIn{Project: "web"})
+	if len(list.Orders) != 0 {
+		t.Fatalf("after retract, list = %+v, want empty", list.Orders)
+	}
+}
+
+func TestStandingSetUnknownProjectRejected(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callDaemon("register_agent", map[string]any{"alias": "web1", "project": "web", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := standingSetHandler(context.Background(), nil, StandingSetIn{From: "web1", Project: "wbe", Body: "x"}); err == nil {
+		t.Fatal("standing_set to an unknown project must be rejected")
+	}
+}

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -262,7 +262,7 @@ SELECT COUNT(*) FROM threads
 WHERE `+threadConcerns+`
   AND EXISTS (SELECT 1 FROM entries e
               WHERE e.thread_id = threads.id
-                AND ((threads.standing = 1 AND e.id > COALESCE((SELECT last_read_standing_entry_id FROM agents WHERE alias=?), 0))
+                AND ((threads.standing = 1 AND threads.standing_retracted = 0 AND e.id > COALESCE((SELECT last_read_standing_entry_id FROM agents WHERE alias=?), 0))
                   OR (threads.standing = 0 AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)))
                 AND e.from_agent != ?)`,
 		alias, alias, alias, alias, alias, alias, alias).Scan(&n)
@@ -462,7 +462,7 @@ FROM threads
 JOIN sess ON `+threadConcernsJoin+`
 WHERE EXISTS (SELECT 1 FROM entries e
               WHERE e.thread_id = threads.id
-                AND ((threads.standing = 1 AND e.id > sess.last_read_standing_entry_id)
+                AND ((threads.standing = 1 AND threads.standing_retracted = 0 AND e.id > sess.last_read_standing_entry_id)
                   OR (threads.standing = 0 AND e.id > sess.last_read_entry_id))
                 AND e.from_agent NOT IN (SELECT alias FROM sess))`,
 		socketPath, sessionID, deviceID, sessionCreated).Scan(&total, &action)

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -98,6 +98,13 @@ type API interface {
 	SetSessionLabel(deviceID, socketPath, sessionID string, sessionCreated int64, label string, manual bool) (int64, error)
 	DeleteAgent(alias string) error
 	CreateThread(t Thread, firstBody string) (int64, error)
+	// SetStandingOrder create-or-replaces the standing order identified by
+	// (project, key) idempotently; RetractStandingOrder retracts it
+	// (idempotent, reports whether a row changed); ListStandingOrders returns
+	// the live keyed orders for a project. See the standing-orders spec.
+	SetStandingOrder(project, key, from, body string) (int64, error)
+	RetractStandingOrder(project, key string) (bool, error)
+	ListStandingOrders(project string) ([]StandingOrder, error)
 	AppendEntry(threadID int64, fromAgent, body, statusChange string) (int64, error)
 	ClaimTask(threadID int64, byAgent string) error
 	TransitionTask(threadID int64, byAgent, newStatus, note string) error

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -122,9 +122,17 @@ type Thread struct {
 	// not the seeded live watermark, decides its unread state). Only
 	// meaningful for to_kind='broadcast'; CreateThread rejects standing on
 	// any other target. A plain (non-standing) broadcast is live-only.
-	Standing  bool  `json:"standing"`
-	CreatedAt int64 `json:"created_at"`
-	UpdatedAt int64 `json:"updated_at"`
+	Standing bool `json:"standing"`
+	// StandingKey is the identity of a keyed standing ORDER within its project
+	// (empty on an ad-hoc append-only standing broadcast). StandingRetracted
+	// marks an order superseded (by a newer set under the same project+key) or
+	// explicitly retracted; a retracted order is filtered from the standing
+	// unread branch so it greets no future session. Both broadcast-only. See
+	// SetStandingOrder/RetractStandingOrder/ListStandingOrders.
+	StandingKey       string `json:"standing_key"`
+	StandingRetracted bool   `json:"standing_retracted"`
+	CreatedAt         int64  `json:"created_at"`
+	UpdatedAt         int64  `json:"updated_at"`
 	// OriginProject is the SENDER's registered project at thread-creation
 	// time (iteration-4 orphan-thread fix): the daemon resolves the sender's
 	// agent record when it calls CreateThread and stamps its Project here —
@@ -151,6 +159,17 @@ type Thread struct {
 	// drilling into get_thread. Threads()/GetThread/CreateThread leave it
 	// zero.
 	Unread int `json:"unread"`
+}
+
+// StandingOrder is one live (non-retracted) keyed standing order for a
+// project, as returned by ListStandingOrders — the audit/verify view the
+// onboarding skill reads. Body is the order's text (its thread's first entry).
+type StandingOrder struct {
+	Key       string `json:"key"`
+	Body      string `json:"body"`
+	From      string `json:"from"`
+	ThreadID  int64  `json:"thread_id"`
+	CreatedAt int64  `json:"created_at"`
 }
 
 // Entry is one append-only message within a thread.

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -32,6 +32,8 @@ CREATE TABLE IF NOT EXISTS threads (
     status     TEXT,                          -- NULL for messages
     intent     TEXT NOT NULL DEFAULT '',       -- '' | fyi | reply-requested | action-requested
     standing   INTEGER NOT NULL DEFAULT 0,      -- 1 = broadcast replayed to sessions registering after send (until read); broadcast-only. Plain broadcast is live-only.
+    standing_key       TEXT NOT NULL DEFAULT '', -- identity of a keyed standing ORDER within its project (empty = ad-hoc append-only standing broadcast); see muster standing set/retract/list
+    standing_retracted INTEGER NOT NULL DEFAULT 0, -- 1 = this standing order was retracted or superseded by a newer set under the same (to_target, standing_key); filtered from the standing unread branch so it greets no future session
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
     origin_project TEXT NOT NULL DEFAULT ''    -- sender's registered project at creation time ('' = unregistered sender); see store.migrate's backfill for pre-existing rows

--- a/internal/store/standing_orders_test.go
+++ b/internal/store/standing_orders_test.go
@@ -1,0 +1,123 @@
+package store
+
+import "testing"
+
+func TestSetStandingOrderIsListableAndGreetsNewSession(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "rebase before push"); err != nil {
+		t.Fatal(err)
+	}
+	orders, err := s.ListStandingOrders("web")
+	if err != nil || len(orders) != 1 {
+		t.Fatalf("list = %d (%v), want 1", len(orders), err)
+	}
+	if orders[0].Key != "invariants" || orders[0].Body != "rebase before push" {
+		t.Fatalf("order = %+v", orders[0])
+	}
+	// A session registering AFTER the order sees it once.
+	if err := s.RegisterAgent(Agent{Alias: "newbie", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("newbie"); n != 1 {
+		t.Fatalf("new session should be greeted by the standing order: unread=%d, want 1", n)
+	}
+}
+
+func TestSetStandingOrderReplacesByKey(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "v1 rules"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "v2 rules"); err != nil {
+		t.Fatal(err)
+	}
+	orders, _ := s.ListStandingOrders("web")
+	if len(orders) != 1 || orders[0].Body != "v2 rules" {
+		t.Fatalf("replace should leave exactly one order (v2), got %+v", orders)
+	}
+	// A new session sees only the current (v2) order — one unread, not two.
+	if err := s.RegisterAgent(Agent{Alias: "newbie", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("newbie"); n != 1 {
+		t.Fatalf("new session should see only the current order: unread=%d, want 1", n)
+	}
+}
+
+func TestRetractStandingOrderStopsGreetingAndDropsFromList(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "rules"); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := s.RetractStandingOrder("web", "invariants")
+	if err != nil || !changed {
+		t.Fatalf("retract should report a change: changed=%v err=%v", changed, err)
+	}
+	if orders, _ := s.ListStandingOrders("web"); len(orders) != 0 {
+		t.Fatalf("retracted order must drop from list, got %+v", orders)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "newbie", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("newbie"); n != 0 {
+		t.Fatalf("retracted order must not greet a new session: unread=%d, want 0", n)
+	}
+	// Idempotent: retracting again changes nothing.
+	if changed, _ := s.RetractStandingOrder("web", "invariants"); changed {
+		t.Fatal("second retract should be a no-op (false)")
+	}
+}
+
+func TestRetractDoesNotDisturbAlreadyReadSession(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "rules"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "seen", Project: "web"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MarkRead("seen"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.RetractStandingOrder("web", "invariants"); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("seen"); n != 0 {
+		t.Fatalf("retract must not resurface as unread for a session that read it: unread=%d, want 0", n)
+	}
+}
+
+func TestSetStandingOrderRejectsEmptyKey(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SetStandingOrder("web", "", "author", "x"); err == nil {
+		t.Fatal("empty key must be rejected")
+	}
+}
+
+func TestListStandingOrdersIgnoresAdHocStandingBroadcast(t *testing.T) {
+	s := newTestStore(t)
+	// An un-keyed standing broadcast (the v1 ad-hoc primitive) is not a
+	// managed order and must never appear in the list.
+	if _, err := s.CreateThread(Thread{Kind: "message", FromAgent: "a", ToKind: "broadcast", ToTarget: "web", Standing: true}, "ad-hoc"); err != nil {
+		t.Fatal(err)
+	}
+	if orders, _ := s.ListStandingOrders("web"); len(orders) != 0 {
+		t.Fatalf("ad-hoc standing broadcast must not be listed, got %+v", orders)
+	}
+}
+
+func TestStandingOrderScopedToProject(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "web rules"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RegisterAgent(Agent{Alias: "in-api", Project: "api"}); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("in-api"); n != 0 {
+		t.Fatalf("other-project session must not see a scoped standing order: unread=%d, want 0", n)
+	}
+	if orders, _ := s.ListStandingOrders("api"); len(orders) != 0 {
+		t.Fatalf("api has no orders, got %+v", orders)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -58,6 +58,8 @@ func migrate(db *sql.DB) error {
 		`ALTER TABLE agents ADD COLUMN transcript_path TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE agents ADD COLUMN last_read_standing_entry_id INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE threads ADD COLUMN standing INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE threads ADD COLUMN standing_key TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE threads ADD COLUMN standing_retracted INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, ddl := range alters {
 		if _, err := db.Exec(ddl); err != nil && !strings.Contains(err.Error(), "duplicate column name") {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -68,6 +68,8 @@ func TestSchemaHasStandingColumns(t *testing.T) {
 	for _, c := range []struct{ table, col string }{
 		{"agents", "last_read_standing_entry_id"},
 		{"threads", "standing"},
+		{"threads", "standing_key"},
+		{"threads", "standing_retracted"},
 	} {
 		var n int
 		if err := s.DB().QueryRow(

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -64,6 +64,91 @@ VALUES (?, ?, ?, ?, ?)`, id, t.FromAgent, firstBody, nil, now); err != nil {
 	return id, tx.Commit()
 }
 
+// SetStandingOrder creates or REPLACES the standing order identified by
+// (project, key): in one transaction it retracts any prior live order under
+// that key, then creates a new standing broadcast (standing=1, standing_key=key,
+// scoped to project) carrying body. Idempotent by identity — re-running with
+// new text replaces the prior order rather than stacking, so a new session
+// sees exactly one order per key. origin_project is stamped from the sender's
+// registered project, matching CreateThread. Returns the new thread id.
+func (s *Store) SetStandingOrder(project, key, from, body string) (int64, error) {
+	if project == "" {
+		return 0, fmt.Errorf("standing order requires a project")
+	}
+	if key == "" {
+		return 0, fmt.Errorf("standing order requires a key")
+	}
+	now := clock.NowMillis()
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(`UPDATE threads SET standing_retracted=1, updated_at=?
+ WHERE to_kind='broadcast' AND standing=1 AND standing_retracted=0 AND to_target=? AND standing_key=?`,
+		now, project, key); err != nil {
+		return 0, err
+	}
+	res, err := tx.Exec(`INSERT INTO threads
+ (kind, from_agent, to_kind, to_target, subject, ref, status, intent, standing, standing_key, standing_retracted, created_at, updated_at, origin_project)
+ VALUES ('message', ?, 'broadcast', ?, '', '', NULL, '', 1, ?, 0, ?, ?, COALESCE((SELECT project FROM agents WHERE alias=?), ''))`,
+		from, project, key, now, now, from)
+	if err != nil {
+		return 0, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	if _, err := tx.Exec(`INSERT INTO entries (thread_id, from_agent, body, status_change, created_at) VALUES (?, ?, ?, NULL, ?)`,
+		id, from, body, now); err != nil {
+		return 0, err
+	}
+	return id, tx.Commit()
+}
+
+// RetractStandingOrder retracts the live standing order under (project, key) so
+// it greets no future session and drops out of ListStandingOrders. Idempotent:
+// an absent or already-retracted order changes nothing and returns (false, nil).
+func (s *Store) RetractStandingOrder(project, key string) (bool, error) {
+	now := clock.NowMillis()
+	res, err := s.db.Exec(`UPDATE threads SET standing_retracted=1, updated_at=?
+ WHERE to_kind='broadcast' AND standing=1 AND standing_retracted=0 AND to_target=? AND standing_key=?`,
+		now, project, key)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
+}
+
+// ListStandingOrders returns the live (non-retracted) keyed standing orders for
+// a project, each with its body (the order's first entry), sorted by key — the
+// audit/verify view the onboarding skill reads. Ad-hoc un-keyed standing
+// broadcasts (standing_key=”) are never returned.
+func (s *Store) ListStandingOrders(project string) ([]StandingOrder, error) {
+	rows, err := s.db.Query(`
+SELECT t.standing_key, t.from_agent, t.id, t.created_at,
+       (SELECT body FROM entries WHERE thread_id = t.id ORDER BY id LIMIT 1) AS body
+FROM threads t
+WHERE t.to_kind='broadcast' AND t.standing=1 AND t.standing_key != '' AND t.standing_retracted=0 AND t.to_target=?
+ORDER BY t.standing_key`, project)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := []StandingOrder{}
+	for rows.Next() {
+		var o StandingOrder
+		if err := rows.Scan(&o.Key, &o.From, &o.ThreadID, &o.CreatedAt, &o.Body); err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+
 // AppendEntry adds an entry and advances the thread's updated_at.
 func (s *Store) AppendEntry(threadID int64, fromAgent, body, statusChange string) (int64, error) {
 	now := clock.NowMillis()
@@ -233,7 +318,7 @@ unread AS (
     SELECT e.thread_id, COUNT(*) AS n
     FROM entries e
     JOIN recent r ON r.id = e.thread_id
-    WHERE ((r.standing = 1 AND e.id > COALESCE((SELECT last_read_standing_entry_id FROM agents WHERE alias=?), 0))
+    WHERE ((r.standing = 1 AND r.standing_retracted = 0 AND e.id > COALESCE((SELECT last_read_standing_entry_id FROM agents WHERE alias=?), 0))
         OR (r.standing = 0 AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)))
       AND e.from_agent != ?
     GROUP BY e.thread_id

--- a/internal/storetest/conformance.go
+++ b/internal/storetest/conformance.go
@@ -113,6 +113,15 @@ var cases = []conformanceCase{
 	{"StandingBroadcastComposesWithProjectScope", testStandingScoped},
 	{"StandingRejectedOnNonBroadcastTarget", testStandingRejectedNonBroadcast},
 
+	// Standing orders (keyed, retractable).
+	{"StandingOrderSetIsListableAndGreetsNewSession", testStandingOrderSetListGreet},
+	{"StandingOrderSetReplacesByKey", testStandingOrderReplace},
+	{"StandingOrderRetractStopsGreetingAndDropsFromList", testStandingOrderRetract},
+	{"StandingOrderRetractSparesAnAlreadyReadSession", testStandingOrderRetractSparesRead},
+	{"StandingOrderSetRejectsEmptyKey", testStandingOrderEmptyKey},
+	{"StandingOrderListIgnoresAdHocStandingBroadcast", testStandingOrderListIgnoresAdHoc},
+	{"StandingOrderScopedToItsProject", testStandingOrderScoped},
+
 	// Session-scoped unread.
 	{"SessionUnreadCountsDistinctThreads", testSessionUnreadDistinct},
 	{"SessionUnreadExcludesSiblingAuthors", testSessionUnreadSiblingAuthors},
@@ -1313,6 +1322,100 @@ func testStandingScoped(t *testing.T, s store.API) {
 func testStandingRejectedNonBroadcast(t *testing.T, s store.API) {
 	if _, err := s.CreateThread(store.Thread{Kind: "message", FromAgent: "sender", ToKind: "agent", ToTarget: "x", Standing: true}, "b"); err == nil {
 		t.Fatal("standing on a non-broadcast target must be rejected")
+	}
+}
+
+func testStandingOrderSetListGreet(t *testing.T, s store.API) {
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "rebase before push"); err != nil {
+		t.Fatalf("SetStandingOrder: %v", err)
+	}
+	orders, err := s.ListStandingOrders("web")
+	if err != nil || len(orders) != 1 || orders[0].Key != "invariants" || orders[0].Body != "rebase before push" {
+		t.Fatalf("list = %+v (%v), want one invariants order", orders, err)
+	}
+	mustRegister(t, s, store.Agent{Alias: "newbie", Project: "web"})
+	if n, err := s.UnreadCount("newbie"); err != nil || n != 1 {
+		t.Fatalf("new session should be greeted: unread=%d (%v), want 1", n, err)
+	}
+}
+
+func testStandingOrderReplace(t *testing.T, s store.API) {
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "v2"); err != nil {
+		t.Fatal(err)
+	}
+	orders, _ := s.ListStandingOrders("web")
+	if len(orders) != 1 || orders[0].Body != "v2" {
+		t.Fatalf("replace should leave one order (v2), got %+v", orders)
+	}
+	mustRegister(t, s, store.Agent{Alias: "newbie", Project: "web"})
+	if n, _ := s.UnreadCount("newbie"); n != 1 {
+		t.Fatalf("new session should see only the current order: unread=%d, want 1", n)
+	}
+}
+
+func testStandingOrderRetract(t *testing.T, s store.API) {
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "rules"); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := s.RetractStandingOrder("web", "invariants"); err != nil || !changed {
+		t.Fatalf("retract should change a row: changed=%v err=%v", changed, err)
+	}
+	if orders, _ := s.ListStandingOrders("web"); len(orders) != 0 {
+		t.Fatalf("retracted order must drop from list, got %+v", orders)
+	}
+	mustRegister(t, s, store.Agent{Alias: "newbie", Project: "web"})
+	if n, _ := s.UnreadCount("newbie"); n != 0 {
+		t.Fatalf("retracted order must not greet a new session: unread=%d, want 0", n)
+	}
+	if changed, _ := s.RetractStandingOrder("web", "invariants"); changed {
+		t.Fatal("second retract must be a no-op")
+	}
+}
+
+func testStandingOrderRetractSparesRead(t *testing.T, s store.API) {
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "rules"); err != nil {
+		t.Fatal(err)
+	}
+	mustRegister(t, s, store.Agent{Alias: "seen", Project: "web"})
+	if err := s.MarkRead("seen"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.RetractStandingOrder("web", "invariants"); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("seen"); n != 0 {
+		t.Fatalf("retract must not resurface for a session that read it: unread=%d, want 0", n)
+	}
+}
+
+func testStandingOrderEmptyKey(t *testing.T, s store.API) {
+	if _, err := s.SetStandingOrder("web", "", "author", "x"); err == nil {
+		t.Fatal("empty key must be rejected")
+	}
+}
+
+func testStandingOrderListIgnoresAdHoc(t *testing.T, s store.API) {
+	if _, err := s.CreateThread(store.Thread{Kind: "message", FromAgent: "a", ToKind: "broadcast", ToTarget: "web", Standing: true}, "ad-hoc"); err != nil {
+		t.Fatal(err)
+	}
+	if orders, _ := s.ListStandingOrders("web"); len(orders) != 0 {
+		t.Fatalf("ad-hoc standing broadcast must not be listed, got %+v", orders)
+	}
+}
+
+func testStandingOrderScoped(t *testing.T, s store.API) {
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "web rules"); err != nil {
+		t.Fatal(err)
+	}
+	mustRegister(t, s, store.Agent{Alias: "in-api", Project: "api"})
+	if n, _ := s.UnreadCount("in-api"); n != 0 {
+		t.Fatalf("other-project session must not see a scoped order: unread=%d, want 0", n)
+	}
+	if orders, _ := s.ListStandingOrders("api"); len(orders) != 0 {
+		t.Fatalf("api has no orders, got %+v", orders)
 	}
 }
 

--- a/internal/storetest/conformance.go
+++ b/internal/storetest/conformance.go
@@ -116,6 +116,7 @@ var cases = []conformanceCase{
 	// Standing orders (keyed, retractable).
 	{"StandingOrderSetIsListableAndGreetsNewSession", testStandingOrderSetListGreet},
 	{"StandingOrderSetReplacesByKey", testStandingOrderReplace},
+	{"StandingOrderSetReGreetsAnAlreadyReadSession", testStandingOrderReGreets},
 	{"StandingOrderRetractStopsGreetingAndDropsFromList", testStandingOrderRetract},
 	{"StandingOrderRetractSparesAnAlreadyReadSession", testStandingOrderRetractSparesRead},
 	{"StandingOrderSetRejectsEmptyKey", testStandingOrderEmptyKey},
@@ -1353,6 +1354,49 @@ func testStandingOrderReplace(t *testing.T, s store.API) {
 	mustRegister(t, s, store.Agent{Alias: "newbie", Project: "web"})
 	if n, _ := s.UnreadCount("newbie"); n != 1 {
 		t.Fatalf("new session should see only the current order: unread=%d, want 1", n)
+	}
+}
+
+// testStandingOrderReGreets: replacing an order under a key must re-greet a
+// session that already read the prior order — a mid-flight invariant fix
+// reaches RUNNING sessions, not only future ones. set creates a new standing
+// entry (id above the retracted one), so the read session's standing watermark
+// now sits below it and the updated order surfaces as unread — and ONLY the
+// updated order (the retracted prior is filtered).
+func testStandingOrderReGreets(t *testing.T, s store.API) {
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	mustRegister(t, s, store.Agent{Alias: "running", Project: "web"})
+	if err := s.MarkRead("running"); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("running"); n != 0 {
+		t.Fatalf("after reading v1, unread should be 0, got %d", n)
+	}
+	if _, err := s.SetStandingOrder("web", "invariants", "author", "v2"); err != nil {
+		t.Fatal(err)
+	}
+	if n, _ := s.UnreadCount("running"); n != 1 {
+		t.Fatalf("a replacement order must re-greet an already-read running session: unread=%d, want 1", n)
+	}
+	// And it surfaces the NEW order only: the running session's inbox shows the
+	// v2 order unread and the retracted v1 not unread.
+	in, err := s.Inbox("running")
+	if err != nil {
+		t.Fatal(err)
+	}
+	unreadBodies := map[string]bool{}
+	for _, th := range in {
+		if th.Unread > 0 {
+			_, entries, _ := s.GetThread(th.ID)
+			if len(entries) > 0 {
+				unreadBodies[entries[0].Body] = true
+			}
+		}
+	}
+	if len(unreadBodies) != 1 || !unreadBodies["v2"] {
+		t.Fatalf("running session must see only the v2 order unread, got %v", unreadBodies)
 	}
 }
 


### PR DESCRIPTION
## What & why

v2 follow-up to the standing-vs-live broadcast (#124). `tool-standards` confirmed (muster thread 346) that the shipped `--standing` broadcast is the right transport but the wrong *shape* for a durable standardization convention: it's append-only (can't replace or retract), and there's no way to list what greets a new session — so standing orders drift.

This adds a dedicated, keyed, retractable per-project **standing order** concept on top of the shipped standing-watermark delivery:

- `muster standing set <project> [--key k] "body"` — idempotent create-or-replace by `(project, key)` (default key `invariants`).
- `muster standing retract <project> [--key k]` — stops greeting new sessions; idempotent.
- `muster standing <project> [--json]` — lists live orders (the audit/verify seam the onboarding skill reads).

A standing order *is* a standing broadcast thread carrying an identity (`standing_key`) and a lifecycle (`standing_retracted`); the delivery path, register-time seed, and watermark are reused verbatim. The only new unread rule is a `standing_retracted = 0` guard on the standing branch.

Spec: `docs/superpowers/specs/2026-08-31-standing-orders-convention-design.md`
Plan: `docs/superpowers/plans/2026-08-31-standing-orders.md`

## Status

Spec + plan committed first so `tool-standards` can review the design against the standard. Implementation (store + dynamostore + conformance + daemon + MCP + CLI, both backends gated) lands as follow-up commits on this branch.
