### PR TITLE
ci: bump GitHub Actions to latest majors (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
-      - uses: extractions/setup-just@v2
+      - uses: extractions/setup-just@v4
       - name: Cache golangci-lint binary
         id: cache-golangci
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/go/bin/golangci-lint
           key: golangci-lint-v2.12.2-${{ runner.os }}
@@ -45,8 +45,8 @@ jobs:
         image: amazon/dynamodb-local
         ports: ["8000:8000"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
       # amazon/dynamodb-local declares no HEALTHCHECK, so the runner reports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     # see the Developer ID certificate at all.
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Resolve tag and mode
         id: rel
         env:
@@ -89,7 +89,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
             echo "create=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         if: steps.rel.outputs.skip == 'false'
         with:
           go-version-file: go.mod
@@ -242,7 +242,7 @@ jobs:
       # CreateInvalidation on the muster.tools distribution — no other access.
       - name: Configure AWS credentials (downloads)
         if: steps.rel.outputs.skip == 'false'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.MUSTER_RELEASE_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -20,7 +20,7 @@ jobs:
   version-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # need the base branch for the diff
       - name: VERSION bumped or no-release label


### PR DESCRIPTION
Silences the Node 20 deprecation warning by moving to action majors that target Node 24: checkout@v7, setup-go@v7, cache@v6, configure-aws-credentials@v6, setup-just@v4. Workflow-file-only change.