### PR TITLE
muster: close four bus-invariant gaps (rebased from #111)

### DIFF
--- a/cmd/muster/main.go
+++ b/cmd/muster/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -167,10 +168,19 @@ func channelInterval() time.Duration {
 // every client above the daemon is identical either way. Local mode touches no
 // remote code at all, and neither mode links the AWS SDK.
 func runServe() int {
-	if err := os.MkdirAll(paths.Home(), 0o755); err != nil {
+	if err := paths.EnsureHome(); err != nil {
 		fmt.Fprintln(os.Stderr, "muster: mkdir:", err)
 		return 1
 	}
+	serveLock, acquired, err := acquireServeLock()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "muster: serve lock:", err)
+		return 1
+	}
+	if !acquired {
+		return 0
+	}
+	defer func() { _ = serveLock.Close() }()
 	notifier := wake.NewTmuxNotifier("@muster_inbox", 500*time.Millisecond)
 
 	var d *daemon.Daemon
@@ -208,6 +218,25 @@ func runServe() int {
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	<-sig
 	return 0
+}
+
+// acquireServeLock serializes daemon ownership of the local socket. A client
+// may auto-spawn serve concurrently with another first client; only the owner
+// may clear a stale socket and bind a new listener.
+func acquireServeLock() (*os.File, bool, error) {
+	f, err := os.OpenFile(filepath.Join(paths.Home(), "serve.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			_ = f.Close()
+			return nil, false, nil
+		}
+		_ = f.Close()
+		return nil, false, err
+	}
+	return f, true, nil
 }
 
 // serveRemote builds the remote-mode daemon: it keeps the unix socket and the

--- a/cmd/muster/main_test.go
+++ b/cmd/muster/main_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/schuettc/muster/internal/daemon"
+	"github.com/schuettc/muster/internal/mustertest"
 	"github.com/schuettc/muster/internal/paths"
 	"github.com/schuettc/muster/internal/store"
 )
@@ -250,7 +251,13 @@ func TestRemoteBackendRequiresItsToken(t *testing.T) {
 // TestSecondServeLeavesFirstDaemonSocketOwned proves that an auto-spawned
 // duplicate exits before it can unlink the live daemon's socket.
 func TestSecondServeLeavesFirstDaemonSocketOwned(t *testing.T) {
-	home := t.TempDir()
+	// ShortHome, not t.TempDir(): the daemon socket path must stay under the
+	// unix sun_path ~104-char limit, which t.TempDir() exceeds on macOS.
+	home, cleanup, err := mustertest.ShortHome()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
 	t.Setenv("MUSTER_HOME", home)
 	if err := os.MkdirAll(home, 0o755); err != nil {
 		t.Fatal(err)

--- a/cmd/muster/main_test.go
+++ b/cmd/muster/main_test.go
@@ -2,12 +2,20 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
+	"time"
+
+	"github.com/schuettc/muster/internal/daemon"
+	"github.com/schuettc/muster/internal/paths"
+	"github.com/schuettc/muster/internal/store"
 )
 
 // TestMain builds the shared binary lazily (see builtBinary) and removes its
@@ -195,6 +203,21 @@ func TestUnknownBackendIsAnErrorNotAFallback(t *testing.T) {
 	}
 }
 
+func TestServeRepairsHomeDirectoryMode(t *testing.T) {
+	home := t.TempDir()
+	if err := os.Chmod(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _ = runEnv(t, []string{"MUSTER_HOME=" + home, "MUSTER_BACKEND=hosted"}, "serve")
+	info, err := os.Stat(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("MUSTER_HOME mode = %#o, want 0700", got)
+	}
+}
+
 // TestRemoteBackendRequiresItsURL: remote mode with no endpoint has nowhere to
 // forward to, and must say which variable is missing rather than start and
 // fail on the first op.
@@ -222,6 +245,54 @@ func TestRemoteBackendRequiresItsToken(t *testing.T) {
 	if !strings.Contains(errOut, "remote-token") {
 		t.Errorf("stderr = %q, want it to name the token file", errOut)
 	}
+}
+
+// TestSecondServeLeavesFirstDaemonSocketOwned proves that an auto-spawned
+// duplicate exits before it can unlink the live daemon's socket.
+func TestSecondServeLeavesFirstDaemonSocketOwned(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("MUSTER_HOME", home)
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s, err := store.Open(paths.DBPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	first, err := daemon.Serve(paths.SocketPath(), s, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+
+	lock, err := os.OpenFile(filepath.Join(home, "serve.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lock.Close() })
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) })
+
+	bin := builtBinary(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, "serve")
+	cmd.Env = append(os.Environ(), "MUSTER_HOME="+home)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctx.Err() != nil {
+			t.Fatalf("second serve did not exit while the first owned serve.lock: %s", out)
+		}
+		t.Fatalf("second serve: %v: %s", err, out)
+	}
+
+	conn, err := net.DialTimeout("unix", paths.SocketPath(), 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("first daemon socket was unlinked: %v", err)
+	}
+	_ = conn.Close()
 }
 
 // TestBareInvocationUnderLambdaRuntimeRoutesToLambda pins the dispatch

--- a/internal/cli/humancli.go
+++ b/internal/cli/humancli.go
@@ -18,8 +18,10 @@ import (
 	"github.com/schuettc/muster/internal/device"
 	"github.com/schuettc/muster/internal/harnessenv"
 	"github.com/schuettc/muster/internal/nudge"
+	"github.com/schuettc/muster/internal/nudgeguard"
 	"github.com/schuettc/muster/internal/paths"
 	"github.com/schuettc/muster/internal/proto"
+	"github.com/schuettc/muster/internal/store"
 	"github.com/schuettc/muster/internal/tmuxenv"
 	"github.com/schuettc/muster/internal/version"
 )
@@ -40,7 +42,9 @@ type agentFull struct {
 	// still alive, pane reaped underneath it) from a fully dead one, so it
 	// can refuse the dead-pane case with a remedy instead of a doomed
 	// send-keys.
-	SessionCreated int64 `json:"session_created"`
+	SessionCreated int64  `json:"session_created"`
+	DeviceID       string `json:"device_id"`
+	DeviceName     string `json:"device_name"`
 	// HarnessSessionID mirrors agentRow's own copy (see store.Agent.HarnessSessionID)
 	// — stampHarnessLinks reads it via hookGetAgent to skip a row that already
 	// has a link.
@@ -759,16 +763,11 @@ func cmdNudge(args []string, out io.Writer) error {
 		return fmt.Errorf("no agent registered as %q", alias)
 	}
 	ag := res.Agent
-	// A stored pane can go stale between registration and nudge — most
-	// commonly a reaped teammate's pane, closed out from under a row that
-	// still names it. Refuse rather than guess: with teammate panes sharing
-	// the session, typing into whatever pane happens to be there next is
-	// worse than failing loudly (spec §3, no auto-retargeting). The row
-	// heals itself the next time that session starts/resumes and
-	// re-registers, or the operator can re-register from the live pane now.
-	if ag.SocketPath != "" && !tmuxenv.IsPaneAlive(ag.SocketPath, ag.PaneID) &&
-		tmuxenv.IsSessionAlive(ag.SocketPath, ag.SessionID, ag.SessionCreated) {
-		return fmt.Errorf("nudge %s: stored pane %s is gone but its session is alive — the row heals at the session's next start/resume (or re-register from the live pane); refusing to type into a guessed pane", dispAlias(ag.Alias), ag.PaneID)
+	if err := nudgeguard.Check(store.Agent{
+		Alias: ag.Alias, DeviceID: ag.DeviceID, DeviceName: ag.DeviceName,
+		SocketPath: ag.SocketPath, SessionID: ag.SessionID, SessionCreated: ag.SessionCreated, PaneID: ag.PaneID,
+	}, dispAlias(ag.Alias)); err != nil {
+		return err
 	}
 	// session_name is mutable — tmux lets an operator rename a session at any
 	// time — so the stored (registration-time) snapshot goes stale the

--- a/internal/cli/humancli_test.go
+++ b/internal/cli/humancli_test.go
@@ -500,13 +500,16 @@ func TestNudgeCommandRejectsUnknownAlias(t *testing.T) {
 func TestNudgeCommandResolvesAndNudges(t *testing.T) {
 	startTestDaemon(t)
 	// register an agent with a pane via the daemon op directly
-	if _, err := callData("register_agent", map[string]any{"alias": "rev", "role": "reviewer", "model_type": "codex", "socket_path": "/s", "pane_id": "%2", "session_id": "$1"}); err != nil {
+	if _, err := callData("register_agent", map[string]any{"alias": "rev", "role": "reviewer", "model_type": "codex", "socket_path": "/s", "pane_id": "%2", "session_id": "$1", "session_created": 100}); err != nil {
 		t.Fatal(err)
 	}
 	var recorded [][]string
 	origNudge := nudgeRun
 	nudgeRun = func(args ...string) error { recorded = append(recorded, args); return nil }
 	t.Cleanup(func() { nudgeRun = origNudge })
+	origRun := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{"#{session_created}": "100", "#{pane_id}": "%2"})
+	t.Cleanup(func() { tmuxenv.Run = origRun })
 
 	var buf bytes.Buffer
 	if err := Dispatch([]string{"nudge", "rev"}, &buf); err != nil {
@@ -567,7 +570,7 @@ func TestNudgePrintsLiveSessionName(t *testing.T) {
 	startTestDaemon(t)
 	if _, err := callData("register_agent", map[string]any{
 		"alias": "rev", "role": "reviewer", "model_type": "codex",
-		"socket_path": "/s", "pane_id": "%2", "session_id": "$1",
+		"socket_path": "/s", "pane_id": "%2", "session_id": "$1", "session_created": 100,
 		"session_name": "stale-name",
 	}); err != nil {
 		t.Fatal(err)
@@ -578,7 +581,7 @@ func TestNudgePrintsLiveSessionName(t *testing.T) {
 	t.Cleanup(func() { nudgeRun = origNudge })
 
 	origRun := tmuxenv.Run
-	tmuxenv.Run = hookRun(map[string]string{"#{session_name}": "renamed-live"})
+	tmuxenv.Run = hookRun(map[string]string{"#{session_created}": "100", "#{pane_id}": "%2", "#{session_name}": "renamed-live"})
 	t.Cleanup(func() { tmuxenv.Run = origRun })
 
 	var buf bytes.Buffer
@@ -600,7 +603,7 @@ func TestNudgeFallsBackToStoredSessionNameWhenLiveQueryFails(t *testing.T) {
 	startTestDaemon(t)
 	if _, err := callData("register_agent", map[string]any{
 		"alias": "rev", "role": "reviewer", "model_type": "codex",
-		"socket_path": "/s", "pane_id": "%2", "session_id": "$1",
+		"socket_path": "/s", "pane_id": "%2", "session_id": "$1", "session_created": 100,
 		"session_name": "stored-name",
 	}); err != nil {
 		t.Fatal(err)
@@ -611,7 +614,16 @@ func TestNudgeFallsBackToStoredSessionNameWhenLiveQueryFails(t *testing.T) {
 	t.Cleanup(func() { nudgeRun = origNudge })
 
 	origRun := tmuxenv.Run
-	tmuxenv.Run = func(_ ...string) (string, error) { return "", fmt.Errorf("no tmux") }
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_created}":
+			return "100", nil
+		case "#{pane_id}":
+			return "%2", nil
+		default:
+			return "", fmt.Errorf("no tmux")
+		}
+	}
 	t.Cleanup(func() { tmuxenv.Run = origRun })
 
 	var buf bytes.Buffer
@@ -627,12 +639,15 @@ func TestNudgeFallsBackToStoredSessionNameWhenLiveQueryFails(t *testing.T) {
 // row exists for the target alias (best-effort log_event call from cmdNudge).
 func TestNudgeSelfReportsJournalRow(t *testing.T) {
 	startTestDaemon(t)
-	if _, err := callData("register_agent", map[string]any{"alias": "rev", "role": "reviewer", "model_type": "codex", "socket_path": "/s", "pane_id": "%2", "session_id": "$1"}); err != nil {
+	if _, err := callData("register_agent", map[string]any{"alias": "rev", "role": "reviewer", "model_type": "codex", "socket_path": "/s", "pane_id": "%2", "session_id": "$1", "session_created": 100}); err != nil {
 		t.Fatal(err)
 	}
 	origNudge := nudgeRun
 	nudgeRun = func(_ ...string) error { return nil }
 	t.Cleanup(func() { nudgeRun = origNudge })
+	origRun := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{"#{session_created}": "100", "#{pane_id}": "%2"})
+	t.Cleanup(func() { tmuxenv.Run = origRun })
 
 	var buf bytes.Buffer
 	if err := Dispatch([]string{"nudge", "rev"}, &buf); err != nil {
@@ -662,12 +677,15 @@ func TestNudgeSelfReportsJournalRow(t *testing.T) {
 // the journal records detail="typed" (not submitted).
 func TestNudgeSelfReportsTypedWhenNoSubmit(t *testing.T) {
 	startTestDaemon(t)
-	if _, err := callData("register_agent", map[string]any{"alias": "rev", "role": "reviewer", "model_type": "codex", "socket_path": "/s", "pane_id": "%2", "session_id": "$1"}); err != nil {
+	if _, err := callData("register_agent", map[string]any{"alias": "rev", "role": "reviewer", "model_type": "codex", "socket_path": "/s", "pane_id": "%2", "session_id": "$1", "session_created": 100}); err != nil {
 		t.Fatal(err)
 	}
 	origNudge := nudgeRun
 	nudgeRun = func(_ ...string) error { return nil }
 	t.Cleanup(func() { nudgeRun = origNudge })
+	origRun := tmuxenv.Run
+	tmuxenv.Run = hookRun(map[string]string{"#{session_created}": "100", "#{pane_id}": "%2"})
+	t.Cleanup(func() { tmuxenv.Run = origRun })
 
 	var buf bytes.Buffer
 	if err := Dispatch([]string{"nudge", "--no-submit", "rev"}, &buf); err != nil {
@@ -796,7 +814,7 @@ func TestNudgeSessionNameFallbackStripsTheDevicePrefix(t *testing.T) {
 	t.Setenv("MUSTER_DEVICE_NAME", "testdev")
 	if _, err := callData("register_agent", map[string]any{
 		"alias": "testdev-dotfiles/main", "role": "reviewer", "model_type": "codex",
-		"socket_path": "/s", "pane_id": "%2", "session_id": "$1",
+		"socket_path": "/s", "pane_id": "%2", "session_id": "$1", "session_created": 100,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -806,7 +824,16 @@ func TestNudgeSessionNameFallbackStripsTheDevicePrefix(t *testing.T) {
 	t.Cleanup(func() { nudgeRun = origNudge })
 
 	origRun := tmuxenv.Run
-	tmuxenv.Run = func(_ ...string) (string, error) { return "", fmt.Errorf("no tmux") }
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_created}":
+			return "100", nil
+		case "#{pane_id}":
+			return "%2", nil
+		default:
+			return "", fmt.Errorf("no tmux")
+		}
+	}
 	t.Cleanup(func() { tmuxenv.Run = origRun })
 
 	var buf bytes.Buffer

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -119,6 +119,10 @@ func Serve(socketPath string, s store.API, n wake.Notifier, deviceName string) (
 	if err != nil {
 		return nil, err
 	}
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
 	d := New(s, n, deviceName)
 	d.ln = ln
 	go d.acceptLoop()
@@ -1114,7 +1118,7 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 		// A read that didn't persist must not report success (spec §3): if
 		// MarkRead fails, the op fails outright — no read event, badge
 		// untouched.
-		if err := d.s.MarkRead(alias); err != nil {
+		if err := d.s.MarkRead(alias, inboxLastEntryID(threads)); err != nil {
 			return fail(err)
 		}
 		detail := ""
@@ -1387,6 +1391,19 @@ func (d *Daemon) dispatch(req proto.Request) proto.Response {
 	default:
 		return proto.Response{Error: "unknown op: " + req.Op}
 	}
+}
+
+// inboxLastEntryID returns the highest entry ID actually carried by an Inbox
+// snapshot. MarkRead must receive this value rather than querying the store
+// again, otherwise mail committed between Inbox and MarkRead is lost.
+func inboxLastEntryID(threads []store.Thread) int64 {
+	var maxID int64
+	for _, thread := range threads {
+		if thread.LastEntryID > maxID {
+			maxID = thread.LastEntryID
+		}
+	}
+	return maxID
 }
 
 // paginateEntries slices entries (already ordered oldest-first by

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,6 +29,28 @@ func startTestDaemon(t *testing.T) string {
 	}
 	t.Cleanup(func() { _ = d.Close() })
 	return paths.SocketPath()
+}
+
+func TestServeSecuresSocket(t *testing.T) {
+	dir := testHome(t)
+	s, err := store.Open(filepath.Join(dir, "bus.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	sock := filepath.Join(dir, "sock")
+	d, err := Serve(sock, s, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	info, err := os.Stat(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("socket mode = %#o, want 0600", got)
+	}
 }
 
 func TestDaemonRegisterAndList(t *testing.T) {

--- a/internal/daemon/remotemode.go
+++ b/internal/daemon/remotemode.go
@@ -58,6 +58,10 @@ func ServeRemote(socketPath string, up Upstream, n wake.Notifier, deviceID, devi
 	if err != nil {
 		return nil, err
 	}
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		_ = ln.Close()
+		return nil, err
+	}
 	// s is nil: remote mode has no local store, and serve() always checks
 	// d.up first and forwards, so dispatch (and resolveAgentTarget's use of
 	// deviceName for expansion) is never reached from this mode — d.s and

--- a/internal/daemon/wake_wiring_test.go
+++ b/internal/daemon/wake_wiring_test.go
@@ -500,11 +500,11 @@ type markReadFailingStore struct {
 	failMarkRead bool
 }
 
-func (m *markReadFailingStore) MarkRead(alias string) error {
+func (m *markReadFailingStore) MarkRead(alias string, upToEntryID int64) error {
 	if m.failMarkRead {
 		return fmt.Errorf("injected MarkRead failure")
 	}
-	return m.Store.MarkRead(alias)
+	return m.Store.MarkRead(alias, upToEntryID)
 }
 
 func TestGetInboxFailsWhenMarkReadFails(t *testing.T) {

--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -123,7 +123,7 @@ func SetName(name string) (string, error) {
 	if clean == "" {
 		return "", fmt.Errorf("device: %q is not a usable device name (letters, digits and dashes)", name)
 	}
-	if err := os.MkdirAll(paths.Home(), 0o755); err != nil {
+	if err := paths.EnsureHome(); err != nil {
 		return "", err
 	}
 	p := filepath.Join(paths.Home(), NameFileName)
@@ -212,7 +212,7 @@ func ID() (string, error) {
 	if v := strings.TrimSpace(string(b)); v != "" {
 		return v, nil
 	}
-	if err := os.MkdirAll(paths.Home(), 0o755); err != nil {
+	if err := paths.EnsureHome(); err != nil {
 		return "", err
 	}
 	v := uuid.NewString()

--- a/internal/device/device_test.go
+++ b/internal/device/device_test.go
@@ -55,6 +55,24 @@ func TestIDHonorsEnvOverride(t *testing.T) {
 	}
 }
 
+func TestIDRepairsHomeDirectoryMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MUSTER_HOME", dir)
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := device.ID(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("MUSTER_HOME mode = %#o, want 0700", got)
+	}
+}
+
 // TestIDFailsRatherThanRotatingOnAReadError pins the ENOENT narrowing.
 //
 // The device id is the wake-routing key. Every agent registered from this

--- a/internal/dynamostore/store.go
+++ b/internal/dynamostore/store.go
@@ -47,10 +47,11 @@
 // consistent even if they wanted to be. Where one of them feeds a
 // consistency-sensitive decision, it is used for MEMBERSHIP only and the
 // per-item state is re-read from the base table — SessionUnread is the worked
-// example. MarkRead is the one place that rule is knowingly bent: the
-// watermark it writes comes from an eventually consistent index read, and it
-// can still overshoot an entry that has not landed yet. See the next section
-// for what that costs and what bounds it.
+// example. MarkRead is the one place that rule is knowingly bent: the bound
+// it writes originates in Inbox's eventually consistent index read (the
+// caller hands back the snapshot's highest last_entry_id), and it can still
+// overshoot an entry that has not landed yet. See the next section for what
+// that costs and what bounds it.
 //
 // # The MarkRead watermark can overshoot within one recipient partition
 //
@@ -74,22 +75,27 @@
 // TestMarkReadStillOvershootsWithinOnePartition a deterministic test rather
 // than a race.
 //
-// MarkRead bounds it as tightly as it can without new durable state:
-// readableThrough derives the watermark from the entries the alias could
-// actually have been shown — its own gsi1 partitions, filtered to threads that
-// concern it — rather than from the global entry log. That leaves the race
-// only between writers landing in the SAME recipient partition set. A message
-// between two other agents can no longer bury one in flight to this alias
-// (TestMarkReadIgnoresEntriesOutsideTheAliasesPartitions), which matters
-// because the un-bounded version scaled with total bus traffic — quadratic in
-// concurrent writers — and permitting concurrent writers is what this backend
-// exists for. The remaining window scales with writers to one recipient.
+// MarkRead bounds it as tightly as a watermark can be bound: it performs no
+// read of its own, writing max(current watermark, upToEntryID) where the
+// bound is supplied by the CALLER — the daemon passes the highest
+// last_entry_id its Inbox snapshot actually carried (store.API). The
+// watermark therefore covers only entries that were genuinely SHOWN, by
+// construction: a message between two other agents can never bury one in
+// flight to this alias (TestMarkReadIgnoresEntriesOutsideTheAliasesPartitions
+// pins it), and a message committed after the snapshot stays unread on both
+// backends (the MarkReadStopsAtTheInboxSnapshot conformance case). What
+// remains is the same-recipient window: Inbox itself can display a committed
+// higher id while a lower allocated id is still in flight to the SAME
+// recipient, and acknowledging that snapshot writes a watermark above the
+// in-flight entry. The window scales with writers to one recipient, not with
+// total bus traffic.
 //
-// Reading the same index Inbox reads also closes a second window that used to
-// exist independently: one base write fans out to gsi1 and gsi2 as separate
-// replications, so a MarkRead reading gsi2 could see an entry gsi1 had not
-// shown Inbox yet and mark it read with no second writer involved. One index,
-// no cross-index skew.
+// Deriving the bound from the snapshot also removes, by construction, a
+// cross-index window that used to exist independently: one base write fans
+// out to gsi1 and gsi2 as separate replications, and a MarkRead that read
+// gsi2 could see an entry gsi1 had not shown Inbox yet and mark it read with
+// no second writer involved. MarkRead now reads no index at all — the bound
+// IS what gsi1 showed Inbox.
 //
 // The remaining repairs are all worse or expensive. Reading the counter item
 // is strongly consistent but strictly worse — it marks ids never written at
@@ -97,9 +103,12 @@
 // price. Ordering allocation with the commit needs durable in-flight state
 // plus its own crash-recovery story (an allocation whose writer died must be
 // released, or every reader's watermark wedges behind it). What is accepted
-// today is the same-partition case, and the price of the bound is that
-// get_inbox pays for the concerns/entriesAfter fan-out twice: once in Inbox,
-// once in MarkRead.
+// today is the same-recipient case above, plus one write-side residue: the
+// UpdateItem is unconditional, its max() computed from a base-table read
+// rather than inside a conditional expression, so two concurrent MarkReads
+// for one alias can interleave and keep the LOWER watermark. That residue
+// errs toward re-flagging shown mail as unread — duplicated signal, never
+// lost signal — which is the survivable direction.
 //
 // Allocation-before-commit is a PACKAGE-WIDE fact, not a MarkRead quirk, and
 // three places answer to it. MarkRead bounds it and accepts what is left (this
@@ -110,11 +119,15 @@
 // watermark that will not pass an id it has not seen (see pollWatermark). Any new
 // watermark over these ids owes the same question an answer.
 //
-// The SQLite backend has neither window. store.Open sets SetMaxOpenConns(1),
-// so its MarkRead transaction (SELECT MAX(id) FROM entries, then the UPDATE)
-// holds the only connection there is, and entry ids come from AUTOINCREMENT
-// inside the inserting transaction rather than ahead of it. This is a real
-// divergence between the two backends, not a limitation they share.
+// The SQLite backend has neither window. Both backends now write the same
+// caller-supplied bound, but SQLite's entry ids come from AUTOINCREMENT
+// inside the inserting transaction on the one pinned connection
+// (SetMaxOpenConns(1)), so a committed higher id proves every lower id is
+// also committed — a snapshot bound can never overshoot an in-flight entry
+// there. Its UPDATE also takes MAX(last_read_entry_id, ?) atomically in SQL,
+// so concurrent MarkReads cannot regress the watermark the way the
+// unconditional Dynamo write can. Real divergences between the two backends,
+// not limitations they share.
 //
 // # The recipient denormalization is write-once
 //

--- a/internal/dynamostore/store_test.go
+++ b/internal/dynamostore/store_test.go
@@ -44,6 +44,23 @@ func newTestStore(t *testing.T) *Store {
 	return s
 }
 
+func markReadInbox(t *testing.T, s *Store, alias string) {
+	t.Helper()
+	threads, err := s.Inbox(alias)
+	if err != nil {
+		t.Fatalf("Inbox(%q): %v", alias, err)
+	}
+	var upToEntryID int64
+	for _, thread := range threads {
+		if thread.LastEntryID > upToEntryID {
+			upToEntryID = thread.LastEntryID
+		}
+	}
+	if err := s.MarkRead(alias, upToEntryID); err != nil {
+		t.Fatalf("MarkRead(%q): %v", alias, err)
+	}
+}
+
 // testTableName derives a unique table per test so tests never share state.
 //
 // DynamoDB accepts only [a-zA-Z0-9_.-] in a table name, and Go builds subtest

--- a/internal/dynamostore/tasks_test.go
+++ b/internal/dynamostore/tasks_test.go
@@ -483,9 +483,7 @@ func TestTaskEntriesLandInTheRecipientPartition(t *testing.T) {
 		t.Fatalf("RegisterAgent: %v", err)
 	}
 	id := newTestTask(t, s)
-	if err := s.MarkRead("watcher"); err != nil {
-		t.Fatalf("MarkRead: %v", err)
-	}
+	markReadInbox(t, s, "watcher")
 	if n, err := s.UnreadCount("watcher"); err != nil || n != 0 {
 		t.Fatalf("UnreadCount after drain = %d, %v; want 0", n, err)
 	}

--- a/internal/dynamostore/threads.go
+++ b/internal/dynamostore/threads.go
@@ -1015,6 +1015,36 @@ func (s *Store) MarkRead(alias string, upToEntryID int64) error {
 	return nil
 }
 
+// readableThrough is the highest entry id visible to alias right now, or after
+// if there are none — never lower than after, so a watermark only moves
+// forward. RegisterAgent uses it to seed a new session's watermark to the
+// concern-scoped max (SQLite seeds the global MAX(entries.id); this is the
+// behaviourally identical concern-scoped equivalent for unread).
+//
+// It runs the same fan-out unreadFor runs (concerns, then entriesAfter from
+// after). Entries outside the concerning set are ignored even though they share
+// a partition: an entry on a thread that does not concern alias can never be
+// unread for it (unreadByThread filters on exactly this set), so counting it
+// would raise the watermark over in-flight ids for no signal at all.
+func (s *Store) readableThrough(ctx context.Context, a store.Agent, after int64) (int64, error) {
+	threads, parts, err := s.concerns(ctx, a)
+	if err != nil {
+		return 0, err
+	}
+	entries, err := s.entriesAfter(ctx, parts, after)
+	if err != nil {
+		return 0, err
+	}
+	concerning := idSet(threads)
+	watermark := after
+	for _, e := range entries {
+		if e.ID > watermark && concerning[e.ThreadID] {
+			watermark = e.ID
+		}
+	}
+	return watermark, nil
+}
+
 // SessionUnread is the session-level unread query: all aliases sharing the
 // exact (socketPath, sessionID) tuple are ONE actor identity for unread math
 // and actor exclusion. total counts DISTINCT threads concerning any alias of

--- a/internal/dynamostore/threads.go
+++ b/internal/dynamostore/threads.go
@@ -183,6 +183,7 @@ func itemToThread(item map[string]types.AttributeValue) store.Thread {
 // denormalized attributes — the counterpart of the SQLite backend's
 // threadLastEntryCTE/Join. Only Threads() and Inbox() call it.
 func annotateLastEntry(t *store.Thread, item map[string]types.AttributeValue) {
+	t.LastEntryID = numAttr(item, "last_entry_id")
 	t.LastFrom = strAttr(item, "last_from")
 	t.LastAt = numAttr(item, "last_at")
 	t.EntryCount = int(numAttr(item, "entry_count"))
@@ -944,39 +945,42 @@ func (s *Store) UnreadCount(alias string) (int, error) {
 	return len(unread), nil
 }
 
-// MarkRead records that alias has read its inbox up to the highest entry id
-// the alias could actually have been SHOWN — the entries Inbox reads, from the
-// alias's own gsi1 recipient partitions, filtered to threads that concern it.
-// The watermark is an entry id, not a wall-clock timestamp, so two entries
-// landing in the same millisecond never race a strict "after last read"
-// comparison. last_read_at is stamped for display only; no unread predicate
-// consults it.
+// MarkRead records that alias has read its inbox through upToEntryID — the
+// highest entry id the caller's own Inbox snapshot actually carried
+// (store.API), not anything this method reads for itself. The watermark is an
+// entry id, not a wall-clock timestamp, so two entries landing in the same
+// millisecond never race a strict "after last read" comparison. last_read_at
+// is stamped for display only; no unread predicate consults it.
 //
 // Three properties this must not lose:
 //
-//   - The watermark comes from WRITTEN entries, never from the entry counter.
-//     A counter value can already be allocated to an entry still in flight,
-//     and treating that as read would swallow its unread signal outright.
-//     entriesAfter reads index items, which exist only once a write committed.
-//   - It reads the SAME index Inbox reads (gsi1). Deriving it from the global
-//     entry log (gsi2) instead meant one write's two index replications could
-//     disagree, so a get_inbox could mark read an entry Inbox had not shown.
+//   - The watermark comes from SHOWN entries, never from the entry counter or
+//     any query of this method's own. A counter value can already be
+//     allocated to an entry still in flight, and a fresh query could see an
+//     entry the caller's snapshot did not — either way an entry gets marked
+//     read without ever being returned. The caller-supplied bound rules both
+//     out by construction.
+//   - The bound originates in the SAME index read Inbox answered from (gsi1's
+//     denormalized last_entry_id), so one write's two index replications
+//     (gsi1/gsi2) can never disagree about what was shown.
 //   - It never moves the watermark DOWN. agentByAlias is strongly consistent,
-//     so the floor is the alias's current watermark and an eventually
-//     consistent index that lags cannot re-surface already-read entries. (Two
-//     MarkReads for the same alias concurrently can still interleave — the
-//     write is not conditional on the old value, because condition failure
-//     already means "unknown alias" here.)
+//     so the floor is the alias's current watermark and a stale caller cannot
+//     re-surface already-read entries. (Two MarkReads for the same alias
+//     concurrently can still interleave — the write is not conditional on the
+//     old value, because condition failure already means "unknown alias"
+//     here — and the loser keeps the lower watermark: duplicated unread
+//     signal, never lost signal.)
 //
-// What remains: writers racing into the alias's own partitions. See "The
-// MarkRead watermark can overshoot" in the package comment.
+// What remains: writers racing into the alias's own partitions, now visible
+// as Inbox showing a committed higher id while a lower one is still in
+// flight. See "The MarkRead watermark can overshoot" in the package comment.
 //
 // The condition mirrors the SQLite UPDATE-matches-no-rows contract: DynamoDB's
 // UpdateItem is an upsert, so without it, marking an unknown alias read would
 // CREATE an agent row holding nothing but a watermark. It is kept alongside
 // the unknown-alias early return because the agent can be deleted between the
 // read and this write.
-func (s *Store) MarkRead(alias string) error {
+func (s *Store) MarkRead(alias string, upToEntryID int64) error {
 	ctx := backgroundCtx()
 	agent, ok, err := s.agentByAlias(ctx, alias)
 	if err != nil {
@@ -985,10 +989,7 @@ func (s *Store) MarkRead(alias string) error {
 	if !ok {
 		return nil // unknown alias: no-op, matching the SQLite contract
 	}
-	watermark, err := s.readableThrough(ctx, agent, agent.LastReadEntryID)
-	if err != nil {
-		return err
-	}
+	watermark := max(agent.LastReadEntryID, upToEntryID)
 	_, err = s.c.UpdateItem(ctx, &dynamodb.UpdateItemInput{
 		TableName: aws.String(s.table),
 		Key:       agentKey(alias),
@@ -1012,35 +1013,6 @@ func (s *Store) MarkRead(alias string) error {
 		return fmt.Errorf("dynamostore: mark read %q: %w", alias, err)
 	}
 	return nil
-}
-
-// readableThrough is the watermark MarkRead writes: the highest id among the
-// entries visible to alias right now, or its current watermark if there are
-// none — never lower than after, so the watermark only moves forward.
-//
-// It runs the same fan-out unreadFor runs (concerns, then entriesAfter from
-// after), which is why get_inbox pays for that fan-out twice. Entries outside
-// the concerning set are ignored even though they share a partition: an entry
-// on a thread that does not concern alias can never be unread for it
-// (unreadByThread filters on exactly this set), so counting it would raise the
-// watermark over in-flight ids for no signal at all.
-func (s *Store) readableThrough(ctx context.Context, a store.Agent, after int64) (int64, error) {
-	threads, parts, err := s.concerns(ctx, a)
-	if err != nil {
-		return 0, err
-	}
-	entries, err := s.entriesAfter(ctx, parts, after)
-	if err != nil {
-		return 0, err
-	}
-	concerning := idSet(threads)
-	watermark := after
-	for _, e := range entries {
-		if e.ID > watermark && concerning[e.ThreadID] {
-			watermark = e.ID
-		}
-	}
-	return watermark, nil
 }
 
 // SessionUnread is the session-level unread query: all aliases sharing the

--- a/internal/dynamostore/threads_test.go
+++ b/internal/dynamostore/threads_test.go
@@ -656,9 +656,7 @@ func TestMarkReadIgnoresEntriesOutsideTheAliasesPartitions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateThread: %v", err)
 	}
-	if err := s.MarkRead("r"); err != nil {
-		t.Fatalf("MarkRead (drain the opener): %v", err)
-	}
+	markReadInbox(t, s, "r")
 
 	// A reply to r is allocated an id and then stalls before committing.
 	lowID, err := s.nextID(ctx, "entry")
@@ -674,9 +672,7 @@ func TestMarkReadIgnoresEntriesOutsideTheAliasesPartitions(t *testing.T) {
 	}
 	// r reads its inbox in the gap. The global entry log now holds an id above
 	// lowID; r's own partitions do not, so r's watermark must not move.
-	if err := s.MarkRead("r"); err != nil {
-		t.Fatalf("MarkRead (in the gap): %v", err)
-	}
+	markReadInbox(t, s, "r")
 
 	// The stalled reply finally commits, under the watermark MarkRead wrote.
 	now := clock.NowMillis()
@@ -712,9 +708,7 @@ func TestMarkReadStillOvershootsWithinOnePartition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateThread: %v", err)
 	}
-	if err := s.MarkRead("r"); err != nil {
-		t.Fatalf("MarkRead (drain the opener): %v", err)
-	}
+	markReadInbox(t, s, "r")
 
 	lowID, err := s.nextID(ctx, "entry")
 	if err != nil {
@@ -727,9 +721,7 @@ func TestMarkReadStillOvershootsWithinOnePartition(t *testing.T) {
 	}, "overtakes the stalled one"); err != nil {
 		t.Fatalf("CreateThread (overtaker): %v", err)
 	}
-	if err := s.MarkRead("r"); err != nil {
-		t.Fatalf("MarkRead (in the gap): %v", err)
-	}
+	markReadInbox(t, s, "r")
 
 	now := clock.NowMillis()
 	late := entryItem(mine, lowID, "peer", "the late reply", "", now, rcpt("agent", "r"))

--- a/internal/nudgeguard/guard.go
+++ b/internal/nudgeguard/guard.go
@@ -1,0 +1,57 @@
+// Package nudgeguard proves a roster row still names the local, live tmux
+// target before an operator surface asks internal/nudge to type into it.
+package nudgeguard
+
+import (
+	"fmt"
+
+	"github.com/schuettc/muster/internal/device"
+	"github.com/schuettc/muster/internal/store"
+	"github.com/schuettc/muster/internal/tmuxenv"
+)
+
+// Checker supplies the identity and tmux liveness probes used by Check. It is
+// injectable so the guard can be tested without a tmux server.
+type Checker struct {
+	DeviceID     func() (string, error)
+	SessionAlive func(socket, sessionID string, created int64) bool
+	PaneAlive    func(socket, paneID string) bool
+}
+
+// Check proves that agent belongs to this device and still names one live tmux
+// incarnation and pane. displayName is the caller's human-facing alias.
+func Check(agent store.Agent, displayName string) error {
+	return Checker{
+		DeviceID:     device.ID,
+		SessionAlive: tmuxenv.IsSessionAlive,
+		PaneAlive:    tmuxenv.IsPaneAlive,
+	}.Check(agent, displayName)
+}
+
+// Check applies the target proof in the only safe order: machine ownership,
+// immutable tmux session incarnation, then pane existence.
+func (c Checker) Check(agent store.Agent, displayName string) error {
+	if displayName == "" {
+		displayName = agent.Alias
+	}
+	if agent.DeviceID != "" {
+		deviceID, err := c.DeviceID()
+		if err != nil {
+			return fmt.Errorf("nudge %s: device id: %w", displayName, err)
+		}
+		if deviceID != agent.DeviceID {
+			deviceName := agent.DeviceName
+			if deviceName == "" {
+				deviceName = "another device"
+			}
+			return fmt.Errorf("nudge %s: registered on %s", displayName, deviceName)
+		}
+	}
+	if !c.SessionAlive(agent.SocketPath, agent.SessionID, agent.SessionCreated) {
+		return fmt.Errorf("nudge %s: stored session %s is not alive — refusing to type into a stale target", displayName, agent.SessionID)
+	}
+	if !c.PaneAlive(agent.SocketPath, agent.PaneID) {
+		return fmt.Errorf("nudge %s: stored pane %s is gone but its session is alive — the row heals at the session's next start/resume (or re-register from the live pane); refusing to type into a guessed pane", displayName, agent.PaneID)
+	}
+	return nil
+}

--- a/internal/nudgeguard/guard_test.go
+++ b/internal/nudgeguard/guard_test.go
@@ -1,0 +1,57 @@
+package nudgeguard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/schuettc/muster/internal/store"
+)
+
+func TestCheckerRefusesForeignDevice(t *testing.T) {
+	c := Checker{
+		DeviceID:     func() (string, error) { return "this-device", nil },
+		SessionAlive: func(string, string, int64) bool { t.Fatal("session check after foreign-device refusal"); return false },
+		PaneAlive:    func(string, string) bool { t.Fatal("pane check after foreign-device refusal"); return false },
+	}
+	err := c.Check(store.Agent{Alias: "review", DeviceID: "other-device", DeviceName: "work-laptop"}, "review")
+	if err == nil || !strings.Contains(err.Error(), "registered on work-laptop") {
+		t.Fatalf("foreign-device error = %v, want registered-on-device refusal", err)
+	}
+}
+
+func TestCheckerRequiresTheRecordedSessionIncarnation(t *testing.T) {
+	c := Checker{
+		DeviceID:     func() (string, error) { return "this-device", nil },
+		SessionAlive: func(string, string, int64) bool { return false },
+		PaneAlive:    func(string, string) bool { t.Fatal("pane check after dead-session refusal"); return false },
+	}
+	err := c.Check(store.Agent{Alias: "review", DeviceID: "this-device", SocketPath: "/s", SessionID: "$1", SessionCreated: 0}, "review")
+	if err == nil || !strings.Contains(err.Error(), "stored session $1 is not alive") {
+		t.Fatalf("dead-session error = %v", err)
+	}
+}
+
+func TestCheckerRefusesDeadPaneWithTheExistingRemedy(t *testing.T) {
+	c := Checker{
+		DeviceID:     func() (string, error) { return "this-device", nil },
+		SessionAlive: func(string, string, int64) bool { return true },
+		PaneAlive:    func(string, string) bool { return false },
+	}
+	err := c.Check(store.Agent{Alias: "review", DeviceID: "this-device", SocketPath: "/s", SessionID: "$1", SessionCreated: 12, PaneID: "%9"}, "review")
+	if err == nil || !strings.Contains(err.Error(), "stored pane %9 is gone but its session is alive") {
+		t.Fatalf("dead-pane error = %v", err)
+	}
+}
+
+func TestCheckerAllowsTheLiveLocalTarget(t *testing.T) {
+	c := Checker{
+		DeviceID: func() (string, error) { return "this-device", nil },
+		SessionAlive: func(socket, session string, created int64) bool {
+			return socket == "/s" && session == "$1" && created == 12
+		},
+		PaneAlive: func(socket, pane string) bool { return socket == "/s" && pane == "%9" },
+	}
+	if err := c.Check(store.Agent{Alias: "review", DeviceID: "this-device", SocketPath: "/s", SessionID: "$1", SessionCreated: 12, PaneID: "%9"}, "review"); err != nil {
+		t.Fatalf("live local target refused: %v", err)
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -23,6 +23,15 @@ func Home() string {
 	return filepath.Join(base, HomeSuffix())
 }
 
+// EnsureHome creates the local state directory with owner-only access and
+// repairs an older, more-permissive directory in place.
+func EnsureHome() error {
+	if err := os.MkdirAll(Home(), 0o700); err != nil {
+		return err
+	}
+	return os.Chmod(Home(), 0o700)
+}
+
 // DBPath is the SQLite database path.
 func DBPath() string { return filepath.Join(Home(), "bus.db") }
 

--- a/internal/station/actions.go
+++ b/internal/station/actions.go
@@ -6,7 +6,9 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/schuettc/muster/internal/nudgeguard"
 	"github.com/schuettc/muster/internal/render"
+	"github.com/schuettc/muster/internal/store"
 )
 
 // This file holds the operator-action Cmds (spec §5): the composer's
@@ -42,18 +44,17 @@ func nudgeCmd(caller render.Caller, n nudger, alias string) tea.Cmd {
 			return nudgeResultMsg{alias: alias, err: err}
 		}
 		var res struct {
-			Found bool `json:"found"`
-			Agent struct {
-				SocketPath string `json:"socket_path"`
-				PaneID     string `json:"pane_id"`
-				ModelType  string `json:"model_type"`
-			} `json:"agent"`
+			Found bool        `json:"found"`
+			Agent store.Agent `json:"agent"`
 		}
 		if err := json.Unmarshal(raw, &res); err != nil {
 			return nudgeResultMsg{alias: alias, err: err}
 		}
 		if !res.Found {
 			return nudgeResultMsg{alias: alias, err: fmt.Errorf("no agent registered as %q", alias)}
+		}
+		if err := nudgeguard.Check(res.Agent, res.Agent.Alias); err != nil {
+			return nudgeResultMsg{alias: alias, err: err}
 		}
 		submitted, err := n.Nudge(res.Agent.SocketPath, res.Agent.PaneID, res.Agent.ModelType, true)
 		if err != nil {

--- a/internal/station/actions_test.go
+++ b/internal/station/actions_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
 )
 
 // nudgeCall records one fakeNudger.Nudge invocation.
@@ -243,12 +245,25 @@ func TestComposerReplyFromFocusedConversation(t *testing.T) {
 // <label>? y/n"; confirming with 'y' invokes the SAME sequence cmdNudge does
 // (get_agent, TmuxNudger.Nudge, then a best-effort log_event self-report).
 func TestNudgeConfirmGateYesInvokesNudgeWithSelfReport(t *testing.T) {
+	t.Setenv("MUSTER_DEVICE_ID", "station-device")
+	origRun := tmuxenv.Run
+	tmuxenv.Run = func(args ...string) (string, error) {
+		switch args[len(args)-1] {
+		case "#{session_created}":
+			return "100", nil
+		case "#{pane_id}":
+			return "%1", nil
+		default:
+			return "", nil
+		}
+	}
+	t.Cleanup(func() { tmuxenv.Run = origRun })
 	var logCalls []map[string]any
 	fn := &fakeNudger{submitted: true}
 	fake := fakeCaller{fn: func(op string, args map[string]any) (json.RawMessage, error) {
 		switch op {
 		case "get_agent":
-			return json.RawMessage(`{"found":true,"agent":{"socket_path":"/s","pane_id":"%1","model_type":"claude"}}`), nil
+			return json.RawMessage(`{"found":true,"agent":{"alias":"backend-1","socket_path":"/s","pane_id":"%1","session_id":"$1","session_created":100,"model_type":"claude","device_id":"station-device"}}`), nil
 		case "log_event":
 			logCalls = append(logCalls, args)
 		}
@@ -294,6 +309,24 @@ func TestNudgeConfirmGateYesInvokesNudgeWithSelfReport(t *testing.T) {
 	}
 	if !strings.Contains(m.status, "backend") {
 		t.Fatalf("status after nudging = %q, want it to mention the label", m.status)
+	}
+}
+
+func TestStationNudgeRefusesForeignDevice(t *testing.T) {
+	t.Setenv("MUSTER_DEVICE_ID", "this-device")
+	fn := &fakeNudger{submitted: true}
+	fake := fakeCaller{fn: func(op string, _ map[string]any) (json.RawMessage, error) {
+		if op == "get_agent" {
+			return json.RawMessage(`{"found":true,"agent":{"alias":"remote","socket_path":"/s","pane_id":"%1","session_id":"$1","session_created":100,"model_type":"claude","device_id":"other-device","device_name":"work-laptop"}}`), nil
+		}
+		return json.RawMessage(`{}`), nil
+	}}
+	msg := nudgeCmd(fake, fn, "remote")().(nudgeResultMsg)
+	if msg.err == nil || !strings.Contains(msg.err.Error(), "registered on work-laptop") {
+		t.Fatalf("foreign-device result = %+v, want registered-on-device refusal", msg)
+	}
+	if len(fn.calls) != 0 {
+		t.Fatalf("foreign-device refusal must not send keys, got %+v", fn.calls)
 	}
 }
 

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -311,28 +311,19 @@ WHERE `+threadConcerns+`
 	return n, err
 }
 
-// MarkRead records that alias has read its inbox up to the highest entry ID
-// that exists right now: the read and the watermark snapshot happen in one
-// transaction, so an entry appended concurrently (even in the same
-// millisecond) is never mistaken for already read. last_read_at is also
-// stamped, for display purposes only — it is no longer consulted by any
-// unread predicate.
-func (s *Store) MarkRead(alias string) error {
+// MarkRead records that alias has read its Inbox snapshot through upToEntryID.
+// The caller supplies the snapshot bound; querying entries here would create a
+// race where a newer entry could be marked read without ever being returned.
+// last_read_at is stamped for display only and does not affect unread math.
+func (s *Store) MarkRead(alias string, upToEntryID int64) error {
 	now := clock.NowMillis()
-	tx, err := s.db.Begin()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	var maxID int64
-	if err := tx.QueryRow(`SELECT COALESCE(MAX(id), 0) FROM entries`).Scan(&maxID); err != nil {
-		return err
-	}
-	if _, err := tx.Exec(`UPDATE agents SET last_read_entry_id=?, last_read_standing_entry_id=?, last_read_at=? WHERE alias=?`, maxID, maxID, now, alias); err != nil {
-		return err
-	}
-	return tx.Commit()
+	_, err := s.db.Exec(`
+UPDATE agents
+SET last_read_entry_id = MAX(last_read_entry_id, ?),
+    last_read_standing_entry_id = MAX(last_read_standing_entry_id, ?),
+    last_read_at = ?
+WHERE alias = ?`, upToEntryID, upToEntryID, now, alias)
+	return err
 }
 
 // ErrBecomeFromMissing / ErrBecomeToExists are become's guard sentinels —

--- a/internal/store/agents_test.go
+++ b/internal/store/agents_test.go
@@ -25,7 +25,7 @@ func TestMarkReadRecordsEntryWatermark(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.MarkRead("a"); err != nil {
+	if err := s.MarkRead("a", 1); err != nil {
 		t.Fatal(err)
 	}
 	if n, err := s.UnreadCount("a"); err != nil || n != 0 {
@@ -262,7 +262,7 @@ func TestBecomeClonesIdentityAndRetiresSeed(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.MarkRead("muster-2"); err != nil { // establish a nonzero watermark
+	if err := s.MarkRead("muster-2", 0); err != nil {
 		t.Fatal(err)
 	}
 	seed, _, _ := s.GetAgent("muster-2")

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -111,7 +111,10 @@ type API interface {
 	GetThread(id int64) (Thread, []Entry, error)
 	Threads(limit int) ([]Thread, error)
 	Inbox(alias string) ([]Thread, error)
-	MarkRead(alias string) error
+	// MarkRead records that alias has read an Inbox snapshot through
+	// upToEntryID. Callers must derive the bound from that snapshot, never
+	// from a later query, so an entry committed in between remains unread.
+	MarkRead(alias string, upToEntryID int64) error
 	UnreadCount(alias string) (int, error)
 	// StatusCounts returns every alias's side-effect-free (unread,
 	// action_required) counts — a pure read for a polling picker; see the

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -146,14 +146,15 @@ type Thread struct {
 	// the roster-only project mapping that made ghost-site's threads vanish
 	// (spec iteration-4 queue item 4) has this as its durable fallback.
 	OriginProject string `json:"origin_project"`
-	// LastFrom, LastAt, and EntryCount are query-time only, populated by
+	// LastEntryID, LastFrom, LastAt, and EntryCount are query-time only, populated by
 	// Threads() and Inbox() from the thread's last entry (by MAX(id), never
 	// MAX(created_at) — same-millisecond entries must not tie-break on
 	// timestamp) and its total entry count. GetThread/CreateThread leave
 	// them zero.
-	LastFrom   string `json:"last_from"`
-	LastAt     int64  `json:"last_at"`
-	EntryCount int    `json:"entry_count"`
+	LastEntryID int64  `json:"last_entry_id"`
+	LastFrom    string `json:"last_from"`
+	LastAt      int64  `json:"last_at"`
+	EntryCount  int    `json:"entry_count"`
 	// Unread is query-time only, populated by Inbox(alias): the count of
 	// this thread's entries after alias's last_read_entry_id watermark that
 	// were NOT written by alias (the same predicate as UnreadCount, scoped

--- a/internal/store/standing_orders_test.go
+++ b/internal/store/standing_orders_test.go
@@ -76,7 +76,7 @@ func TestRetractDoesNotDisturbAlreadyReadSession(t *testing.T) {
 	if err := s.RegisterAgent(Agent{Alias: "seen", Project: "web"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.MarkRead("seen"); err != nil {
+	if err := s.MarkRead("seen", maxEntryID(t, s)); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.RetractStandingOrder("web", "invariants"); err != nil {

--- a/internal/store/standing_test.go
+++ b/internal/store/standing_test.go
@@ -62,7 +62,7 @@ func TestNewSessionSeesStandingBroadcastOnce(t *testing.T) {
 	if n, _ := s.UnreadCount("newbie"); n != 1 {
 		t.Fatalf("standing broadcast should reach new session: unread=%d, want 1", n)
 	}
-	if err := s.MarkRead("newbie"); err != nil {
+	if err := s.MarkRead("newbie", maxEntryID(t, s)); err != nil {
 		t.Fatal(err)
 	}
 	if n, _ := s.UnreadCount("newbie"); n != 0 {
@@ -93,7 +93,7 @@ func TestMarkReadAdvancesBothWatermarks(t *testing.T) {
 	bcast(t, s, false, "live")
 	bcast(t, s, true, "standing")
 	want := maxEntryID(t, s)
-	if err := s.MarkRead("a"); err != nil {
+	if err := s.MarkRead("a", want); err != nil {
 		t.Fatal(err)
 	}
 	got, _, _ := s.GetAgent("a")
@@ -109,7 +109,7 @@ func TestReviveKeepsBothWatermarks(t *testing.T) {
 		t.Fatal(err)
 	}
 	bcast(t, s, true, "standing")
-	if err := s.MarkRead("back"); err != nil {
+	if err := s.MarkRead("back", maxEntryID(t, s)); err != nil {
 		t.Fatal(err)
 	}
 	want := maxEntryID(t, s)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	_ "embed"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -34,7 +35,20 @@ func Open(dbPath string) (*Store, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
+	if err := secureDatabaseFiles(dbPath); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("secure db files: %w", err)
+	}
 	return &Store{db: db}, nil
+}
+
+func secureDatabaseFiles(dbPath string) error {
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if err := os.Chmod(path, 0o600); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 // migrate applies additive column migrations to pre-existing databases. Each

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -31,6 +31,27 @@ func TestOpenCreatesSchema(t *testing.T) {
 	}
 }
 
+func TestOpenSecuresDatabaseFiles(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "bus.db")
+	s, err := Open(db)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	for _, path := range []string{db, db + "-wal", db + "-shm"} {
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Stat(%s): %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != 0o600 {
+			t.Errorf("%s mode = %#o, want 0600", path, got)
+		}
+	}
+}
+
 func TestOpenMigrationIsIdempotent(t *testing.T) {
 	db := filepath.Join(t.TempDir(), "bus.db")
 

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -326,7 +326,7 @@ unread AS (
 SELECT recent.id, recent.kind, recent.from_agent, recent.to_kind, recent.to_target,
        recent.subject, recent.ref, recent.status, recent.eff_intent, recent.standing, recent.wake,
        recent.created_at, recent.updated_at, recent.origin_project,
-       le.from_agent, le.created_at, last.n, COALESCE(unread.n, 0)
+       last.max_id, le.from_agent, le.created_at, last.n, COALESCE(unread.n, 0)
 FROM recent`+threadLastEntryJoin+`
 LEFT JOIN unread ON unread.thread_id = recent.id
 ORDER BY recent.updated_at DESC`, alias, alias, alias, alias, alias, alias, alias)
@@ -341,7 +341,7 @@ ORDER BY recent.updated_at DESC`, alias, alias, alias, alias, alias, alias, alia
 		if err := rows.Scan(&t.ID, &t.Kind, &t.FromAgent, &t.ToKind, &t.ToTarget,
 			&t.Subject, &t.Ref, &status, &t.Intent, &t.Standing, &t.Wake,
 			&t.CreatedAt, &t.UpdatedAt, &t.OriginProject,
-			&t.LastFrom, &t.LastAt, &t.EntryCount, &t.Unread); err != nil {
+			&t.LastEntryID, &t.LastFrom, &t.LastAt, &t.EntryCount, &t.Unread); err != nil {
 			return nil, err
 		}
 		if status.Valid {
@@ -386,7 +386,7 @@ WITH recent AS (
 SELECT recent.id, recent.kind, recent.from_agent, recent.to_kind, recent.to_target,
        recent.subject, recent.ref, recent.status, recent.eff_intent, recent.standing, recent.wake,
        recent.created_at, recent.updated_at, recent.origin_project,
-       le.from_agent, le.created_at, last.n
+       last.max_id, le.from_agent, le.created_at, last.n
 FROM recent`+threadLastEntryJoin+`
 ORDER BY recent.updated_at DESC, recent.id DESC`, limit)
 	if err != nil {
@@ -400,7 +400,7 @@ ORDER BY recent.updated_at DESC, recent.id DESC`, limit)
 		if err := rows.Scan(&t.ID, &t.Kind, &t.FromAgent, &t.ToKind, &t.ToTarget,
 			&t.Subject, &t.Ref, &status, &t.Intent, &t.Standing, &t.Wake,
 			&t.CreatedAt, &t.UpdatedAt, &t.OriginProject,
-			&t.LastFrom, &t.LastAt, &t.EntryCount); err != nil {
+			&t.LastEntryID, &t.LastFrom, &t.LastAt, &t.EntryCount); err != nil {
 			return nil, err
 		}
 		if status.Valid {

--- a/internal/storetest/conformance.go
+++ b/internal/storetest/conformance.go
@@ -95,6 +95,7 @@ var cases = []conformanceCase{
 	// Inbox and unread.
 	{"UnreadCountRespectsWatermark", testUnreadWatermark},
 	{"BroadcastCountsAsUnread", testBroadcastUnread},
+	{"MarkReadStopsAtTheInboxSnapshot", testMarkReadStopsAtInboxSnapshot},
 	{"MarkReadUnknownAliasIsNoOp", testMarkReadUnknown},
 	{"StatusCountsPerAliasSideEffectFree", testStatusCounts},
 	{"InboxMatchesAgentRoleBroadcastAndOriginated", testInboxArms},
@@ -263,6 +264,25 @@ func mustAppend(t *testing.T, s store.API, id int64, from, body, statusChange st
 	t.Helper()
 	if _, err := s.AppendEntry(id, from, body, statusChange); err != nil {
 		t.Fatalf("AppendEntry: %v", err)
+	}
+}
+
+// markReadInbox acknowledges exactly the Inbox snapshot it just read. Tests
+// use it whenever they need the ordinary "drain the current inbox" operation.
+func markReadInbox(t *testing.T, s store.API, alias string) {
+	t.Helper()
+	threads, err := s.Inbox(alias)
+	if err != nil {
+		t.Fatalf("Inbox(%q): %v", alias, err)
+	}
+	var upToEntryID int64
+	for _, thread := range threads {
+		if thread.LastEntryID > upToEntryID {
+			upToEntryID = thread.LastEntryID
+		}
+	}
+	if err := s.MarkRead(alias, upToEntryID); err != nil {
+		t.Fatalf("MarkRead(%q): %v", alias, err)
 	}
 }
 
@@ -441,9 +461,7 @@ func testDepartAgentTombstone(t *testing.T, s store.API) {
 	mustThread(t, s, store.Thread{
 		Kind: "message", FromAgent: "x", ToKind: "agent", ToTarget: "muster-2",
 	}, "hi")
-	if err := s.MarkRead("muster-2"); err != nil {
-		t.Fatalf("MarkRead: %v", err)
-	}
+	markReadInbox(t, s, "muster-2")
 	before, ok, err := s.GetAgent("muster-2")
 	if err != nil || !ok {
 		t.Fatalf("GetAgent: ok=%v err=%v", ok, err)
@@ -968,7 +986,7 @@ func testUnreadWatermark(t *testing.T, s store.API) {
 	if n != 1 {
 		t.Fatalf("UnreadCount = %d, want 1", n)
 	}
-	if err := s.MarkRead("a2"); err != nil {
+	if err := s.MarkRead("a2", 1); err != nil {
 		t.Fatalf("MarkRead: %v", err)
 	}
 	if n, err := s.UnreadCount("a2"); err != nil || n != 0 {
@@ -1032,8 +1050,37 @@ func testStatusCounts(t *testing.T, s store.API) {
 	}
 }
 
+// testMarkReadStopsAtInboxSnapshot reproduces the get_inbox interleave: mail
+// committed after the inbox snapshot must remain unread when that snapshot is
+// acknowledged. The daemon will supply the snapshot's final entry ID once
+// MarkRead accepts the bound.
+func testMarkReadStopsAtInboxSnapshot(t *testing.T, s store.API) {
+	mustRegister(t, s, store.Agent{Alias: "receiver"})
+	mustThread(t, s, store.Thread{
+		Kind: "message", FromAgent: "sender", ToKind: "agent", ToTarget: "receiver",
+	}, "shown in the snapshot")
+
+	snapshot, err := s.Inbox("receiver")
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(snapshot) != 1 || snapshot[0].Unread != 1 {
+		t.Fatalf("Inbox snapshot = %+v, want one unread thread", snapshot)
+	}
+
+	mustThread(t, s, store.Thread{
+		Kind: "message", FromAgent: "sender", ToKind: "agent", ToTarget: "receiver",
+	}, "committed after the snapshot")
+	if err := s.MarkRead("receiver", snapshot[0].LastEntryID); err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+	if n, err := s.UnreadCount("receiver"); err != nil || n != 1 {
+		t.Fatalf("newer entry after snapshot is unread = %d (%v), want 1", n, err)
+	}
+}
+
 func testMarkReadUnknown(t *testing.T, s store.API) {
-	if err := s.MarkRead("nobody"); err != nil {
+	if err := s.MarkRead("nobody", 0); err != nil {
 		t.Fatalf("MarkRead on an unknown alias: %v", err)
 	}
 	agents, err := s.ListAgents()
@@ -1107,9 +1154,7 @@ func testUnreadOriginatorSeesReply(t *testing.T, s store.API) {
 	if n, err := s.UnreadCount("web"); err != nil || n != 1 {
 		t.Fatalf("peer reply on an originated thread = %d unread (%v), want 1", n, err)
 	}
-	if err := s.MarkRead("web"); err != nil {
-		t.Fatalf("MarkRead: %v", err)
-	}
+	markReadInbox(t, s, "web")
 	if n, err := s.UnreadCount("web"); err != nil || n != 0 {
 		t.Fatalf("unread after MarkRead = %d (%v), want 0", n, err)
 	}
@@ -1120,9 +1165,7 @@ func testUnreadIgnoresOwnReply(t *testing.T, s store.API) {
 	id := mustThread(t, s, store.Thread{
 		Kind: "message", FromAgent: "web", ToKind: "agent", ToTarget: "api",
 	}, "req")
-	if err := s.MarkRead("api"); err != nil {
-		t.Fatalf("MarkRead: %v", err)
-	}
+	markReadInbox(t, s, "api")
 	mustAppend(t, s, id, "api", "done", "")
 	if n, err := s.UnreadCount("api"); err != nil || n != 0 {
 		t.Fatalf("own reply re-flagged own inbox: %d unread (%v), want 0", n, err)
@@ -1177,9 +1220,7 @@ func testInboxUnreadDrops(t *testing.T, s store.API) {
 	if len(before) != 1 || before[0].Unread != 1 {
 		t.Fatalf("before MarkRead: %+v, want one thread with unread 1", before)
 	}
-	if err := s.MarkRead("web"); err != nil {
-		t.Fatalf("MarkRead: %v", err)
-	}
+	markReadInbox(t, s, "web")
 	after, err := s.Inbox("web")
 	if err != nil {
 		t.Fatalf("Inbox: %v", err)
@@ -1565,16 +1606,12 @@ func testSessionUnreadPerAliasWatermark(t *testing.T, s store.API) {
 	if total, _, err := s.SessionUnread("", "/s", "$1", liveCreated); err != nil || total != 1 {
 		t.Fatalf("before any read: total=%d (%v), want 1", total, err)
 	}
-	if err := s.MarkRead("a2"); err != nil {
-		t.Fatalf("MarkRead a2: %v", err)
-	}
+	markReadInbox(t, s, "a2")
 	if total, _, err := s.SessionUnread("", "/s", "$1", liveCreated); err != nil || total != 1 {
 		t.Fatalf("after a sibling's MarkRead: total=%d (%v), want 1 — each alias is judged against its OWN watermark",
 			total, err)
 	}
-	if err := s.MarkRead("a1"); err != nil {
-		t.Fatalf("MarkRead a1: %v", err)
-	}
+	markReadInbox(t, s, "a1")
 	if total, _, err := s.SessionUnread("", "/s", "$1", liveCreated); err != nil || total != 0 {
 		t.Fatalf("after the concerned alias's MarkRead: total=%d (%v), want 0", total, err)
 	}
@@ -2572,9 +2609,7 @@ func testBecomeCarriesWatermark(t *testing.T, s store.API) {
 	mustThread(t, s, store.Thread{
 		Kind: "message", FromAgent: "peer", ToKind: "agent", ToTarget: "seed",
 	}, "old news")
-	if err := s.MarkRead("seed"); err != nil {
-		t.Fatalf("MarkRead: %v", err)
-	}
+	markReadInbox(t, s, "seed")
 	seed, _, err := s.GetAgent("seed")
 	if err != nil {
 		t.Fatalf("GetAgent(seed): %v", err)

--- a/internal/storetest/conformance.go
+++ b/internal/storetest/conformance.go
@@ -1362,9 +1362,7 @@ func testNewSessionStandingOnce(t *testing.T, s store.API) {
 	if n, err := s.UnreadCount("newbie"); err != nil || n != 1 {
 		t.Fatalf("standing broadcast should reach new session: unread=%d (%v), want 1", n, err)
 	}
-	if err := s.MarkRead("newbie"); err != nil {
-		t.Fatalf("MarkRead: %v", err)
-	}
+	markReadInbox(t, s, "newbie")
 	if n, err := s.UnreadCount("newbie"); err != nil || n != 0 {
 		t.Fatalf("standing should be quiet after MarkRead: unread=%d (%v), want 0", n, err)
 	}
@@ -1449,9 +1447,7 @@ func testStandingOrderReGreets(t *testing.T, s store.API) {
 		t.Fatal(err)
 	}
 	mustRegister(t, s, store.Agent{Alias: "running", Project: "web"})
-	if err := s.MarkRead("running"); err != nil {
-		t.Fatal(err)
-	}
+	markReadInbox(t, s, "running")
 	if n, _ := s.UnreadCount("running"); n != 0 {
 		t.Fatalf("after reading v1, unread should be 0, got %d", n)
 	}
@@ -1505,9 +1501,7 @@ func testStandingOrderRetractSparesRead(t *testing.T, s store.API) {
 		t.Fatal(err)
 	}
 	mustRegister(t, s, store.Agent{Alias: "seen", Project: "web"})
-	if err := s.MarkRead("seen"); err != nil {
-		t.Fatal(err)
-	}
+	markReadInbox(t, s, "seen")
 	if _, err := s.RetractStandingOrder("web", "invariants"); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Rebases external PR #111 (`walt-verweij:fix/review-findings`, "close four bus-invariant gaps from the 2026-08-17 dual review") onto current `dev`. **Credit: walt-verweij** authored the original fix — their commit is preserved verbatim (cherry-picked, author unchanged); a single follow-up commit carries the rebase resolutions.

## The four gaps closed
1. **Snapshot-bound inbox acknowledgement** (the confirmed data-loss bug) — `get_inbox` now passes the snapshot's max `LastEntryID` to `MarkRead`, so mail committed between `Inbox()` and `MarkRead()` is no longer silently marked read. Pinned by cross-backend conformance `MarkReadStopsAtTheInboxSnapshot`.
2. **Single-owner daemon startup** — `runServe` takes an exclusive non-blocking `flock` on `serve.lock` before clearing/binding the socket; a losing duplicate exits before it can unlink the live socket. `TestSecondServeLeavesFirstDaemonSocketOwned`.
3. **Permission hardening** — state dir 0700 (create + repair), socket 0600, `bus.db`/`-wal`/`-shm` 0600. `TestServeSecuresSocket`, `TestOpenSecuresDatabaseFiles`, `TestIDRepairsHomeDirectoryMode`.
4. **One canonical pre-nudge guard** — new `internal/nudgeguard.Check` (device ownership → session incarnation → pane liveness), used by both the CLI and station nudge paths. `internal/nudgeguard` tests.

## Rebase resolutions (follow-up commit)
The PR predates two things on `dev` — the **standing-orders** feature (second watermark `last_read_standing_entry_id`) and the **`internal/humancli` → `internal/cli`** rename. The rename absorbed cleanly via git rename-detection. The standing-orders overlap required hand-resolution:

- **SQLite `MarkRead` (HIGH):** resolved to advance **both** watermarks — `last_read_entry_id` **and** `last_read_standing_entry_id` — each bounded by the caller's snapshot max (`MAX(col, ?)`). Taking the PR side verbatim would have dropped the standing watermark and frozen standing-order read state. The DynamoDB `MarkRead` auto-merged with the same two-watermark + snapshot semantics (verified).
- **Conformance-caller fixups:** standing-orders tests added on `dev` called the old single-arg `MarkRead(alias)` (a compile break). Every caller updated to `MarkRead(alias, upToEntryID)` — storetest cases via the `markReadInbox` helper; `internal/store` cases pass `maxEntryID` to preserve the "mark everything read" intent.
- **`readableThrough` restored:** the PR's dynamostore `MarkRead` rewrite removed the `readableThrough` helper, but dev's `RegisterAgent` still uses it to seed a new session's watermark — restored so the package compiles.
- **macOS socket-path test fix:** the PR's new flock test used `t.TempDir()` for the socket path (exceeds the unix `sun_path` ~104-char limit on macOS); switched to `mustertest.ShortHome()` per repo convention.
- Trivial import-order and adjacent-insertion conflicts resolved by keeping both sides.

## Verification
- `gofmt -l .` clean; `golangci-lint run ./...` → 0 issues; `go vet ./...` clean.
- `go test -race ./...` (the CI gate) — **all packages pass**.
- Cross-compile all four release targets + the `-tags lambda` build; `cmd/muster` links **no AWS packages** (aws-free gate).
- `verify-dynamo` (DynamoDB-semantics half of the conformance suite): **not run** — Docker daemon was unavailable in this environment. The dynamostore package compiles/vets and ran under `-race` (DDB-specific cases skip without an endpoint). CI's `dynamo` job should exercise it.

`VERSION` intentionally not bumped (release is a later dev→main step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)