### PR TITLE
humancli: add commands [--json] for family CLI discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/muesli/termenv v0.16.0
-	github.com/schuettc/tools-common v0.1.0
+	github.com/schuettc/tools-common v0.3.0
 	modernc.org/sqlite v1.53.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/schuettc/tools-common v0.1.0 h1:a4SovSnGSqzpTRj8XX1eK0lTrl3+2Mw9oixZSbQdZ1c=
-github.com/schuettc/tools-common v0.1.0/go.mod h1:0JSstEbB+vc5PLi3PA5d2VU9FkyROMYTiNpRU8UwYFM=
+github.com/schuettc/tools-common v0.3.0 h1:rKnCfx8DPd3+vE6rI8V8z4q1p1t5JFo4aqyGet2zWDE=
+github.com/schuettc/tools-common v0.3.0/go.mod h1:0JSstEbB+vc5PLi3PA5d2VU9FkyROMYTiNpRU8UwYFM=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=

--- a/internal/humancli/commands.go
+++ b/internal/humancli/commands.go
@@ -1,0 +1,74 @@
+package humancli
+
+import (
+	"errors"
+	"flag"
+	"io"
+
+	tools "github.com/schuettc/tools-common"
+)
+
+// newCommandsFlagsWithVals declares commands' flags and returns typed access
+// to their values — shared by cmdCommands (real parsing) and newCommandsFlags
+// (registry help/man rendering).
+func newCommandsFlagsWithVals() (fs *flag.FlagSet, jsonOut *bool) {
+	fs = flag.NewFlagSet("commands", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	jsonOut = fs.Bool("json", false, "emit the machine-readable command index instead of the grouped listing")
+	return fs, jsonOut
+}
+
+// newCommandsFlags builds commands' flag.FlagSet for registry-driven
+// help/man rendering.
+func newCommandsFlags() *flag.FlagSet {
+	fs, _ := newCommandsFlagsWithVals()
+	return fs
+}
+
+// cmdCommands prints every muster command. Bare, it's the same grouped
+// listing as bare `muster`/`muster help`; --json instead emits the
+// .tools-family machine-readable command index (tools.CommandsJSON) that
+// kempt, tackle, and galley already expose via their own `commands --json` —
+// the one missing piece for a coding agent to discover muster's surface
+// without shelling out to `muster help` and scraping text.
+func cmdCommands(args []string, out io.Writer) error {
+	fs, jsonOut := newCommandsFlagsWithVals()
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("commands", out)
+		}
+		return err
+	}
+	if !*jsonOut {
+		Usage(out)
+		return nil
+	}
+	adapted := make([]tools.Command, 0, len(Registry))
+	for _, c := range Registry {
+		tc := tools.Command{
+			Name:     c.Name,
+			Synopsis: c.Synopsis,
+			Summary:  c.Summary,
+			Help:     c.Help,
+			Group:    groupHeading[c.Group],
+			NewFlags: c.NewFlags,
+		}
+		if c.Run != nil {
+			// tools.CommandsJSON derives selfRouted from Run == nil, so a
+			// dispatchable muster command (Run != nil here) must also carry a
+			// non-nil tools.Command.Run, even though nothing ever calls it —
+			// this adapter only feeds CommandsJSON, never Dispatch. serve/
+			// mcp/debug/lambda/channel have Run == nil in the muster Registry
+			// (cmd/muster's main() owns them directly) and are left nil here
+			// too, so they report selfRouted: true, matching reality.
+			tc.Run = func([]string, io.Writer, io.Writer) error { return nil }
+		}
+		adapted = append(adapted, tc)
+	}
+	b, err := tools.CommandsJSON("muster", adapted)
+	if err != nil {
+		return err
+	}
+	_, err = out.Write(append(b, '\n'))
+	return err
+}

--- a/internal/humancli/commands_test.go
+++ b/internal/humancli/commands_test.go
@@ -1,0 +1,109 @@
+package humancli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// commandsJSONRow mirrors the family shape tools.CommandsJSON emits, for
+// unmarshaling in tests.
+type commandsJSONRow struct {
+	Name       string `json:"name"`
+	Synopsis   string `json:"synopsis"`
+	Summary    string `json:"summary"`
+	Group      string `json:"group"`
+	Help       string `json:"help"`
+	SelfRouted bool   `json:"selfRouted"`
+	Flags      []struct {
+		Name    string `json:"name"`
+		Type    string `json:"type"`
+		Default string `json:"default"`
+		Usage   string `json:"usage"`
+	} `json:"flags"`
+}
+
+// TestCommandsJSONCoversRegistry checks `muster commands --json` against the
+// family shape (tools.CommandsJSON) and full Registry coverage: every
+// Registry command appears exactly once, a dispatchable command (Run != nil)
+// reports selfRouted: false, a process-mode command (Run == nil, owned
+// directly by cmd/muster's main()) reports selfRouted: true, and a
+// flag-bearing command's flags are populated.
+func TestCommandsJSONCoversRegistry(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"commands", "--json"}, &buf); err != nil {
+		t.Fatalf("commands --json: unexpected error: %v", err)
+	}
+
+	var rows []commandsJSONRow
+	if err := json.Unmarshal(buf.Bytes(), &rows); err != nil {
+		t.Fatalf("commands --json output does not unmarshal as a JSON array: %v\noutput:\n%s", err, buf.String())
+	}
+
+	if len(rows) != len(Registry) {
+		t.Fatalf("commands --json listed %d commands, Registry has %d", len(rows), len(Registry))
+	}
+
+	byName := make(map[string]commandsJSONRow, len(rows))
+	for _, r := range rows {
+		byName[r.Name] = r
+	}
+	for _, c := range Registry {
+		if _, ok := byName[c.Name]; !ok {
+			t.Errorf("commands --json is missing Registry command %q", c.Name)
+		}
+	}
+
+	send, ok := byName["send"]
+	if !ok {
+		t.Fatal("commands --json missing \"send\"")
+	}
+	if send.SelfRouted {
+		t.Errorf("\"send\" (Run != nil in Registry) reported selfRouted: true, want false")
+	}
+
+	serve, ok := byName["serve"]
+	if !ok {
+		t.Fatal("commands --json missing \"serve\"")
+	}
+	if !serve.SelfRouted {
+		t.Errorf("\"serve\" (Run == nil in Registry, owned by cmd/muster's main()) reported selfRouted: false, want true")
+	}
+
+	status, ok := byName["status"]
+	if !ok {
+		t.Fatal("commands --json missing \"status\"")
+	}
+	if len(status.Flags) == 0 {
+		t.Errorf("\"status\" has flags in its NewFlags constructor but commands --json reported none")
+	}
+	foundJSONFlag := false
+	for _, fl := range status.Flags {
+		if fl.Name == "json" {
+			foundJSONFlag = true
+		}
+	}
+	if !foundJSONFlag {
+		t.Errorf("\"status\" flags missing the known --json flag: %+v", status.Flags)
+	}
+}
+
+// TestCommandsBareShowsGroupedListing checks that bare `muster commands`
+// (no --json) renders the same grouped usage listing as bare `muster` /
+// `muster help`.
+func TestCommandsBareShowsGroupedListing(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Dispatch([]string{"commands"}, &buf); err != nil {
+		t.Fatalf("commands: unexpected error: %v", err)
+	}
+	out := buf.String()
+	for _, heading := range []string{"Talk:", "Watch:", "Identity:", "Plumbing:"} {
+		if !strings.Contains(out, heading) {
+			t.Errorf("commands output missing group heading %q:\n%s", heading, out)
+		}
+	}
+	if !strings.Contains(out, "commands") {
+		t.Errorf("commands output does not list itself:\n%s", out)
+	}
+}

--- a/internal/humancli/registry.go
+++ b/internal/humancli/registry.go
@@ -485,6 +485,21 @@ exploring or debugging the wire protocol — not part of the stable operator
 surface.`,
 			Group: GroupPlumbing,
 		},
+		{
+			Name:     "commands",
+			Synopsis: "commands [--json]",
+			Summary:  "List every command (--json for the machine-readable index).",
+			Help: `Bare, this is the same grouped listing as bare 'muster' / 'muster help'.
+--json instead emits the .tools-family command index (name, synopsis,
+summary, group, help, selfRouted, flags) that kempt, tackle, and galley
+already expose the same way — so a coding agent can discover muster's full
+command surface, including the process-mode commands (serve/mcp/debug/
+lambda/channel) that main() dispatches directly and so report
+selfRouted: true, without shelling out to 'muster help' and scraping text.`,
+			Group:    GroupPlumbing,
+			NewFlags: newCommandsFlags,
+			Run:      cmdCommands,
+		},
 	}
 }
 

--- a/internal/humancli/registry_test.go
+++ b/internal/humancli/registry_test.go
@@ -17,7 +17,7 @@ var wantCommandNames = []string{
 	"send", "nudge", "reply", "standing",
 	"agents", "status", "inbox", "tasks", "thread", "events", "watch", "station",
 	"register", "become", "deregister", "label", "whereami", "device", "gc",
-	"serve", "mcp", "channel", "lambda", "hook", "update", "debug",
+	"serve", "mcp", "channel", "lambda", "hook", "update", "debug", "commands",
 }
 
 // mainOwnedCommands are the Registry names cmd/muster's main() dispatches


### PR DESCRIPTION
## What

Adds `muster commands [--json]` and bumps the tools-common pin to v0.3.0. This is the final, minimal step of the `.tools`-family CLI consolidation.

## Why

muster is used heavily by coding agents. kempt, tackle, and galley all now expose a machine-readable command index via `commands --json` (the tools-common v0.3.0 shape). muster already had a rich registry-based help system (grouped usage, per-command help, man page, anti-drift flag constructors) — it was the one family CLI **not** offering that index. This closes the gap without touching muster's help system, dispatch, or exit-code handling.

Deliberately **not** a migration onto `tools.App`: muster's registry help already equals or exceeds v0.3.0, and a generic port would lose its bespoke man-page sections and the main()-level daemon/MCP/lambda/channel bypass. This is alignment, not replacement.

## Changes

- **tools-common v0.1.0 → v0.3.0** (for `tools.CommandsJSON`/`tools.FlagsOf`; the existing `tools.New`/`Config`/`Version`/`SelfUpdate` call sites are unchanged across versions).
- **`commands` Registry row** (Plumbing group). Bare, it prints the same grouped listing as bare `muster` / `muster help`; `--json` emits the family index (`name, synopsis, summary, group, help, selfRouted, flags[]`), adapting the **full** Registry — including the process-mode commands (serve/mcp/debug/lambda/channel) that `cmd/muster`'s main() owns directly, which correctly report `selfRouted: true`.
- Flags declared via one shared `newCommandsFlagsWithVals()` constructor (muster's anti-drift idiom), used by both `Run` and the registry's help/man rendering.
- Tests: full Registry coverage, `selfRouted` discrimination (serve vs send), populated flags, and the bare grouped listing. `wantCommandNames` invariant updated.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `golangci-lint run ./...` **0 issues** · `go test ./...` pass. Spot-checked: `commands --json` (27 commands, valid array), `commands` (grouped), `commands -h` (exit 0), bare `muster`/`muster help` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
