### PR TITLE
muster status --json: side-effect-free per-alias inbox counts (proj ✉ column)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -890,6 +890,12 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 			return fail(err)
 		}
 		return ok(agents)
+	case "status":
+		status, err := d.s.StatusCounts()
+		if err != nil {
+			return fail(err)
+		}
+		return ok(map[string]any{"agents": status})
 	case "send_message":
 		from := str(a, "from")
 		toKind, toTarget := str(a, "to_kind"), str(a, "to_target")

--- a/internal/daemon/idem_test.go
+++ b/internal/daemon/idem_test.go
@@ -320,7 +320,7 @@ func TestGetInboxIsIdempotencyProtected(t *testing.T) {
 var readOps = map[string]bool{
 	"list_agents": true, "session_aliases": true, "session_unread": true,
 	"get_thread": true, "list_threads": true, "kv_get": true,
-	"standing_list": true,
+	"standing_list": true, "status": true,
 	// device_poll reads a watermark and answers with it; the watermark lives
 	// on the POLLING DEVICE (the daemon's own loop variable), never in the
 	// store, so two identical polls are indistinguishable to the bus.

--- a/internal/dynamostore/threads.go
+++ b/internal/dynamostore/threads.go
@@ -906,6 +906,33 @@ func (s *Store) Inbox(alias string) ([]store.Thread, error) {
 	return out, nil
 }
 
+// StatusCounts returns every registered alias's side-effect-free (unread,
+// action_required) counts — the DynamoDB mirror of the SQLite method. Pure
+// read: no MarkRead, no journaled peek. Reuses unreadFor per alias so the
+// counts match get_inbox exactly.
+func (s *Store) StatusCounts() ([]store.AliasStatus, error) {
+	ctx := backgroundCtx()
+	agents, err := s.ListAgents()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]store.AliasStatus, 0, len(agents))
+	for _, a := range agents {
+		threads, unread, err := s.unreadFor(ctx, a.Alias)
+		if err != nil {
+			return nil, err
+		}
+		action := 0
+		for id := range unread {
+			if effectiveIntent(strAttr(threads[id], "kind"), strAttr(threads[id], "intent")) == store.IntentAction {
+				action++
+			}
+		}
+		out = append(out, store.AliasStatus{Alias: a.Alias, Unread: len(unread), ActionRequired: action})
+	}
+	return out, nil
+}
+
 // UnreadCount returns how many threads concerning alias contain an entry newer
 // than its watermark written by someone else — the same predicate Inbox
 // annotates each row with, reached through the same code path.

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -166,6 +166,23 @@ form is the audit/verify seam.`,
 			Run:      cmdStanding,
 		},
 		{
+			Name:     "status",
+			Synopsis: "status [--json] [--alias <alias>]",
+			Summary:  "Side-effect-free per-alias inbox counts (unread, action_required).",
+			Help: `Prints every registered alias's unread count and the subset whose intent is
+action-requested. It is a PURE READ — it moves no read watermark and journals
+no peek — so a picker or attention column can poll it on a cadence without
+disturbing anyone's inbox state (unlike 'inbox', which marks read for the
+owning session).
+
+--json emits a top-level JSON array of {alias, unread, action_required}; the
+default is a plain 'unread action alias' table. --alias restricts to one
+alias. Departed aliases are included — their mail still waits.`,
+			Group:    GroupWatch,
+			NewFlags: newStatusFlags,
+			Run:      cmdStatus,
+		},
+		{
 			Name:     "agents",
 			Synopsis: "agents",
 			Summary:  "List registered agents, grouped by project, with live status.",

--- a/internal/humancli/registry_test.go
+++ b/internal/humancli/registry_test.go
@@ -15,7 +15,7 @@ import (
 // cmd/muster/main.go's routing comment.
 var wantCommandNames = []string{
 	"send", "nudge", "reply", "standing",
-	"agents", "inbox", "tasks", "thread", "events", "watch", "station",
+	"agents", "status", "inbox", "tasks", "thread", "events", "watch", "station",
 	"register", "become", "deregister", "label", "whereami", "device", "gc",
 	"serve", "mcp", "channel", "lambda", "hook", "update", "debug",
 }

--- a/internal/humancli/status.go
+++ b/internal/humancli/status.go
@@ -1,0 +1,77 @@
+package humancli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/schuettc/muster/internal/store"
+)
+
+func newStatusFlagsWithVals() (fs *flag.FlagSet, jsonOut *bool, alias *string) {
+	fs = flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut = fs.Bool("json", false, "emit a JSON array of {alias, unread, action_required}")
+	alias = fs.String("alias", "", "restrict the output to a single alias")
+	return fs, jsonOut, alias
+}
+
+func newStatusFlags() *flag.FlagSet {
+	fs, _, _ := newStatusFlagsWithVals()
+	return fs
+}
+
+// cmdStatus prints every alias's side-effect-free inbox counts (unread +
+// action_required) — a pure read that moves no watermark, so a picker can poll
+// it on a cadence. --json emits the array a tool parses; the default is a
+// human table.
+func cmdStatus(args []string, out io.Writer) error {
+	fs, jsonOut, alias := newStatusFlagsWithVals()
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("status", out)
+		}
+		return err
+	}
+	raw, err := callData("status", nil)
+	if err != nil {
+		return err
+	}
+	var res struct {
+		Agents []store.AliasStatus `json:"agents"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return err
+	}
+	rows := res.Agents
+	if *alias != "" {
+		filtered := rows[:0:0]
+		for _, r := range rows {
+			if r.Alias == *alias {
+				filtered = append(filtered, r)
+			}
+		}
+		rows = filtered
+	}
+	if *jsonOut {
+		// Top-level array is the wire contract proj reads (thread 354).
+		b, err := json.Marshal(rows)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(out, string(b))
+		return err
+	}
+	if len(rows) == 0 {
+		_, err = fmt.Fprintln(out, "no agents")
+		return err
+	}
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(out, "%-6d %-6d %s\n", r.Unread, r.ActionRequired, r.Alias); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/humancli/status_test.go
+++ b/internal/humancli/status_test.go
@@ -1,0 +1,50 @@
+package humancli
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/schuettc/muster/internal/store"
+)
+
+func TestStatusJSONRoundTrip(t *testing.T) {
+	startTestDaemon(t)
+	if _, err := callData("register_agent", map[string]any{"alias": "web/a", "model_type": "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := callData("send_message", map[string]any{"from": "sender", "to_kind": "agent", "to_target": "web/a", "intent": "action-requested", "body": "go"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := cmdStatus([]string{"--json"}, &buf); err != nil {
+		t.Fatalf("status --json: %v", err)
+	}
+	var rows []store.AliasStatus
+	if err := json.Unmarshal(buf.Bytes(), &rows); err != nil {
+		t.Fatalf("status --json is not a top-level array: %v (%s)", err, buf.String())
+	}
+	var got store.AliasStatus
+	for _, r := range rows {
+		if r.Alias == "web/a" {
+			got = r
+		}
+	}
+	if got.Alias != "web/a" || got.Unread != 1 || got.ActionRequired != 1 {
+		t.Fatalf("status for web/a = %+v, want unread 1 / action 1", got)
+	}
+
+	// --alias scopes to one row.
+	buf.Reset()
+	if err := cmdStatus([]string{"--json", "--alias", "web/a"}, &buf); err != nil {
+		t.Fatalf("status --alias: %v", err)
+	}
+	var scoped []store.AliasStatus
+	if err := json.Unmarshal(buf.Bytes(), &scoped); err != nil {
+		t.Fatal(err)
+	}
+	if len(scoped) != 1 || scoped[0].Alias != "web/a" {
+		t.Fatalf("--alias should return exactly web/a, got %+v", scoped)
+	}
+}

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -247,6 +247,48 @@ func (s *Store) DeleteAgent(alias string) error {
 	return err
 }
 
+// StatusCounts returns every registered alias's side-effect-free inbox counts
+// (unread + action_required), for a picker/attention column that polls on a
+// cadence. It moves NO watermark and journals NO peek — a pure read, which is
+// exactly why a poller uses it instead of get_inbox. Departed aliases are
+// included (their mail still waits), matching ListAgents. The per-alias count
+// reuses the canonical unread predicate (standing/retracted-aware), so it can
+// never disagree with UnreadCount/get_inbox about what is unread.
+func (s *Store) StatusCounts() ([]AliasStatus, error) {
+	agents, err := s.ListAgents()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AliasStatus, 0, len(agents))
+	for _, a := range agents {
+		unread, action, err := s.unreadAndAction(a.Alias)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, AliasStatus{Alias: a.Alias, Unread: unread, ActionRequired: action})
+	}
+	return out, nil
+}
+
+// unreadAndAction is UnreadCount plus the action-requested subset in one query:
+// the count of threads concerning alias with an unread entry, and how many of
+// those have effective intent action-requested. Same predicate as UnreadCount
+// (they must never drift), read-only.
+func (s *Store) unreadAndAction(alias string) (unread, action int, err error) {
+	err = s.db.QueryRow(`
+SELECT COUNT(*),
+       COUNT(CASE WHEN `+effectiveIntent+` = 'action-requested' THEN 1 END)
+FROM threads
+WHERE `+threadConcerns+`
+  AND EXISTS (SELECT 1 FROM entries e
+              WHERE e.thread_id = threads.id
+                AND ((threads.standing = 1 AND threads.standing_retracted = 0 AND e.id > COALESCE((SELECT last_read_standing_entry_id FROM agents WHERE alias=?), 0))
+                  OR (threads.standing = 0 AND e.id > COALESCE((SELECT last_read_entry_id FROM agents WHERE alias=?), 0)))
+                AND e.from_agent != ?)`,
+		alias, alias, alias, alias, alias, alias, alias).Scan(&unread, &action)
+	return unread, action, err
+}
+
 // UnreadCount returns how many threads concerning alias (threadConcerns —
 // matching Inbox exactly) contain an entry with id greater than the agent's
 // entry-ID read watermark (last_read_entry_id) that was written by someone

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -113,6 +113,10 @@ type API interface {
 	Inbox(alias string) ([]Thread, error)
 	MarkRead(alias string) error
 	UnreadCount(alias string) (int, error)
+	// StatusCounts returns every alias's side-effect-free (unread,
+	// action_required) counts — a pure read for a polling picker; see the
+	// method comment on Store.
+	StatusCounts() ([]AliasStatus, error)
 	SessionUnread(deviceID, socketPath, sessionID string, sessionCreated int64) (total, action int, err error)
 	SessionAliasLineage(deviceID, socketPath, sessionID string, sessionCreated int64) ([]string, error)
 	// FindConversation answers "which live row IS this conversation" (spec

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -176,6 +176,17 @@ type StandingOrder struct {
 	CreatedAt int64  `json:"created_at"`
 }
 
+// AliasStatus is one alias's side-effect-free inbox counts, as returned by
+// StatusCounts: the unread message/task count and the subset whose effective
+// intent is action-requested. It is a pure read — no watermark moves — so a
+// picker can poll it on a cadence. Field names are the stable wire contract
+// (proj's ✉ column reads them verbatim; see muster thread 354).
+type AliasStatus struct {
+	Alias          string `json:"alias"`
+	Unread         int    `json:"unread"`
+	ActionRequired int    `json:"action_required"`
+}
+
 // Entry is one append-only message within a thread.
 type Entry struct {
 	ID           int64  `json:"id"`

--- a/internal/storetest/conformance.go
+++ b/internal/storetest/conformance.go
@@ -96,6 +96,7 @@ var cases = []conformanceCase{
 	{"UnreadCountRespectsWatermark", testUnreadWatermark},
 	{"BroadcastCountsAsUnread", testBroadcastUnread},
 	{"MarkReadUnknownAliasIsNoOp", testMarkReadUnknown},
+	{"StatusCountsPerAliasSideEffectFree", testStatusCounts},
 	{"InboxMatchesAgentRoleBroadcastAndOriginated", testInboxArms},
 	{"InboxIncludesOriginatedThreadsForUnregisteredAlias", testInboxOriginatedUnregistered},
 	{"UnreadCountOriginatorSeesPeerReply", testUnreadOriginatorSeesReply},
@@ -990,6 +991,44 @@ func testBroadcastUnread(t *testing.T, s store.API) {
 	}
 	if n != 1 {
 		t.Fatalf("broadcast unread = %d, want 1", n)
+	}
+}
+
+// testStatusCounts: StatusCounts reports per-alias unread + action_required
+// for every registered alias, and is side-effect-free — it moves no watermark,
+// so an agent's own unread is unchanged after the call.
+func testStatusCounts(t *testing.T, s store.API) {
+	mustRegister(t, s, store.Agent{Alias: "a"})
+	mustRegister(t, s, store.Agent{Alias: "b"})
+	// two unread for a: one action-requested, one fyi.
+	mustThread(t, s, store.Thread{Kind: "message", FromAgent: "sender", ToKind: "agent", ToTarget: "a", Intent: "action-requested"}, "do this")
+	mustThread(t, s, store.Thread{Kind: "message", FromAgent: "sender", ToKind: "agent", ToTarget: "a", Intent: "fyi"}, "note")
+
+	byAlias := func() map[string]store.AliasStatus {
+		st, err := s.StatusCounts()
+		if err != nil {
+			t.Fatalf("StatusCounts: %v", err)
+		}
+		m := map[string]store.AliasStatus{}
+		for _, r := range st {
+			m[r.Alias] = r
+		}
+		return m
+	}
+	m := byAlias()
+	if m["a"].Unread != 2 || m["a"].ActionRequired != 1 {
+		t.Fatalf("a status = %+v, want unread 2 / action 1", m["a"])
+	}
+	if m["b"].Unread != 0 || m["b"].ActionRequired != 0 {
+		t.Fatalf("b status = %+v, want 0/0", m["b"])
+	}
+	// Side-effect-free: a's own unread is unchanged after StatusCounts (no
+	// watermark moved), and a second call agrees.
+	if n, _ := s.UnreadCount("a"); n != 2 {
+		t.Fatalf("StatusCounts must not move a's watermark: UnreadCount=%d, want 2", n)
+	}
+	if m2 := byAlias(); m2["a"].Unread != 2 || m2["a"].ActionRequired != 1 {
+		t.Fatalf("second StatusCounts disagreed: %+v", m2["a"])
 	}
 }
 


### PR DESCRIPTION
## What & why

tackle's proj picker wants a side-effect-free per-alias unread/attention count to light its ✉ column (muster thread 354). `muster inbox <alias>` can't be used — it marks read / journals a peek for the owning session. This adds a pure read.

## `muster status [--json] [--alias <alias>]`

- Prints every registered alias's `unread` and `action_required` (the subset of unread threads whose effective intent is action-requested).
- **Side-effect-free**: moves no read watermark, journals no peek — safe to poll on a cadence.
- `--json` emits the top-level array proj reads verbatim: `[{"alias":"<project>/<label>","unread":N,"action_required":M}, ...]`; default is a plain `unread action alias` table. `--alias` scopes to one row. Departed aliases included (their mail still waits).

Field names (`alias` / `unread` / `action_required`) and the top-level-array shape are exactly tackle's contract — confirmed verbatim on thread 354, no parser change on their end.

## Mechanism

- `store.StatusCounts()` (both backends, conformance-gated): per-alias unread + action count, reusing the canonical unread predicate (standing/retracted-aware) so it can never disagree with `UnreadCount`/`get_inbox`.
- Daemon read op `status`; CLI `status` command; classified read-only (`readOps`).

## Testing

- Conformance (both stores): correct per-alias unread + action_required, and side-effect-free (a's watermark unchanged after the call, second call agrees).
- CLI round-trip: `--json` is a valid top-level array with the right counts; `--alias` scopes.
- `just verify` + `just verify-dynamo` green.
