### PR TITLE
channel: resolve pane by ancestry when env is stripped

### DIFF
--- a/cmd/muster/channel.go
+++ b/cmd/muster/channel.go
@@ -16,6 +16,22 @@ import (
 	"github.com/schuettc/muster/internal/version"
 )
 
+// channelCapture resolves the tmux identity the channel pushes for: the
+// environment when the harness passed $TMUX/$TMUX_PANE through, else the
+// process-ancestry walk. This mirrors cli.hookCapture on purpose — the
+// channel MCP server is a synchronous, long-lived child of the harness
+// process, so it shares the pane's ancestry exactly as a hook does. Without
+// the fallback, a harness that spawns MCP servers env-stripped (the hook is
+// registered via ancestry, but the channel saw only $TMUX) leaves the carrier
+// paneless and silently idle: mail lands in the inbox but never wakes the
+// session (the 2026-09 "no tmux identity" report).
+func channelCapture() tmuxenv.Capture {
+	if c := tmuxenv.CaptureEnv(); c.SocketPath != "" && c.PaneID != "" {
+		return c
+	}
+	return tmuxenv.CaptureFromAncestry()
+}
+
 // channelInstructions is the durable core, taught once at handshake: what
 // the channel is and how a push is shaped. Everything specific to a kind of
 // event travels WITH that event, after the separator, so the rule sits next
@@ -56,7 +72,7 @@ func channelMaxListed() int {
 // pi-channels client, which had to SIGKILL after a grace period.
 func runChannel() {
 	channel.MaxListed = channelMaxListed()
-	capture := tmuxenv.CaptureEnv()
+	capture := channelCapture()
 	carrier := &channel.Carrier{
 		Call:     channel.DaemonClient(paths.SocketPath()),
 		Ident:    channel.Identity{SocketPath: capture.SocketPath, SessionID: capture.SessionID, PaneID: capture.PaneID, SessionCreated: capture.SessionCreated},

--- a/cmd/muster/channel_test.go
+++ b/cmd/muster/channel_test.go
@@ -8,7 +8,45 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/schuettc/muster/internal/tmuxenv"
 )
+
+// The channel MCP server is spawned env-stripped by some harnesses (Claude
+// Code): $TMUX/$TMUX_PANE never reach it, so tmuxenv.CaptureEnv comes back
+// paneless and the carrier idles — mail lands in the inbox but never wakes the
+// session. The SessionStart hook survives this by walking process ancestry to
+// find its pane; the channel must do the same, or the two disagree and only
+// the hook resolves an identity (the 2026-09 "no tmux identity" report). This
+// pins the env-else-ancestry fallback: env empty, but an ancestor IS a pane
+// pid, so channelCapture must resolve that pane rather than go paneless.
+func TestChannelCaptureFallsBackToAncestry(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("TMUX_PANE", "")
+
+	prevRun, prevAnc, prevDir := tmuxenv.Run, tmuxenv.AncestorPIDs, tmuxenv.SocketDir
+	t.Cleanup(func() { tmuxenv.Run, tmuxenv.AncestorPIDs, tmuxenv.SocketDir = prevRun, prevAnc, prevDir })
+
+	tmuxenv.AncestorPIDs = func() []int { return []int{4242, 1} }
+	tmuxenv.Run = func(args ...string) (string, error) {
+		for _, a := range args {
+			if a == "list-panes" {
+				return "4242\t%7\t$3\tmuster-2\t555", nil
+			}
+		}
+		return "", nil
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "proj-muster"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tmuxenv.SocketDir = func() string { return dir }
+
+	c := channelCapture()
+	if c.SocketPath == "" || c.PaneID != "%7" || c.SessionID != "$3" || c.SessionCreated != 555 {
+		t.Fatalf("channelCapture() = %+v, want the ancestry pane %%7 on $3 created 555 (env-stripped must fall back, not go paneless)", c)
+	}
+}
 
 // A SIGTERM must end `muster channel` even while the client still holds its
 // stdio pipes open. It did not: signal.NotifyContext swallowed the signal

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,10 @@
 
 There is no CHANGELOG.md in this repository yet. This file holds the notes for releases where the change is operator-visible enough to need explaining rather than just listing. Newest first.
 
+## 0.19.1 — channel wakes survive an env-stripped harness
+
+**The muster channel now resolves its pane by process ancestry when the environment is stripped.** The channel MCP server captured its tmux identity from `$TMUX`/`$TMUX_PANE` only. Harnesses that spawn MCP servers without those variables (Claude Code) left the channel with no pane: the SessionStart hook still registered the agent (it already walks process ancestry), so mail arrived and the inbox filled, but the channel never pushed a wake — the session only saw its mail when an operator told it to check the inbox, and `muster_channel_status` reported `idle: no tmux pane`. The channel now uses the same env-else-ancestry capture the hooks use (`channelCapture`); since the channel server is a synchronous child of the harness, its ancestry reaches the pane's shell exactly as a hook's does. No change is needed on machines where the channel already worked. A genuinely paneless session (no pane in the environment or the ancestry) still idles, as before.
+
 ## 0.19.0 — `muster setup`
 
 **`muster setup`** configures your coding agents for you. It detects the agents installed on the machine — **Claude Code, Codex, and Cursor** — and, for each, registers muster's MCP server and installs the session hooks (SessionStart/Stop/SessionEnd) via idempotent JSON/TOML deep-merge, so there is no config file to hand-edit. Flags: `--tmux` also renders the 📬 mailbox badge in `~/.tmux.conf`; `--dry-run` previews every change; `--no-hooks` registers the MCP server only; `--agent` limits to specific agents; `--force` applies even when kempt is present. Re-running is safe — every write is a merge that preserves existing content.


### PR DESCRIPTION
## Problem

The muster-channel MCP server captured its tmux identity from `\$TMUX`/`\$TMUX_PANE` only (`tmuxenv.CaptureEnv`). Harnesses that spawn MCP servers env-stripped (**Claude Code**) left the carrier paneless: the SessionStart hook still registered the agent via its ancestry walk, so mail arrived and the inbox filled — but the channel never pushed a wake. `muster_channel_status` reported `idle: no tmux pane`, and the session only saw its mail when an operator manually told it to check the inbox. This is the "no tmux identity" report from the field.

## Fix

Give the channel the same env-else-ancestry capture the hooks already use (`channelCapture`, mirroring `cli.hookCapture`). The channel MCP server is a synchronous, long-lived child of the harness process, so its ancestry reaches the pane's shell exactly as a hook's does. A genuinely paneless session (no pane in env or ancestry) still idles, as before.

## Testing

- New `TestChannelCaptureFallsBackToAncestry` (fails on env-only, passes with the fallback).
- Reproduced end-to-end against a real `muster channel` binary with `\$TMUX`/`\$TMUX_PANE` stripped: pre-fix reports `idle: no tmux pane`; post-fix resolves the pane via ancestry.
- `gofmt` clean, `golangci-lint` 0 issues, `go test -race` green, all cross-compile targets + lambda build, `cmd/muster` AWS-free.

Release note added under 0.19.1. No VERSION bump (dev-targeting; bumps at promotion).