### PR TITLE
feat(setup): muster setup — one command to configure agents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/muesli/termenv v0.16.0
+	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/schuettc/tools-common v0.3.0
 	modernc.org/sqlite v1.53.0
 )

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -466,6 +466,32 @@ session: every internal error is swallowed.`,
 			Run:   func(args []string, out io.Writer) error { return cmdHook(args, os.Stdin, out) },
 		},
 		{
+			Name:     "setup",
+			Synopsis: "setup [--agent claude|codex|cursor] [--no-hooks] [--tmux] [--dry-run] [--force] [--print kempt]",
+			Summary:  "Configure your coding agents (Claude Code, Codex, Cursor) to use muster.",
+			Help: `Registers muster's MCP server with each DETECTED agent, installs the
+session-lifecycle hooks, and (with --tmux) renders the tmux mailbox — the
+imperative fallback for people not using kempt, applying the exact same
+configuration the kempt package declares so the two paths never drift.
+
+Detection is by config presence: Claude Code (~/.claude or ~/.claude.json),
+Codex (~/.codex), Cursor (~/.cursor). Only detected agents are touched; with
+none found, setup prints how to proceed and changes nothing.
+
+Every file edit is an idempotent deep-merge that preserves existing content,
+so re-running adds no duplicates. --dry-run prints every change without
+writing. --no-hooks registers the MCP server only. --agent (repeatable or
+comma-separated) limits to specific agents. --tmux (off by default) also adds
+the mailbox lines to ~/.tmux.conf.
+
+When kempt is installed, setup defers to it: it prints the [packages.muster]
+block to add to your kempt.toml rather than editing files, unless --force is
+given. --print kempt emits that same canonical block and exits.`,
+			Group:    GroupPlumbing,
+			NewFlags: newSetupFlags,
+			Run:      cmdSetup,
+		},
+		{
 			Name:     "update",
 			Synopsis: "update",
 			Summary:  "Update muster to the latest release.",

--- a/internal/cli/registry_test.go
+++ b/internal/cli/registry_test.go
@@ -17,7 +17,7 @@ var wantCommandNames = []string{
 	"send", "nudge", "reply", "standing",
 	"agents", "status", "inbox", "tasks", "thread", "events", "watch", "station",
 	"register", "become", "deregister", "label", "whereami", "device", "gc",
-	"serve", "mcp", "channel", "lambda", "hook", "update", "debug", "commands",
+	"serve", "mcp", "channel", "lambda", "hook", "setup", "update", "debug", "commands",
 }
 
 // mainOwnedCommands are the Registry names cmd/muster's main() dispatches

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,0 +1,503 @@
+package cli
+
+import (
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// setupKemptTOML is the canonical declarative setup — the exact kempt package
+// block `muster setup --print kempt` emits and the imperative equivalent
+// `muster setup` applies for people who don't use kempt, so the two paths
+// never drift. Co-located and embedded the same way internal/store embeds
+// schema.sql.
+//
+//go:embed setup_kempt.toml
+var setupKemptTOML string
+
+// setupFlagVals holds cmdSetup's parsed flag pointers.
+type setupFlagVals struct {
+	print   *string
+	force   *bool
+	dryRun  *bool
+	noHooks *bool
+	tmux    *bool
+	agents  *stringList
+}
+
+// stringList is a repeatable / comma-separated string flag (--agent claude
+// --agent codex, or --agent claude,codex).
+type stringList []string
+
+func (s *stringList) String() string {
+	if s == nil {
+		return ""
+	}
+	return strings.Join(*s, ",")
+}
+
+func (s *stringList) Set(v string) error {
+	for _, part := range strings.Split(v, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			*s = append(*s, part)
+		}
+	}
+	return nil
+}
+
+// newSetupFlagsWithVals declares setup's flags and returns both the FlagSet
+// and typed access to its values — the one declaration cmdSetup (real
+// parsing) and newSetupFlags (registry help/man rendering) both build on, so
+// the two can't drift apart.
+func newSetupFlagsWithVals() (*flag.FlagSet, setupFlagVals) {
+	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var v setupFlagVals
+	v.print = fs.String("print", "", "print a configuration instead of applying it (only: kempt)")
+	v.force = fs.Bool("force", false, "apply directly even when kempt is installed")
+	v.dryRun = fs.Bool("dry-run", false, "compute and print every change but write nothing")
+	v.noHooks = fs.Bool("no-hooks", false, "register the MCP server only; skip session hooks")
+	v.tmux = fs.Bool("tmux", false, "also add the tmux mailbox lines to ~/.tmux.conf")
+	v.agents = &stringList{}
+	fs.Var(v.agents, "agent", "limit to these agents (claude|codex|cursor); repeatable or comma-separated")
+	return fs, v
+}
+
+// newSetupFlags builds setup's flag.FlagSet for registry-driven help/man
+// rendering (Command.NewFlags).
+func newSetupFlags() *flag.FlagSet {
+	fs, _ := newSetupFlagsWithVals()
+	return fs
+}
+
+// supportedAgents is setup's v1 scope, in display order.
+var supportedAgents = []string{"claude", "codex", "cursor"}
+
+// cmdSetup configures the user's coding agents to use muster: it registers
+// the MCP server with each detected agent, installs the session hooks, and
+// (opt-in) renders the tmux mailbox — the imperative fallback for people not
+// using kempt, applying the exact same configuration the embedded kempt
+// package declares.
+func cmdSetup(args []string, out io.Writer) error {
+	if helpRequested(args) {
+		return HelpFor("setup", out)
+	}
+	fs, v := newSetupFlagsWithVals()
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return HelpFor("setup", out)
+		}
+		return err
+	}
+
+	// --print kempt: emit the canonical template, touch nothing.
+	if *v.print != "" {
+		if *v.print != "kempt" {
+			return fmt.Errorf("unknown --print value %q (only: kempt)", *v.print)
+		}
+		_, err := fmt.Fprint(out, setupKemptTOML)
+		return err
+	}
+
+	// Validate any explicitly requested agents up front.
+	for _, a := range *v.agents {
+		if !contains(supportedAgents, a) {
+			return fmt.Errorf("unknown --agent %q (supported: claude, codex, cursor)", a)
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		if h := os.Getenv("HOME"); h != "" {
+			home = h
+		} else {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
+	}
+
+	// kempt manages machine config declaratively; when it's installed we
+	// don't fight it — we hand back the exact block to add, unless --force.
+	if !*v.force {
+		if _, err := exec.LookPath("kempt"); err == nil {
+			_, _ = fmt.Fprintln(out, "kempt is installed — it manages machine config declaratively, so muster setup will not edit files directly.")
+			_, _ = fmt.Fprintln(out)
+			_, _ = fmt.Fprint(out, setupKemptTOML)
+			_, _ = fmt.Fprintln(out)
+			_, err := fmt.Fprintln(out, "Add this to your kempt.toml and run `kempt apply`, or re-run with `muster setup --force` to configure directly.")
+			return err
+		}
+	}
+
+	return applySetup(out, home, v)
+}
+
+// applySetup performs (or, under --dry-run, describes) the direct-merge
+// configuration for every detected, requested agent.
+func applySetup(out io.Writer, home string, v setupFlagVals) error {
+	// The muster binary path, resolved once: prefer an installed
+	// ~/.local/bin/muster, else the running executable's absolute path. Files
+	// that expand ~ get the literal ~/.local/bin/muster; files that do NOT
+	// expand ~ (codex/cursor hooks.json) get the absolute path.
+	mbAbs := resolveMusterBin(home)
+	const mbTilde = "~/.local/bin/muster"
+
+	requested := *v.agents
+	var ops []fileOp
+	var configured []string
+
+	for _, agent := range supportedAgents {
+		if len(requested) > 0 && !contains(requested, agent) {
+			continue
+		}
+		if !agentDetected(home, agent) {
+			continue
+		}
+		configured = append(configured, agent)
+		ops = append(ops, agentOps(home, agent, mbAbs, mbTilde, *v.noHooks)...)
+	}
+
+	if len(configured) == 0 {
+		_, err := fmt.Fprintln(out, "No supported agents found; install Claude Code, Codex, or Cursor first.")
+		return err
+	}
+
+	for _, op := range ops {
+		changed, err := op.apply(*v.dryRun)
+		if err != nil {
+			return fmt.Errorf("%s: %w", op.disp, err)
+		}
+		reportOp(out, op, changed, *v.dryRun)
+	}
+
+	if *v.tmux {
+		if err := applyTmux(out, home, *v.dryRun); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// resolveMusterBin returns the absolute muster binary path: the installed
+// ~/.local/bin/muster if it exists, else the running executable.
+func resolveMusterBin(home string) string {
+	local := filepath.Join(home, ".local", "bin", "muster")
+	if _, err := os.Stat(local); err == nil {
+		return local
+	}
+	if exe, err := os.Executable(); err == nil {
+		if abs, err := filepath.Abs(exe); err == nil {
+			return abs
+		}
+		return exe
+	}
+	return local
+}
+
+// agentDetected reports whether the given agent looks installed on this
+// machine, by the presence of its config directory (or, for Claude, its
+// top-level config file).
+func agentDetected(home, agent string) bool {
+	switch agent {
+	case "claude":
+		return dirExists(filepath.Join(home, ".claude")) || fileExists(filepath.Join(home, ".claude.json"))
+	case "codex":
+		return dirExists(filepath.Join(home, ".codex"))
+	case "cursor":
+		return dirExists(filepath.Join(home, ".cursor"))
+	}
+	return false
+}
+
+// agentOps builds the file merge operations for one agent.
+func agentOps(home, agent, mbAbs, mbTilde string, noHooks bool) []fileOp {
+	switch agent {
+	case "claude":
+		ops := []fileOp{{
+			path: filepath.Join(home, ".claude.json"),
+			disp: "~/.claude.json",
+			desc: "mcpServers.muster + muster-channel",
+			desired: mustJSON(`{"mcpServers":{"muster":{"type":"stdio","command":"muster","args":["mcp"],"env":{}},` +
+				`"muster-channel":{"type":"stdio","command":"muster","args":["channel"],"env":{}}}}`),
+		}}
+		if !noHooks {
+			settings := filepath.Join(home, ".claude", "settings.json")
+			ops = append(ops,
+				fileOp{
+					path:    settings,
+					disp:    "~/.claude/settings.json",
+					desc:    "permissions.allow mcp__muster",
+					desired: mustJSON(`{"permissions":{"allow":["mcp__muster"]}}`),
+				},
+				fileOp{
+					path: settings,
+					disp: "~/.claude/settings.json",
+					desc: "SessionStart/Stop/SessionEnd hooks",
+					desired: mustJSON(`{"hooks":{` +
+						`"SessionStart":[{"matcher":"startup|resume","hooks":[{"type":"command","command":"` + mbTilde + ` hook SessionStart claude"}]}],` +
+						`"Stop":[{"hooks":[{"type":"command","command":"` + mbTilde + ` hook Stop claude"}]}],` +
+						`"SessionEnd":[{"hooks":[{"type":"command","command":"` + mbTilde + ` hook SessionEnd claude"}]}]}}`),
+				},
+			)
+		}
+		return ops
+	case "codex":
+		ops := []fileOp{{
+			path:    filepath.Join(home, ".codex", "config.toml"),
+			disp:    "~/.codex/config.toml",
+			desc:    "mcp_servers.muster",
+			toml:    true,
+			desired: mustJSON(`{"mcp_servers":{"muster":{"command":"muster","args":["mcp"]}}}`),
+		}}
+		if !noHooks {
+			ops = append(ops, fileOp{
+				path: filepath.Join(home, ".codex", "hooks.json"),
+				disp: "~/.codex/hooks.json",
+				desc: "SessionStart/Stop hooks",
+				desired: mustJSON(`{"hooks":{` +
+					`"SessionStart":[{"hooks":[{"type":"command","command":"` + mbAbs + ` hook SessionStart codex"}]}],` +
+					`"Stop":[{"hooks":[{"type":"command","command":"` + mbAbs + ` hook Stop codex"}]}]}}`),
+			})
+		}
+		return ops
+	case "cursor":
+		ops := []fileOp{{
+			path:    filepath.Join(home, ".cursor", "mcp.json"),
+			disp:    "~/.cursor/mcp.json",
+			desc:    "mcpServers.muster",
+			desired: mustJSON(`{"mcpServers":{"muster":{"command":"muster","args":["mcp"]}}}`),
+		}}
+		if !noHooks {
+			ops = append(ops, fileOp{
+				path: filepath.Join(home, ".cursor", "hooks.json"),
+				disp: "~/.cursor/hooks.json",
+				desc: "sessionStart/stop/sessionEnd hooks",
+				desired: mustJSON(`{"version":1,"hooks":{` +
+					`"sessionStart":[{"command":"` + mbAbs + ` hook SessionStart cursor"}],` +
+					`"stop":[{"command":"` + mbAbs + ` hook Stop cursor","loop_limit":3}],` +
+					`"sessionEnd":[{"command":"` + mbAbs + ` hook SessionEnd cursor"}]}}`),
+			})
+		}
+		return ops
+	}
+	return nil
+}
+
+// fileOp is one deep-merge into one config file.
+type fileOp struct {
+	path    string         // absolute filesystem path
+	disp    string         // display path (~ form) for summaries
+	desc    string         // what this merge adds, for the summary line
+	toml    bool           // true → TOML file, else JSON
+	desired map[string]any // the map to deep-merge in
+}
+
+// apply reads the target file, deep-merges the desired map, and (unless
+// dryRun) writes it back. It reports whether the merge changed the file's
+// serialized content — the idempotency signal the summary keys off.
+func (op fileOp) apply(dryRun bool) (bool, error) {
+	before, err := os.ReadFile(op.path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+		before = nil
+	}
+
+	current := map[string]any{}
+	if len(strings.TrimSpace(string(before))) > 0 {
+		if op.toml {
+			if err := toml.Unmarshal(before, &current); err != nil {
+				return false, fmt.Errorf("parse: %w", err)
+			}
+		} else {
+			if err := json.Unmarshal(before, &current); err != nil {
+				return false, fmt.Errorf("parse: %w", err)
+			}
+		}
+	}
+
+	deepMerge(current, op.desired)
+
+	var after []byte
+	if op.toml {
+		after, err = toml.Marshal(current)
+	} else {
+		after, err = json.MarshalIndent(current, "", "  ")
+		if err == nil {
+			after = append(after, '\n')
+		}
+	}
+	if err != nil {
+		return false, fmt.Errorf("encode: %w", err)
+	}
+
+	if string(after) == string(before) {
+		return false, nil
+	}
+	if dryRun {
+		return true, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(op.path), 0o755); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(op.path, after, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// reportOp prints one summary line for a completed (or dry-run) file op.
+func reportOp(out io.Writer, op fileOp, changed, dryRun bool) {
+	switch {
+	case changed && dryRun:
+		_, _ = fmt.Fprintf(out, "would update %s: add %s\n", op.disp, op.desc)
+	case changed:
+		_, _ = fmt.Fprintf(out, "updated %s: %s\n", op.disp, op.desc)
+	default:
+		_, _ = fmt.Fprintf(out, "no change %s (%s already present)\n", op.disp, op.desc)
+	}
+}
+
+// tmuxLines are the three mailbox lines setup ensures in ~/.tmux.conf, exact
+// text, added only if not already present.
+var tmuxLines = []string{
+	"set -g set-titles on",
+	"set -g set-titles-string '#{?@muster_inbox,📬#{@muster_inbox} ,}#S'",
+	"set -ga status-left '#{?@muster_inbox,#[fg=colour0#,bg=colour6#,bold] 📬#{@muster_inbox} #[default] ,}'",
+}
+
+// applyTmux ensures each mailbox line exists in ~/.tmux.conf (exact-line
+// match, so re-runs add no duplicates).
+func applyTmux(out io.Writer, home string, dryRun bool) error {
+	path := filepath.Join(home, ".tmux.conf")
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	existing := map[string]bool{}
+	for _, l := range strings.Split(string(data), "\n") {
+		existing[l] = true
+	}
+
+	var missing []string
+	for _, l := range tmuxLines {
+		if !existing[l] {
+			missing = append(missing, l)
+		}
+	}
+
+	if len(missing) == 0 {
+		_, _ = fmt.Fprintln(out, "no change ~/.tmux.conf (mailbox lines already present)")
+		return nil
+	}
+	if dryRun {
+		_, _ = fmt.Fprintf(out, "would update ~/.tmux.conf: add %d mailbox line(s)\n", len(missing))
+		return nil
+	}
+
+	buf := string(data)
+	if len(buf) > 0 && !strings.HasSuffix(buf, "\n") {
+		buf += "\n"
+	}
+	buf += strings.Join(missing, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(buf), 0o644); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(out, "updated ~/.tmux.conf: added %d mailbox line(s)\n", len(missing))
+	return nil
+}
+
+// deepMerge merges src into dst in place: nested maps merge recursively;
+// arrays union by deep equality (a desired element is appended only when no
+// existing element is reflect.DeepEqual to it, so re-runs add no duplicates);
+// scalars overwrite. Every pre-existing key not named in src is preserved.
+func deepMerge(dst, src map[string]any) {
+	for k, sv := range src {
+		switch sval := sv.(type) {
+		case map[string]any:
+			if dval, ok := dst[k].(map[string]any); ok {
+				deepMerge(dval, sval)
+			} else {
+				nm := map[string]any{}
+				deepMerge(nm, sval)
+				dst[k] = nm
+			}
+		case []any:
+			dst[k] = mergeArray(asArray(dst[k]), sval)
+		default:
+			dst[k] = sv
+		}
+	}
+}
+
+// mergeArray returns dst with each element of src appended only if no element
+// already deep-equals it.
+func mergeArray(dst, src []any) []any {
+	for _, s := range src {
+		dup := false
+		for _, d := range dst {
+			if reflect.DeepEqual(d, s) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			dst = append(dst, s)
+		}
+	}
+	return dst
+}
+
+// asArray coerces an existing value to []any (nil for anything that isn't
+// already an array — a scalar under a key we merge an array into is replaced,
+// matching "scalars: desired overwrites").
+func asArray(v any) []any {
+	if a, ok := v.([]any); ok {
+		return a
+	}
+	return nil
+}
+
+// mustJSON parses a compile-time-constant JSON literal into a map[string]any.
+// Building the desired maps by unmarshaling JSON (rather than as Go literals)
+// normalizes their types to exactly what re-reading a written file produces
+// (numbers as float64, etc.), so the array union-by-deep-equality stays exact
+// across runs and never appends a "different-typed" duplicate.
+func mustJSON(s string) map[string]any {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		panic(fmt.Sprintf("setup: bad desired JSON literal: %v", err))
+	}
+	return m
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+func dirExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}
+
+func fileExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && !fi.IsDir()
+}

--- a/internal/cli/setup_kempt.toml
+++ b/internal/cli/setup_kempt.toml
@@ -1,0 +1,71 @@
+# muster — kempt package (the canonical declarative setup)
+#
+# Drop this [packages.muster] block into your kempt.toml (https://kempt.tools)
+# and run `kempt apply`. kempt installs the binary, registers the MCP server
+# with each agent, installs the session hooks, renders the tmux mailbox, and
+# runs the daemon as a background service — all idempotently, no shell scripts.
+#
+# This block is emitted verbatim by `muster setup --print kempt`, and is the
+# exact configuration `muster setup` applies for people who do not use kempt,
+# so the two paths never drift.
+#
+# macOS-focused (launchd service). Drop the `service` step on Linux or adapt it
+# to systemd --user.
+
+[packages.muster]
+description = "Cross-terminal agent coordination bus (daemon, MCP + hooks in Claude/Codex/Cursor, tmux mailbox)"
+only = { os = "darwin" }
+
+  [[packages.muster.download]]
+  site = "muster.tools"
+  tool = "muster"
+  bin = "muster"
+
+  [[packages.muster.service]]
+  label = "tools.muster.serve"
+  program = ["/bin/zsh", "-lc", "exec \"$HOME/.local/bin/muster\" serve"]
+  stdout = "~/.local/share/muster/serve.log"
+  stderr = "~/.local/share/muster/serve.log"
+
+  [[packages.muster.json-merge]]
+  file = "~/.claude.json"
+  merge = { mcpServers = { muster = { type = "stdio", command = "muster", args = ["mcp"], env = {} }, "muster-channel" = { type = "stdio", command = "muster", args = ["channel"], env = {} } } }
+
+  [[packages.muster.toml-merge]]
+  file = "~/.codex/config.toml"
+  merge = { mcp_servers = { muster = { command = "muster", args = ["mcp"] } } }
+
+  [[packages.muster.json-merge]]
+  file = "~/.cursor/mcp.json"
+  merge = { mcpServers = { muster = { command = "muster", args = ["mcp"] } } }
+
+  [[packages.muster.json-merge]]
+  file = "~/.claude/settings.json"
+  merge = { permissions = { allow = ["mcp__muster"] } }
+
+  [[packages.muster.json-merge]]
+  file = "~/.claude/settings.json"
+  merge = { hooks = { SessionStart = [ { matcher = "startup|resume", hooks = [ { type = "command", command = "~/.local/bin/muster hook SessionStart claude" } ] } ], Stop = [ { hooks = [ { type = "command", command = "~/.local/bin/muster hook Stop claude" } ] } ], SessionEnd = [ { hooks = [ { type = "command", command = "~/.local/bin/muster hook SessionEnd claude" } ] } ] } }
+
+  [[packages.muster.json-merge]]
+  file = "~/.codex/hooks.json"
+  merge = { hooks = { SessionStart = [ { hooks = [ { type = "command", command = "${HOME}/.local/bin/muster hook SessionStart codex" } ] } ], Stop = [ { hooks = [ { type = "command", command = "${HOME}/.local/bin/muster hook Stop codex" } ] } ] } }
+
+  [[packages.muster.json-merge]]
+  file = "~/.cursor/hooks.json"
+  merge = { version = 1, hooks = { sessionStart = [ { command = "${HOME}/.local/bin/muster hook SessionStart cursor" } ], stop = [ { command = "${HOME}/.local/bin/muster hook Stop cursor", loop_limit = 3 } ], sessionEnd = [ { command = "${HOME}/.local/bin/muster hook SessionEnd cursor" } ] } }
+
+  [[packages.muster.line-in-file]]
+  file = "~/.tmux.conf"
+  line = "set -g set-titles on"
+
+  [[packages.muster.line-in-file]]
+  file = "~/.tmux.conf"
+  line = "set -g set-titles-string '#{?@muster_inbox,📬#{@muster_inbox} ,}#S'"
+
+  [[packages.muster.line-in-file]]
+  file = "~/.tmux.conf"
+  line = "set -ga status-left '#{?@muster_inbox,#[fg=colour0#,bg=colour6#,bold] 📬#{@muster_inbox} #[default] ,}'"
+
+  [[packages.muster.verify]]
+  command-exists = "muster"

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,0 +1,356 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// setupHome points setup at a fresh temp HOME and a PATH with no `kempt` on
+// it, so the direct-apply path is exercised by default. It returns the home
+// dir. (This is not a unix-socket test, so t.TempDir's long path is fine.)
+func setupHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Isolate PATH so exec.LookPath("kempt") fails unless a test opts in.
+	t.Setenv("PATH", t.TempDir())
+	return home
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return m
+}
+
+func runSetup(t *testing.T, args ...string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := cmdSetup(args, &buf); err != nil {
+		t.Fatalf("cmdSetup(%v): %v", args, err)
+	}
+	return buf.String()
+}
+
+func TestSetupDetectClaudeOnly(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSetup(t)
+
+	if !fileExists(filepath.Join(home, ".claude.json")) {
+		t.Fatal("claude configured: ~/.claude.json missing")
+	}
+	if dirExists(filepath.Join(home, ".codex")) || dirExists(filepath.Join(home, ".cursor")) {
+		t.Fatal("undetected agents should not be created")
+	}
+}
+
+func TestSetupApplyClaude(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSetup(t)
+
+	// MCP into ~/.claude.json
+	claudeJSON := readJSON(t, filepath.Join(home, ".claude.json"))
+	mcp, _ := claudeJSON["mcpServers"].(map[string]any)
+	if mcp == nil {
+		t.Fatalf("mcpServers missing: %v", claudeJSON)
+	}
+	wantMuster := map[string]any{
+		"type": "stdio", "command": "muster",
+		"args": []any{"mcp"}, "env": map[string]any{},
+	}
+	if got := mcp["muster"]; !reflect.DeepEqual(got, wantMuster) {
+		t.Errorf("mcpServers.muster = %#v, want %#v", got, wantMuster)
+	}
+	wantChannel := map[string]any{
+		"type": "stdio", "command": "muster",
+		"args": []any{"channel"}, "env": map[string]any{},
+	}
+	if got := mcp["muster-channel"]; !reflect.DeepEqual(got, wantChannel) {
+		t.Errorf("mcpServers.muster-channel = %#v, want %#v", got, wantChannel)
+	}
+
+	// Hooks + permission into ~/.claude/settings.json
+	settings := readJSON(t, filepath.Join(home, ".claude", "settings.json"))
+	perms, _ := settings["permissions"].(map[string]any)
+	if perms == nil || !reflect.DeepEqual(perms["allow"], []any{"mcp__muster"}) {
+		t.Errorf("permissions.allow = %#v", settings["permissions"])
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		t.Fatalf("hooks missing: %v", settings)
+	}
+	for _, ev := range []string{"SessionStart", "Stop", "SessionEnd"} {
+		if _, ok := hooks[ev].([]any); !ok {
+			t.Errorf("hooks.%s missing/not-array: %#v", ev, hooks[ev])
+		}
+	}
+	// Command uses the ~/.local/bin/muster tilde form for the tilde-expanding
+	// settings.json.
+	ss := hooks["SessionStart"].([]any)[0].(map[string]any)
+	inner := ss["hooks"].([]any)[0].(map[string]any)
+	if cmd, _ := inner["command"].(string); !strings.HasPrefix(cmd, "~/.local/bin/muster hook SessionStart claude") {
+		t.Errorf("SessionStart command = %q", cmd)
+	}
+}
+
+func TestSetupIdempotent(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSetup(t)
+
+	files := []string{
+		filepath.Join(home, ".claude.json"),
+		filepath.Join(home, ".claude", "settings.json"),
+		filepath.Join(home, ".codex", "config.toml"),
+		filepath.Join(home, ".codex", "hooks.json"),
+		filepath.Join(home, ".cursor", "mcp.json"),
+		filepath.Join(home, ".cursor", "hooks.json"),
+	}
+	first := map[string][]byte{}
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		first[f] = b
+	}
+
+	runSetup(t) // second run must not change anything
+
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		if !bytes.Equal(b, first[f]) {
+			t.Errorf("%s changed on re-run:\n--- first ---\n%s\n--- second ---\n%s", f, first[f], b)
+		}
+	}
+}
+
+func TestSetupNoHooks(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSetup(t, "--no-hooks")
+
+	if !fileExists(filepath.Join(home, ".claude.json")) {
+		t.Fatal("MCP should still be written with --no-hooks")
+	}
+	if fileExists(filepath.Join(home, ".claude", "settings.json")) {
+		t.Fatal("settings.json hooks should NOT be written with --no-hooks")
+	}
+}
+
+func TestSetupCodexTOML(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSetup(t)
+
+	path := filepath.Join(home, ".codex", "config.toml")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := toml.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	srv, _ := m["mcp_servers"].(map[string]any)
+	muster, _ := srv["muster"].(map[string]any)
+	if muster == nil || muster["command"] != "muster" {
+		t.Fatalf("mcp_servers.muster = %#v", srv)
+	}
+	if !reflect.DeepEqual(muster["args"], []any{"mcp"}) {
+		t.Errorf("args = %#v", muster["args"])
+	}
+
+	// Re-run idempotent.
+	runSetup(t)
+	b2, _ := os.ReadFile(path)
+	if !bytes.Equal(b, b2) {
+		t.Errorf("codex config.toml changed on re-run:\n%s\nvs\n%s", b, b2)
+	}
+}
+
+func TestSetupPrintKempt(t *testing.T) {
+	setupHome(t)
+	out := runSetup(t, "--print", "kempt")
+	if out != setupKemptTOML {
+		t.Errorf("--print kempt output does not equal the embedded template.\ngot:\n%s", out)
+	}
+}
+
+func TestSetupPrintUnknown(t *testing.T) {
+	setupHome(t)
+	var buf bytes.Buffer
+	if err := cmdSetup([]string{"--print", "bogus"}, &buf); err == nil {
+		t.Fatal("expected error for unknown --print value")
+	}
+}
+
+func TestSetupKemptPresent(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Put a fake `kempt` executable on PATH.
+	bindir := t.TempDir()
+	kempt := filepath.Join(bindir, "kempt")
+	if err := os.WriteFile(kempt, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bindir)
+
+	out := runSetup(t)
+	if !strings.Contains(out, "kempt apply") {
+		t.Errorf("expected kempt guidance, got:\n%s", out)
+	}
+	if fileExists(filepath.Join(home, ".claude.json")) {
+		t.Fatal("no files should be written when kempt is present without --force")
+	}
+
+	// --force overrides.
+	runSetup(t, "--force")
+	if !fileExists(filepath.Join(home, ".claude.json")) {
+		t.Fatal("--force should configure directly even with kempt present")
+	}
+}
+
+func TestSetupTmux(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSetup(t, "--tmux")
+
+	path := filepath.Join(home, ".tmux.conf")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range tmuxLines {
+		if !strings.Contains(string(b), l) {
+			t.Errorf("~/.tmux.conf missing line %q", l)
+		}
+	}
+
+	runSetup(t, "--tmux") // re-run: no duplicates
+	b2, _ := os.ReadFile(path)
+	for _, l := range tmuxLines {
+		if n := strings.Count(string(b2), l); n != 1 {
+			t.Errorf("line %q appears %d times, want 1", l, n)
+		}
+	}
+}
+
+func TestSetupNoTmuxByDefault(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runSetup(t)
+	if fileExists(filepath.Join(home, ".tmux.conf")) {
+		t.Fatal("tmux config should not be touched without --tmux")
+	}
+}
+
+func TestSetupPreserveExisting(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := map[string]any{
+		"topLevelKey": "keepme",
+		"mcpServers": map[string]any{
+			"other": map[string]any{"command": "other-tool"},
+		},
+	}
+	b, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runSetup(t)
+
+	got := readJSON(t, filepath.Join(home, ".claude.json"))
+	if got["topLevelKey"] != "keepme" {
+		t.Errorf("top-level key not preserved: %#v", got)
+	}
+	mcp := got["mcpServers"].(map[string]any)
+	if _, ok := mcp["other"]; !ok {
+		t.Errorf("pre-existing mcpServers.other dropped: %#v", mcp)
+	}
+	if _, ok := mcp["muster"]; !ok {
+		t.Errorf("mcpServers.muster not added: %#v", mcp)
+	}
+}
+
+func TestSetupNoAgents(t *testing.T) {
+	setupHome(t)
+	out := runSetup(t)
+	if !strings.Contains(out, "No supported agents found") {
+		t.Errorf("expected no-agents message, got:\n%s", out)
+	}
+}
+
+func TestSetupDryRun(t *testing.T) {
+	home := setupHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out := runSetup(t, "--dry-run")
+	if !strings.Contains(out, "would update") {
+		t.Errorf("expected dry-run output, got:\n%s", out)
+	}
+	if fileExists(filepath.Join(home, ".claude.json")) {
+		t.Fatal("--dry-run must not write files")
+	}
+}
+
+func TestSetupAgentFilter(t *testing.T) {
+	home := setupHome(t)
+	for _, d := range []string{".claude", ".codex", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(home, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runSetup(t, "--agent", "codex")
+	if fileExists(filepath.Join(home, ".claude.json")) {
+		t.Error("claude configured despite --agent codex")
+	}
+	if !fileExists(filepath.Join(home, ".codex", "config.toml")) {
+		t.Error("codex not configured with --agent codex")
+	}
+}


### PR DESCRIPTION
Adds `muster setup`: detects installed agents (Claude Code, Codex, Cursor) and idempotently registers muster's MCP server + installs the session hooks for each — the imperative fallback for non-kempt users. Flags: `--tmux`, `--dry-run`, `--no-hooks`, `--agent`, `--force`, `--print kempt` (emits the canonical kempt package; `internal/cli/setup_kempt.toml` is the single source both paths share). Defers to kempt when installed.

Tested: 14 unit tests + `-race`; functional smoke (print/dry-run/apply/idempotent/kempt-defer) on the built binary; and parity — output is byte-identical to the maintainer's live kempt-managed muster config. `just verify` green. Adds pure-Go dep `pelletier/go-toml/v2`.